### PR TITLE
Fix pincode screen scaling on smaller screens

### DIFF
--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/pincode/PincodeFragment.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/pincode/PincodeFragment.kt
@@ -13,7 +13,9 @@ import io.novafoundation.nova.feature_account_api.di.AccountFeatureApi
 import io.novafoundation.nova.feature_account_impl.R
 import io.novafoundation.nova.feature_account_impl.di.AccountFeatureComponent
 import io.novafoundation.nova.feature_account_impl.presentation.pincode.fingerprint.FingerprintWrapper
-import kotlinx.android.synthetic.main.fragment_pincode.pinCodeView
+import kotlinx.android.synthetic.main.fragment_pincode.pinCodeNumbers
+import kotlinx.android.synthetic.main.fragment_pincode.pinCodeTitle
+import kotlinx.android.synthetic.main.fragment_pincode.pincodeProgress
 import kotlinx.android.synthetic.main.fragment_pincode.toolbar
 import javax.inject.Inject
 
@@ -57,10 +59,12 @@ class PincodeFragment : BaseFragment<PinCodeViewModel>() {
 
         viewModel.fingerprintScannerAvailable(fingerprintWrapper.isAuthReady())
 
-        with(pinCodeView) {
+        with(pinCodeNumbers) {
             pinCodeEnteredListener = { viewModel.pinCodeEntered(it) }
             fingerprintClickListener = { fingerprintWrapper.toggleScanner() }
         }
+
+        pinCodeNumbers.bindProgressView(pincodeProgress)
     }
 
     override fun subscribe(viewModel: PinCodeViewModel) {
@@ -79,7 +83,7 @@ class PincodeFragment : BaseFragment<PinCodeViewModel>() {
         }
 
         viewModel.showFingerPrintEvent.observeEvent {
-            pinCodeView.changeFingerPrintButtonVisibility(fingerprintWrapper.isAuthReady())
+            pinCodeNumbers.changeFingerPrintButtonVisibility(fingerprintWrapper.isAuthReady())
         }
 
         viewModel.fingerPrintErrorEvent.observeEvent {
@@ -89,12 +93,12 @@ class PincodeFragment : BaseFragment<PinCodeViewModel>() {
         viewModel.homeButtonVisibilityLiveData.observe(toolbar::setHomeButtonVisibility)
 
         viewModel.matchingPincodeErrorEvent.observeEvent {
-            pinCodeView.pinCodeMatchingError()
+            pinCodeNumbers.pinCodeMatchingError()
         }
 
         viewModel.resetInputEvent.observeEvent {
-            pinCodeView.resetInput()
-            pinCodeView.setTitle(it)
+            pinCodeNumbers.resetInput()
+            pinCodeTitle.text = it
         }
 
         viewModel.startAuth()

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/pincode/view/PinCodeView.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/pincode/view/PinCodeView.kt
@@ -19,9 +19,7 @@ import kotlinx.android.synthetic.main.pincode_view.view.btn7
 import kotlinx.android.synthetic.main.pincode_view.view.btn8
 import kotlinx.android.synthetic.main.pincode_view.view.btn9
 import kotlinx.android.synthetic.main.pincode_view.view.btnDelete
-import kotlinx.android.synthetic.main.pincode_view.view.dotsProgressView
 import kotlinx.android.synthetic.main.pincode_view.view.fingerprintBtn
-import kotlinx.android.synthetic.main.pincode_view.view.pinCodeTitleTv
 
 class PinCodeView @JvmOverloads constructor(
     context: Context,
@@ -46,8 +44,12 @@ class PinCodeView @JvmOverloads constructor(
 
     private var inputCode: String = ""
 
+    private var progressView: DotsProgressView? = null
+
     init {
         View.inflate(context, R.layout.pincode_view, this)
+
+        orientation = VERTICAL
 
         btn1.setOnClickListener(pinCodeNumberClickListener)
         btn2.setOnClickListener(pinCodeNumberClickListener)
@@ -75,12 +77,14 @@ class PinCodeView @JvmOverloads constructor(
         }
     }
 
-    fun setTitle(title: String) {
-        pinCodeTitleTv.text = title
-    }
-
     fun resetInput() {
         inputCode = ""
+        updateProgress()
+    }
+
+    fun bindProgressView(view: DotsProgressView) {
+        progressView = view
+
         updateProgress()
     }
 
@@ -111,13 +115,13 @@ class PinCodeView @JvmOverloads constructor(
 
     private fun updateProgress() {
         val currentProgress = inputCode.length
-        dotsProgressView.setProgress(currentProgress)
+        progressView?.setProgress(currentProgress)
 
         btnDelete.isEnabled = currentProgress != 0
     }
 
     private fun shakeDotsAnimation() {
         val animation = AnimationUtils.loadAnimation(context, R.anim.shake)
-        dotsProgressView.startAnimation(animation)
+        progressView?.startAnimation(animation)
     }
 }

--- a/feature-account-impl/src/main/res/layout/fragment_pincode.xml
+++ b/feature-account-impl/src/main/res/layout/fragment_pincode.xml
@@ -9,21 +9,48 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:homeButtonVisible="false"
         app:dividerVisible="false"
+        app:homeButtonVisible="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <io.novafoundation.nova.feature_account_impl.presentation.pincode.view.PinCodeView
-        android:id="@+id/pinCodeView"
+    <TextView
+        android:id="@+id/pinCodeTitle"
+        style="@style/TextAppearance.NovaFoundation.Regular.Title3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="24dp"
+        android:layout_marginStart="@dimen/x1"
+        android:layout_marginEnd="@dimen/x1"
+        android:text="@string/pincode_enter_pin_code_v2_2_0"
+        app:layout_constraintBottom_toTopOf="@+id/pincodeProgress"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <io.novafoundation.nova.feature_account_impl.presentation.pincode.view.DotsProgressView
+        android:id="@+id/pincodeProgress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintBottom_toTopOf="@id/pinCodeNumbers"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/pinCodeTitle" />
+
+    <io.novafoundation.nova.feature_account_impl.presentation.pincode.view.PinCodeView
+        android:id="@+id/pinCodeNumbers"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar"
-        app:layout_constraintVertical_bias="0.55" />
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature-account-impl/src/main/res/layout/pincode_view.xml
+++ b/feature-account-impl/src/main/res/layout/pincode_view.xml
@@ -6,140 +6,110 @@
     tools:orientation="vertical"
     tools:parentTag="android.widget.LinearLayout">
 
-    <TextView
-        android:id="@+id/pinCodeTitleTv"
-        style="@style/TextAppearance.NovaFoundation.Regular.Title3"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginStart="@dimen/x1"
-        android:layout_marginEnd="@dimen/x1"
-        android:text="@string/pincode_enter_pin_code_v2_2_0" />
-
-    <io.novafoundation.nova.feature_account_impl.presentation.pincode.view.DotsProgressView
-        android:id="@+id/dotsProgressView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginStart="@dimen/x1"
-        android:layout_marginTop="@dimen/x3"
-        android:layout_marginEnd="@dimen/x1"
-        android:gravity="center_horizontal" />
-
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="92dp"
-        android:orientation="vertical"
-        android:padding="8dp">
+        android:gravity="center_horizontal"
+        android:orientation="horizontal">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:orientation="horizontal">
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn1"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="1" />
 
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn1"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="1" />
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn2"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="2" />
 
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn2"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="2" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn3"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="3" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:orientation="horizontal">
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn4"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="4" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn5"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="5" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn6"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="6" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:orientation="horizontal">
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn7"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="7" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn8"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="8" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn9"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="9" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:orientation="horizontal">
-
-            <androidx.appcompat.widget.AppCompatImageButton
-                android:id="@+id/fingerprintBtn"
-                style="@style/Widget.Nova.Button.PinCodeControlButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:src="@drawable/ic_fingerprint"
-                android:visibility="invisible"
-                tools:visibility="visible" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn0"
-                style="@style/Widget.Nova.Button.PinCodeNumberButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:text="0" />
-
-            <androidx.appcompat.widget.AppCompatImageButton
-                android:id="@+id/btnDelete"
-                style="@style/Widget.Nova.Button.PinCodeControlButton"
-                android:layout_margin="@dimen/pin_code_view_spacing"
-                android:src="@drawable/ic_delete"
-                android:tint="@color/color_delete_button" />
-
-        </LinearLayout>
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn3"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="3" />
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn4"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="4" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn5"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="5" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn6"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="6" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn7"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="7" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn8"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="8" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn9"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="9" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/fingerprintBtn"
+            style="@style/Widget.Nova.Button.PinCodeControlButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:src="@drawable/ic_fingerprint"
+            android:visibility="invisible"
+            tools:visibility="visible" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn0"
+            style="@style/Widget.Nova.Button.PinCodeNumberButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:text="0" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/btnDelete"
+            style="@style/Widget.Nova.Button.PinCodeControlButton"
+            android:layout_margin="@dimen/pin_code_view_spacing"
+            android:src="@drawable/ic_delete"
+            android:tint="@color/color_delete_button" />
+
+    </LinearLayout>
 </merge>

--- a/feature-account-impl/src/main/res/values-hdpi/dimens.xml
+++ b/feature-account-impl/src/main/res/values-hdpi/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="pin_code_number_button_size">60dp</dimen>
+</resources>

--- a/feature-account-impl/src/main/res/values-xhdpi/dimens.xml
+++ b/feature-account-impl/src/main/res/values-xhdpi/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="pin_code_number_button_size">80dp</dimen>
+</resources>


### PR DESCRIPTION
* Separate progress view from pincode view since it is not possible to perform former centering separately 
* There were not way to fit the pincode nicely on small screens (tagereted 320dpi screens) so I decided to reduce pincode buttons size to 60dp on such screens (<= hdpi)

# Normal Screen

<img src="https://user-images.githubusercontent.com/70131744/146309208-4f7a07c5-0ffa-460e-95c8-8a4c1e916b4e.png" alt="drawing" width="400"/>

# Small  (320 dpi) screen

<img src="https://user-images.githubusercontent.com/70131744/146309372-2b9464d6-3f1b-41e9-b1eb-340d98b41f67.png" alt="drawing" width="400"/>
