### PR TITLE
Fix - bottom content of WebVew is not visible due to overlay with Botttom Nav Bar

### DIFF
--- a/feature-dapp-impl/src/main/res/layout/fragment_dapp_browser.xml
+++ b/feature-dapp-impl/src/main/res/layout/fragment_dapp_browser.xml
@@ -42,13 +42,13 @@
         android:id="@+id/dappBrowserWebView"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/dappBrowserBottomBarTopMargin"
+        app:layout_constraintBottom_toTopOf="@+id/dappBrowserBottomNavigation"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/dappBrowserAddressBarGroup" />
 
     <View
-        android:id="@+id/view"
+        android:id="@+id/dappBrowserBottomNavigation"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="-11dp"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70131744/149296341-5fd6fea5-760d-4305-a3fa-84cc7cedec0e.png)
