### PR TITLE
Fix - dublicated BuildConfig

### DIFF
--- a/feature-assets/src/main/AndroidManifest.xml
+++ b/feature-assets/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova">
+    package="io.novafoundation.nova.feature_assets">
 
 </manifest>

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/buyToken/MoonPayProvider.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/buyToken/MoonPayProvider.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.feature_assets.data.buyToken
 
 import android.content.Context
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.hmacSHA256
 import io.novafoundation.nova.common.utils.showBrowser
 import io.novafoundation.nova.common.utils.toBase64

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/buyToken/RampProvider.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/buyToken/RampProvider.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_assets.data.buyToken
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.showBrowser
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/mappers/mappers/AssetMappers.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/mappers/mappers/AssetMappers.kt
@@ -1,6 +1,6 @@
 package io.novafoundation.nova.feature_assets.data.mappers.mappers
 
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.formatAsChange
 import io.novafoundation.nova.common.utils.formatAsCurrency
 import io.novafoundation.nova.common.utils.isNonNegative

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/mappers/mappers/OperationMappers.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/mappers/mappers/OperationMappers.kt
@@ -1,6 +1,6 @@
 package io.novafoundation.nova.feature_assets.data.mappers.mappers
 
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_account_api.presenatation.account.AddressDisplayUseCase

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/di/AssetsFeatureModule.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/di/AssetsFeatureModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_assets.di
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.BuildConfig
+import io.novafoundation.nova.feature_assets.BuildConfig
 import io.novafoundation.nova.common.data.storage.Preferences
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/assetActions/AssetActionsView.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/assetActions/AssetActionsView.kt
@@ -5,7 +5,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.dp
 import io.novafoundation.nova.common.utils.updatePadding
 import io.novafoundation.nova.common.view.shape.getBlurDrawable

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/assetActions/buy/BuyProviderChooserBottomSheet.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/assetActions/buy/BuyProviderChooserBottomSheet.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_assets.presentation.balance.assetActions.
 import android.content.Context
 import android.os.Bundle
 import android.view.View
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.inflateChild
 import io.novafoundation.nova.common.view.bottomSheet.list.dynamic.ClickHandler
 import io.novafoundation.nova.common.view.bottomSheet.list.dynamic.DynamicListBottomSheet

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/detail/AssetDetailBalancesView.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/detail/AssetDetailBalancesView.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_assets.presentation.balance.detail
 
 import android.content.Context
 import android.util.AttributeSet
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.setDrawableEnd
 import io.novafoundation.nova.feature_wallet_api.presentation.view.BalancesView
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/detail/BalanceDetailFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/detail/BalanceDetailFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import coil.ImageLoader
 import coil.load
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.applyBarMargin

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/detail/LockedTokensBottomSheet.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/detail/LockedTokensBottomSheet.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_assets.presentation.balance.detail
 
 import android.content.Context
 import android.os.Bundle
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.view.bottomSheet.list.fixed.FixedListBottomSheet
 import io.novafoundation.nova.feature_assets.presentation.common.currencyItem
 import io.novafoundation.nova.feature_assets.presentation.model.AssetModel

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/filters/AssetFiltersFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/filters/AssetFiltersFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
 import coil.ImageLoader
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.applyStatusBarInsets

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/BalanceListFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/BalanceListFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ConcatAdapter
 import coil.ImageLoader
 import dev.chrisbanes.insetter.applyInsetter
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.hideKeyboard

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/AssetsHeaderAdapter.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/AssetsHeaderAdapter.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_assets.presentation.balance.list.view
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.address.AddressModel
 import io.novafoundation.nova.common.utils.inflateChild
 import io.novafoundation.nova.common.utils.setVisible

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/AssetsTotalBalanceView.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/AssetsTotalBalanceView.kt
@@ -5,7 +5,7 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
 import android.widget.LinearLayout
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.WithContextExtensions
 import io.novafoundation.nova.common.utils.setShimmerVisible
 import io.novafoundation.nova.common.utils.setVisible

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/BalanceListAdapter.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/BalanceListAdapter.kt
@@ -4,7 +4,7 @@ import android.view.View
 import android.view.ViewGroup
 import coil.ImageLoader
 import coil.load
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.list.BaseGroupedDiffCallback
 import io.novafoundation.nova.common.list.GroupedListAdapter
 import io.novafoundation.nova.common.list.GroupedListHolder

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/GoToNftsView.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/GoToNftsView.kt
@@ -7,7 +7,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import coil.ImageLoader
 import coil.load
 import coil.transform.RoundedCornersTransformation
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.presentation.LoadingState
 import io.novafoundation.nova.common.presentation.dataOrNull

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/common/FixedListBottomSheet.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/common/FixedListBottomSheet.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.feature_assets.presentation.common
 
 import androidx.annotation.StringRes
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.format
 import io.novafoundation.nova.common.view.bottomSheet.list.fixed.FixedListBottomSheet
 import kotlinx.android.synthetic.main.item_sheet_currency.view.itemCurrencyLabel

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/model/OperationStatusAppearance.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/model/OperationStatusAppearance.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_assets.presentation.model
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 
 enum class OperationStatusAppearance(
     @DrawableRes val icon: Int,

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/receive/ReceiveFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/receive/ReceiveFragment.kt
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import coil.ImageLoader
 import coil.load
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.setVisible

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/receive/ReceiveViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/receive/ReceiveViewModel.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_assets.presentation.receive
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.base.BaseViewModel
 import io.novafoundation.nova.common.resources.ResourceManager

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/BalanceDetailsBottomSheet.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/BalanceDetailsBottomSheet.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_assets.presentation.send
 
 import android.content.Context
 import android.os.Bundle
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.view.bottomSheet.list.fixed.FixedListBottomSheet
 import io.novafoundation.nova.feature_assets.presentation.common.currencyItem
 import io.novafoundation.nova.feature_assets.presentation.model.AssetModel

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/TransferAssetValidationFailureUi.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/TransferAssetValidationFailureUi.kt
@@ -1,6 +1,6 @@
 package io.novafoundation.nova.feature_assets.presentation.send
 
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.TitleAndMessage
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransferValidationFailure

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/amount/ChooseAmountFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/amount/ChooseAmountFragment.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_assets.presentation.send.amount
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.mixin.impl.observeValidations

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmTransferFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmTransferFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import coil.ImageLoader
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.mixin.impl.observeValidations

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmTransferViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmTransferViewModel.kt
@@ -1,6 +1,6 @@
 package io.novafoundation.nova.feature_assets.presentation.send.confirm
 
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.base.BaseViewModel
 import io.novafoundation.nova.common.mixin.api.Validatable

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/phishing/PhishingWarningUi.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/phishing/PhishingWarningUi.kt
@@ -1,6 +1,6 @@
 package io.novafoundation.nova.feature_assets.presentation.send.phishing
 
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.base.BaseViewModel
 import io.novafoundation.nova.common.view.dialog.warningDialog

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/recipient/ChooseRecipientAdapter.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/recipient/ChooseRecipientAdapter.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_assets.presentation.send.recipient
 
 import android.view.View
 import android.view.ViewGroup
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.address.AddressModel
 import io.novafoundation.nova.common.list.BaseGroupedDiffCallback
 import io.novafoundation.nova.common.list.GroupedListAdapter

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/recipient/ChooseRecipientFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/recipient/ChooseRecipientFragment.kt
@@ -8,7 +8,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
 import com.google.zxing.integration.android.IntentIntegrator
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.onDoneClicked

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/recipient/ChooseRecipientViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/recipient/ChooseRecipientViewModel.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.AddressModel
 import io.novafoundation.nova.common.base.BaseViewModel

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/recipient/QrCodeSourceChooserBottomSheet.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/recipient/QrCodeSourceChooserBottomSheet.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_assets.presentation.send.recipient
 
 import android.content.Context
 import android.os.Bundle
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.view.bottomSheet.list.fixed.FixedListBottomSheet
 import io.novafoundation.nova.common.view.bottomSheet.list.fixed.item
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/extrinsic/ExtrinsicDetailFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/extrinsic/ExtrinsicDetailFragment.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_assets.presentation.transaction.detail.ex
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.formatDateTime

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/reward/RewardDetailFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/reward/RewardDetailFragment.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_assets.presentation.transaction.detail.re
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.formatDateTime

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/reward/RewardDetailViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/reward/RewardDetailViewModel.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.feature_assets.presentation.transaction.detail.reward
 
 import androidx.lifecycle.liveData
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.createAddressModel
 import io.novafoundation.nova.common.base.BaseViewModel

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/transfer/TransferDetailFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/transfer/TransferDetailFragment.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_assets.presentation.transaction.detail.tr
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.formatDateTime

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/filter/TransactionHistoryFilterFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/filter/TransactionHistoryFilterFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.CompoundButton
 import androidx.lifecycle.lifecycleScope
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.view.ButtonState

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/TransactionHistoryAdapter.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/TransactionHistoryAdapter.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_assets.presentation.transaction.history
 
 import android.view.View
 import android.view.ViewGroup
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.list.BaseGroupedDiffCallback
 import io.novafoundation.nova.common.list.GroupedListAdapter
 import io.novafoundation.nova.common.list.GroupedListHolder

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/TransactionHistoryView.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/TransactionHistoryView.kt
@@ -12,7 +12,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import io.novafoundation.nova.R
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.utils.dp
 import io.novafoundation.nova.common.utils.enableShowingNewlyAddedTopElements
 import io.novafoundation.nova.common.utils.makeGone

--- a/feature-nft-impl/src/main/AndroidManifest.xml
+++ b/feature-nft-impl/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova">
+    package="io.novafoundation.nova.feature_nft_impl">
 
 </manifest>

--- a/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/common/Mappers.kt
+++ b/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/common/Mappers.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_nft_impl.presentation.nft.common
 
-import io.novafoundation.nova.R
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.format
 import io.novafoundation.nova.feature_nft_api.data.model.Nft
+import io.novafoundation.nova.feature_nft_impl.R
 
 fun ResourceManager.formatIssuance(issuance: Nft.Issuance): String {
     return when (issuance) {

--- a/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/common/NftIssuanceView.kt
+++ b/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/common/NftIssuanceView.kt
@@ -3,11 +3,11 @@ package io.novafoundation.nova.feature_nft_impl.presentation.nft.common
 import android.content.Context
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatTextView
-import io.novafoundation.nova.R
 import io.novafoundation.nova.common.utils.WithContextExtensions
 import io.novafoundation.nova.common.utils.setTextColorRes
 import io.novafoundation.nova.common.utils.updatePadding
 import io.novafoundation.nova.common.view.shape.getRoundedCornerDrawable
+import io.novafoundation.nova.feature_nft_impl.R
 
 class NftIssuanceView @JvmOverloads constructor(
     context: Context,

--- a/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/details/NftDetailsFragment.kt
+++ b/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/details/NftDetailsFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import coil.ImageLoader
 import coil.load
-import io.novafoundation.nova.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.applyStatusBarInsets
@@ -19,6 +18,7 @@ import io.novafoundation.nova.feature_account_api.presenatation.actions.setupExt
 import io.novafoundation.nova.feature_account_api.view.showAddress
 import io.novafoundation.nova.feature_account_api.view.showChain
 import io.novafoundation.nova.feature_nft_api.NftFeatureApi
+import io.novafoundation.nova.feature_nft_impl.R
 import io.novafoundation.nova.feature_nft_impl.di.NftFeatureComponent
 import io.novafoundation.nova.feature_wallet_api.presentation.view.setPriceOrHide
 import kotlinx.android.synthetic.main.fragment_nft_details.nftDetailsChain

--- a/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/list/NftAdapter.kt
+++ b/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/list/NftAdapter.kt
@@ -10,7 +10,6 @@ import coil.ImageLoader
 import coil.clear
 import coil.load
 import coil.transform.RoundedCornersTransformation
-import io.novafoundation.nova.R
 import io.novafoundation.nova.common.presentation.LoadingState
 import io.novafoundation.nova.common.utils.dpF
 import io.novafoundation.nova.common.utils.inflateChild
@@ -18,6 +17,7 @@ import io.novafoundation.nova.common.utils.makeGone
 import io.novafoundation.nova.common.utils.makeVisible
 import io.novafoundation.nova.common.view.shape.addRipple
 import io.novafoundation.nova.common.view.shape.getRoundedCornerDrawable
+import io.novafoundation.nova.feature_nft_impl.R
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.item_nft.view.itemNftContent
 import kotlinx.android.synthetic.main.item_nft.view.itemNftIssuance

--- a/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/list/NftListFragment.kt
+++ b/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/presentation/nft/list/NftListFragment.kt
@@ -5,12 +5,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import coil.ImageLoader
-import io.novafoundation.nova.R
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.applyStatusBarInsets
 import io.novafoundation.nova.common.utils.submitListPreservingViewPoint
 import io.novafoundation.nova.feature_nft_api.NftFeatureApi
+import io.novafoundation.nova.feature_nft_impl.R
 import io.novafoundation.nova.feature_nft_impl.di.NftFeatureComponent
 import kotlinx.android.synthetic.main.fragment_nft_list.nftListBack
 import kotlinx.android.synthetic.main.fragment_nft_list.nftListCounter


### PR DESCRIPTION
Due to copy-paste error of AndroidManifest both `feature-assets` and `feature-nft-impl` modules had the same (wrong) package without module suffix. This caused release build to fail due to clash of BuildConfig classes from these modules.

This also why CI started to fail on `upload` jobs