### PR TITLE
Fix - fee calculation is broken on send

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/FearlessLibExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/FearlessLibExt.kt
@@ -44,6 +44,14 @@ fun ByteArray.toAddress(networkType: Node.NetworkType) = toAddress(networkType.r
 
 fun String.removeHexPrefix() = removePrefix("0x")
 
+fun String.ethereumAddressToAccountId(): ByteArray {
+    return fromHex().also {
+        require(it.size == 20) {
+            "Ethereum address must be 20 bytes long"
+        }
+    }
+}
+
 fun <T> DataType<T>.fromHex(hex: String): T {
     val codecReader = ScaleCodecReader(hex.fromHex())
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.runtime.ext
 import io.novafoundation.nova.common.data.network.runtime.binding.MultiAddress
 import io.novafoundation.nova.common.data.network.runtime.binding.bindOrNull
 import io.novafoundation.nova.common.utils.ethereumAddressFromPublicKey
+import io.novafoundation.nova.common.utils.ethereumAddressToAccountId
 import io.novafoundation.nova.common.utils.ethereumAddressToHex
 import io.novafoundation.nova.common.utils.formatNamed
 import io.novafoundation.nova.common.utils.substrateAccountId
@@ -49,7 +50,7 @@ fun Chain.addressOf(accountId: ByteArray): String {
 
 fun Chain.accountIdOf(address: String): ByteArray {
     return if (isEthereumBased) {
-        address.fromHex()
+        address.ethereumAddressToAccountId()
     } else {
         address.toAccountId()
     }


### PR DESCRIPTION
Due to not complete validation of address candidate during conversion to accountId, any valid hex string was converted and later passed to fee estimation causing extrinsic encoding to fail. Now chain.accountIdOf() converts only valid ethereum addresses (20-bytes long hex strings). 