### PR TITLE
Fix Astar again

### DIFF
--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/webview/WebViewScriptInjector.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/webview/WebViewScriptInjector.kt
@@ -70,14 +70,17 @@ class WebViewScriptInjector(
             }
         """.trimIndent()
 
+        // some dApps (like Astar) breaks when the this code is executing directly. Anonymous function with self-invocation fixes this
         val wrappedScript = """
-            if (document !== undefined && document.readyState !== 'loading') {
-                $initializationCode
-            } else {
-                window.addEventListener("DOMContentLoaded", function(event) {
-                 $initializationCode
-                });
-            }
+            (function() {
+                if (document !== undefined && document.readyState !== 'loading') {
+                    $initializationCode
+                } else {
+                    window.addEventListener("DOMContentLoaded", function(event) {
+                     $initializationCode
+                    });
+                }
+            })();
         """.trimIndent()
 
         into.evaluateJavascript(wrappedScript, null)


### PR DESCRIPTION
For some reason Astar dapp breaks if script is injected without being wrapped into function

![image](https://user-images.githubusercontent.com/70131744/164219360-6956bf10-f159-4fe2-8cb7-0c7ba6e843c9.png)
