### PR TITLE
Fix - unable to sign evm native transfer

### DIFF
--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/data/network/ethereum/EthereumApi.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/data/network/ethereum/EthereumApi.kt
@@ -20,7 +20,7 @@ interface EthereumApi {
     suspend fun formTransaction(
         fromAddress: String,
         toAddress: String,
-        data: String,
+        data: String?,
         value: BigInteger?,
     ): RawTransaction
 
@@ -51,9 +51,11 @@ private class Web3JEthereumApi(
         return Web3j.build(HttpService(url, okHttpClient))
     }
 
-    override suspend fun formTransaction(fromAddress: String, toAddress: String, data: String, value: BigInteger?): RawTransaction {
+    override suspend fun formTransaction(fromAddress: String, toAddress: String, data: String?, value: BigInteger?): RawTransaction {
         val nonce = getNonce(fromAddress)
         val gasPrice = getGasPrice()
+
+        val dataOrDefault = data.orEmpty()
 
         val forFeeEstimatesTx = Transaction.createFunctionCallTransaction(
             fromAddress,
@@ -62,7 +64,7 @@ private class Web3JEthereumApi(
             null,
             toAddress,
             value,
-            data
+            dataOrDefault
         )
 
         val gasLimit = estimateGasLimit(forFeeEstimatesTx)
@@ -73,7 +75,7 @@ private class Web3JEthereumApi(
             gasLimit,
             toAddress,
             value,
-            data
+            dataOrDefault
         )
     }
 

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/metamask/model/MetamaskTransaction.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/metamask/model/MetamaskTransaction.kt
@@ -10,7 +10,7 @@ class MetamaskTransaction(
     val gasPrice: String?,
     val from: String,
     val to: String,
-    val data: String,
+    val data: String?,
     val value: String?
 ) : Parcelable
 


### PR DESCRIPTION
Ethereum lib does not support passing `null` for `data` parameter