### PR TITLE
Prioritize selected meta account for accountId search

### DIFF
--- a/core-db/src/main/java/io/novafoundation/nova/core_db/dao/MetaAccountDao.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/dao/MetaAccountDao.kt
@@ -28,6 +28,7 @@ private const val FIND_BY_ADDRESS_QUERY = """
                 INNER JOIN chain_accounts as c ON m.id = c.metaId
                 WHERE  c.accountId = :accountId
             )
+        ORDER BY (CASE WHEN isSelected THEN 0 ELSE 1 END)
     """
 
 @Dao

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/extrinsic/ExtrinsicService.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/extrinsic/ExtrinsicService.kt
@@ -10,23 +10,23 @@ import java.math.BigInteger
 
 interface ExtrinsicService {
 
-    suspend fun submitExtrinsic(
+    suspend fun submitExtrinsicWithSelectedWallet(
         chain: Chain,
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,
     ): Result<*>
 
-    suspend fun submitAndWatchExtrinsic(
+    suspend fun submitAndWatchExtrinsicWithSelectedWallet(
         chain: Chain,
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,
     ): Flow<ExtrinsicStatus>
 
-    suspend fun submitExtrinsic(
+    suspend fun submitExtrinsicWithAnySuitableWallet(
         chain: Chain,
         accountId: ByteArray,
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,
     ): Result<String>
 
-    suspend fun submitAndWatchExtrinsic(
+    suspend fun submitAndWatchExtrinsicAnySuitableWallet(
         chain: Chain,
         accountId: ByteArray,
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/extrinsic/ExtrinsicServiceExt.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/extrinsic/ExtrinsicServiceExt.kt
@@ -6,11 +6,11 @@ import jp.co.soramitsu.fearless_utils.runtime.extrinsic.ExtrinsicBuilder
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 
-suspend fun ExtrinsicService.submitExtrinsicAndWaitBlockInclusion(
+suspend fun ExtrinsicService.submitExtrinsicWithSelectedWalletAndWaitBlockInclusion(
     chain: Chain,
     formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,
 ): Result<*> = runCatching {
-    submitAndWatchExtrinsic(chain, formExtrinsic)
+    submitAndWatchExtrinsicWithSelectedWallet(chain, formExtrinsic)
         .filterIsInstance<ExtrinsicStatus.InBlock>()
         .first()
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/extrinsic/RealExtrinsicService.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/extrinsic/RealExtrinsicService.kt
@@ -28,27 +28,27 @@ class RealExtrinsicService(
     private val signerProvider: SignerProvider,
 ) : ExtrinsicService {
 
-    override suspend fun submitExtrinsic(
+    override suspend fun submitExtrinsicWithSelectedWallet(
         chain: Chain,
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,
     ): Result<*> {
         val account = accountRepository.getSelectedMetaAccount()
         val accountId = account.accountIdIn(chain)!!
 
-        return submitExtrinsic(chain, accountId, formExtrinsic)
+        return submitExtrinsicWithAnySuitableWallet(chain, accountId, formExtrinsic)
     }
 
-    override suspend fun submitAndWatchExtrinsic(
+    override suspend fun submitAndWatchExtrinsicWithSelectedWallet(
         chain: Chain,
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,
     ): Flow<ExtrinsicStatus> {
         val account = accountRepository.getSelectedMetaAccount()
         val accountId = account.accountIdIn(chain)!!
 
-        return submitAndWatchExtrinsic(chain, accountId, formExtrinsic)
+        return submitAndWatchExtrinsicAnySuitableWallet(chain, accountId, formExtrinsic)
     }
 
-    override suspend fun submitExtrinsic(
+    override suspend fun submitExtrinsicWithAnySuitableWallet(
         chain: Chain,
         accountId: ByteArray,
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,
@@ -58,7 +58,7 @@ class RealExtrinsicService(
         rpcCalls.submitExtrinsic(chain.id, extrinsic)
     }
 
-    override suspend fun submitAndWatchExtrinsic(
+    override suspend fun submitAndWatchExtrinsicAnySuitableWallet(
         chain: Chain,
         accountId: ByteArray,
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/contribute/CrowdloanContributeInteractor.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/contribute/CrowdloanContributeInteractor.kt
@@ -104,7 +104,7 @@ class CrowdloanContributeInteractor(
         ) { submission, chain, account ->
             val accountId = account.accountIdIn(chain)!!
 
-            extrinsicService.submitExtrinsic(chain, accountId, submission)
+            extrinsicService.submitExtrinsicWithAnySuitableWallet(chain, accountId, submission)
         }.getOrThrow()
 
         txHash

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/contribute/custom/moonbeam/MoonbeamCrowdloanInteractor.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/contribute/custom/moonbeam/MoonbeamCrowdloanInteractor.kt
@@ -132,7 +132,7 @@ class MoonbeamCrowdloanInteractor(
             val agreeRemarkRequest = AgreeRemarkRequest(currentAddress, signedHash)
             val remark = httpExceptionHandler.wrap { moonbeamApi.agreeRemark(parachainMetadata, agreeRemarkRequest) }.remark
 
-            val finalizedStatus = extrinsicService.submitAndWatchExtrinsic(chain, metaAccount.accountIdIn(chain)!!) {
+            val finalizedStatus = extrinsicService.submitAndWatchExtrinsicAnySuitableWallet(chain, metaAccount.accountIdIn(chain)!!) {
                 systemRemark(remark.encodeToByteArray())
             }
                 .filterIsInstance<ExtrinsicStatus.Finalized>()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rebond/ParachainStakingRebondInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rebond/ParachainStakingRebondInteractor.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.rebo
 
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
-import io.novafoundation.nova.feature_account_api.data.extrinsic.submitExtrinsicAndWaitBlockInclusion
+import io.novafoundation.nova.feature_account_api.data.extrinsic.submitExtrinsicWithSelectedWalletAndWaitBlockInclusion
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.calls.cancelDelegationRequest
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.DelegatorStateRepository
@@ -49,7 +49,7 @@ class RealParachainStakingRebondInteractor(
     }
 
     override suspend fun rebond(collatorId: AccountId): Result<*> = withContext(Dispatchers.IO) {
-        extrinsicService.submitExtrinsicAndWaitBlockInclusion(selectedAssetState.chain()) {
+        extrinsicService.submitExtrinsicWithSelectedWalletAndWaitBlockInclusion(selectedAssetState.chain()) {
             cancelDelegationRequest(collatorId)
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/redeem/ParachainStakingRedeemInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/redeem/ParachainStakingRedeemInteractor.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.rede
 
 import io.novafoundation.nova.common.utils.sumByBigInteger
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
-import io.novafoundation.nova.feature_account_api.data.extrinsic.submitExtrinsicAndWaitBlockInclusion
+import io.novafoundation.nova.feature_account_api.data.extrinsic.submitExtrinsicWithSelectedWalletAndWaitBlockInclusion
 import io.novafoundation.nova.feature_staking_api.domain.api.AccountIdMap
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.ScheduledDelegationRequest
@@ -44,7 +44,7 @@ class RealParachainStakingRedeemInteractor(
     }
 
     override suspend fun redeem(delegatorState: DelegatorState): Result<*> = withContext(Dispatchers.Default) {
-        extrinsicService.submitExtrinsicAndWaitBlockInclusion(delegatorState.chain) {
+        extrinsicService.submitExtrinsicWithSelectedWalletAndWaitBlockInclusion(delegatorState.chain) {
             redeem(delegatorState)
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/start/StartParachainStakingInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/start/StartParachainStakingInteractor.kt
@@ -79,7 +79,7 @@ class RealStartParachainStakingInteractor(
 
             val currentDelegationState = delegatorStateRepository.getDelegationState(chain, chainAsset, accountId)
 
-            extrinsicService.submitAndWatchExtrinsic(chain, accountId) {
+            extrinsicService.submitAndWatchExtrinsicAnySuitableWallet(chain, accountId) {
                 if (currentDelegationState.hasDelegation(collator)) {
                     delegatorBondMore(
                         candidate = collator,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/unbond/ParachainStakingUnbondInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/unbond/ParachainStakingUnbondInteractor.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.unbo
 
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
-import io.novafoundation.nova.feature_account_api.data.extrinsic.submitExtrinsicAndWaitBlockInclusion
+import io.novafoundation.nova.feature_account_api.data.extrinsic.submitExtrinsicWithSelectedWalletAndWaitBlockInclusion
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.delegationAmountTo
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.calls.scheduleBondLess
@@ -48,7 +48,7 @@ class RealParachainStakingUnbondInteractor(
     override suspend fun unbond(amount: BigInteger, collator: AccountId): Result<*> = withContext(Dispatchers.IO) {
         val chain = selectedAssetSharedState.chain()
 
-        extrinsicService.submitExtrinsicAndWaitBlockInclusion(chain) {
+        extrinsicService.submitExtrinsicWithSelectedWalletAndWaitBlockInclusion(chain) {
             unbond(amount, collator)
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/payout/PayoutInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/payout/PayoutInteractor.kt
@@ -32,7 +32,7 @@ class PayoutInteractor(
             val chain = stakingSharedState.chain()
             val accountId = chain.accountIdOf(payload.originAddress)
 
-            extrinsicService.submitExtrinsic(chain, accountId) {
+            extrinsicService.submitExtrinsicWithAnySuitableWallet(chain, accountId) {
                 payload.payoutStakersCalls.forEach {
                     payoutStakers(it.era, it.validatorAddress.toAccountId())
                 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/setup/SetupStakingInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/setup/SetupStakingInteractor.kt
@@ -57,7 +57,7 @@ class SetupStakingInteractor(
         val accountId = chain.accountIdOf(controllerAddress)
 
         runCatching {
-            extrinsicService.submitExtrinsic(chain, accountId) {
+            extrinsicService.submitExtrinsicWithAnySuitableWallet(chain, accountId) {
                 formExtrinsic(chain, chainAsset, controllerAddress, validatorAccountIds, bondPayload)
             }
         }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/bond/BondMoreInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/bond/BondMoreInteractor.kt
@@ -29,7 +29,7 @@ class BondMoreInteractor(
             val chain = stakingSharedState.chain()
             val accountId = chain.accountIdOf(accountAddress)
 
-            extrinsicService.submitExtrinsic(chain, accountId) {
+            extrinsicService.submitExtrinsicWithAnySuitableWallet(chain, accountId) {
                 bondMore(amount)
             }
         }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/controller/ControllerInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/controller/ControllerInteractor.kt
@@ -29,7 +29,7 @@ class ControllerInteractor(
             val chain = sharedStakingSate.chain()
             val accountId = chain.accountIdOf(stashAccountAddress)
 
-            extrinsicService.submitExtrinsic(chain, accountId) {
+            extrinsicService.submitExtrinsicWithAnySuitableWallet(chain, accountId) {
                 setController(chain.multiAddressOf(controllerAccountAddress))
             }
         }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/rebond/RebondInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/rebond/RebondInteractor.kt
@@ -26,7 +26,7 @@ class RebondInteractor(
 
     suspend fun rebond(stashState: StakingState.Stash, amount: BigInteger): Result<String> {
         return withContext(Dispatchers.IO) {
-            extrinsicService.submitExtrinsic(stashState.chain, stashState.controllerId) {
+            extrinsicService.submitExtrinsicWithAnySuitableWallet(stashState.chain, stashState.controllerId) {
                 rebond(amount)
             }
         }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/redeem/RedeemInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/redeem/RedeemInteractor.kt
@@ -24,7 +24,7 @@ class RedeemInteractor(
 
     suspend fun redeem(stakingState: StakingState.Stash, asset: Asset): Result<RedeemConsequences> {
         return withContext(Dispatchers.IO) {
-            extrinsicService.submitExtrinsic(stakingState.chain, stakingState.controllerId) {
+            extrinsicService.submitExtrinsicWithAnySuitableWallet(stakingState.chain, stakingState.controllerId) {
                 withdrawUnbonded(getSlashingSpansNumber(stakingState))
             }.map {
                 RedeemConsequences(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/rewardDestination/ChangeRewardDestinationInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/rewardDestination/ChangeRewardDestinationInteractor.kt
@@ -25,7 +25,7 @@ class ChangeRewardDestinationInteractor(
         stashState: StakingState.Stash,
         rewardDestination: RewardDestination,
     ): Result<String> = withContext(Dispatchers.IO) {
-        extrinsicService.submitExtrinsic(stashState.chain, stashState.controllerId) {
+        extrinsicService.submitExtrinsicWithAnySuitableWallet(stashState.chain, stashState.controllerId) {
             setPayee(rewardDestination)
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/unbond/UnbondInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/unbond/UnbondInteractor.kt
@@ -42,7 +42,7 @@ class UnbondInteractor(
         amount: BigInteger
     ): Result<String> {
         return withContext(Dispatchers.IO) {
-            extrinsicService.submitExtrinsic(stashState.chain, stashState.controllerId) {
+            extrinsicService.submitExtrinsicWithAnySuitableWallet(stashState.chain, stashState.controllerId) {
                 constructUnbondExtrinsic(stashState, currentBondedBalance, amount)
             }
         }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/BaseAssetTransfers.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/BaseAssetTransfers.kt
@@ -46,7 +46,7 @@ abstract class BaseAssetTransfers(
     override suspend fun performTransfer(transfer: AssetTransfer): Result<String> {
         val senderAccountId = transfer.sender.accountIdIn(transfer.originChain)!!
 
-        return extrinsicService.submitExtrinsic(transfer.originChain, senderAccountId) {
+        return extrinsicService.submitExtrinsicWithAnySuitableWallet(transfer.originChain, senderAccountId) {
             transfer(transfer)
         }
     }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
@@ -71,7 +71,7 @@ class RealCrossChainTransactor(
         transfer: AssetTransfer,
         crossChainFee: BigInteger
     ): Result<*> {
-        return extrinsicService.submitExtrinsic(transfer.originChain) {
+        return extrinsicService.submitExtrinsicWithSelectedWallet(transfer.originChain) {
             crossChainTransfer(configuration, transfer, crossChainFee)
         }
     }


### PR DESCRIPTION
PR Fixes the following corner-case:
User has same account id both in Secrets wallet and WO wallet. Currently, wallet is searched by accountId and first matched wallet is used. This works correctly unser assumption that it does not matter which wallet to pick for the same accountId. However, with wallet types added, this assumption is now broken - we do not want to use secrets wallet for signing while being on WO wallet.

The fix is to prioritize a selected wallet in the search. That way, the only time when different wallet will be matched is for controller/stash setups. However, in that case, this behavior becomes an expected one.

PR also renames ExtrinsicServeice functions to reflect which lookup type is used

In future we might also want to prioritize non-selected wallets by the wallet type - currently, if user has the following setup
stash (watch)
stash (secrets)
controller <- selected

It might happen that watch only stash will be picked for stash transactions and wont allow user to submit tx 

