### PR TITLE
Fix bt checker corner cases

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/LifecycleEx.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/LifecycleEx.kt
@@ -13,3 +13,18 @@ fun Lifecycle.onDestroy(action: () -> Unit) {
         }
     })
 }
+
+
+fun Lifecycle.whenStarted(action: () -> Unit) {
+    if (currentState.isAtLeast(Lifecycle.State.STARTED)) {
+        action()
+    } else {
+        addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                action()
+
+                removeObserver(this)
+            }
+        })
+    }
+}

--- a/common/src/main/java/io/novafoundation/nova/common/utils/bluetooth/BluetoothManager.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/bluetooth/BluetoothManager.kt
@@ -8,6 +8,7 @@ import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanSettings
 import android.content.Intent
 import io.novafoundation.nova.common.resources.ContextManager
+import io.novafoundation.nova.common.utils.whenStarted
 import android.bluetooth.BluetoothManager as NativeBluetoothManager
 
 interface BluetoothManager {
@@ -32,18 +33,20 @@ internal class RealBluetoothManager(
         get() = nativeBluetoothManager.adapter
 
     override fun startBleScan(filters: List<ScanFilter>, settings: ScanSettings, callback: ScanCallback) {
-        bluetoothAdapter.bluetoothLeScanner.startScan(filters, settings, callback)
+        bluetoothAdapter.bluetoothLeScanner?.startScan(filters, settings, callback)
     }
 
     override fun stopBleScan(callback: ScanCallback) {
-        bluetoothAdapter.bluetoothLeScanner.stopScan(callback)
+        bluetoothAdapter.bluetoothLeScanner?.stopScan(callback)
     }
 
     override fun enableBluetooth() {
-        val activity = contextManager.getActivity()
+        val activity = contextManager.getActivity()!!
         val intent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
 
-        activity!!.startActivityForResult(intent, 0)
+        activity.lifecycle.whenStarted {
+            activity.startActivityForResult(intent, 0)
+        }
     }
 
     override fun isBluetoothEnabled(): Boolean {

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectLedger/SelectLedgerFragment.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectLedger/SelectLedgerFragment.kt
@@ -76,14 +76,14 @@ abstract class SelectLedgerFragment<V : SelectLedgerViewModel> : BaseFragment<V>
         setupLedgerMessages(ledgerMessagePresentable)
     }
 
-    override fun onStart() {
-        super.onStart()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
 
         enableBluetoothConnectivityTracker()
     }
 
-    override fun onStop() {
-        super.onStop()
+    override fun onDestroy() {
+        super.onDestroy()
 
         disableBluetoothConnectivityTracker()
     }


### PR DESCRIPTION
1. On some devices (e.g. Lev's one) bt enable dialog triggers onStop() event of Fragment. So we need to disable bt checker later - at onDestroy()
2. When bt is disabled outside of application bt enable dialog was not shown since `startActivityForResult` is forbidden in background. So we should wait until `onStarted`