### PR TITLE
Fix ledger dapp signing

### DIFF
--- a/app/src/main/res/navigation/sign_ledger_nav_graph.xml
+++ b/app/src/main/res/navigation/sign_ledger_nav_graph.xml
@@ -5,6 +5,7 @@
     app:startDestination="@id/signLedgerFragment">
     
     <fragment
+        app:useAdd="true"
         android:id="@+id/signLedgerFragment"
         android:name="io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerFragment"
         android:label="SignLedgerFragment" />


### PR DESCRIPTION
Ledger sign fragment used `replace` method which caused dapp view to be destroyed. WebView cannot restore itself completely when it is recreated