### PR TITLE
Fix - weight is not parsed correctly on new versions

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/data/network/runtime/model/FeeResponse.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/network/runtime/model/FeeResponse.kt
@@ -4,5 +4,4 @@ import java.math.BigInteger
 
 class FeeResponse(
     val partialFee: BigInteger,
-    val weight: Long
 )


### PR DESCRIPTION
`Weight` type was recently changed in Substrate. While we surely can adapt to the new definition, it seems like it is gonna change once again quite soon. So lets remove it from `FeeResponse` for now since it is not used anywhere yet   

### Westend fee loads
![image](https://user-images.githubusercontent.com/70131744/190619293-ef5275ec-ae81-4f07-9f1b-d35c81cfd6b7.png)
