### PR TITLE
Crowdloan fixes

### DIFF
--- a/feature-crowdloan-api/src/main/java/io/novafoundation/nova/feature_crowdloan_api/domain/contributions/ContributionWithMetadata.kt
+++ b/feature-crowdloan-api/src/main/java/io/novafoundation/nova/feature_crowdloan_api/domain/contributions/ContributionWithMetadata.kt
@@ -35,10 +35,10 @@ class ContributionWithMetadata(
     val metadata: ContributionMetadata
 )
 
-class ContributionsWithTotalAmount(val totalContributed: BigInteger, val contributions: List<ContributionWithMetadata>) {
+class ContributionsWithTotalAmount<T>(val totalContributed: BigInteger, val contributions: List<T>) {
     companion object {
-        fun empty(): ContributionsWithTotalAmount {
-            return ContributionsWithTotalAmount(BigInteger.ZERO, listOf())
+        fun <T> empty(): ContributionsWithTotalAmount<T> {
+            return ContributionsWithTotalAmount(BigInteger.ZERO, emptyList())
         }
     }
 }
@@ -65,8 +65,4 @@ fun mapContributionFromLocal(
         contribution.paraId,
         contribution.sourceId,
     )
-}
-
-fun List<ContributionWithMetadata>.totalContributionAmount(): BigInteger {
-    return sumOf { it.contribution.amountInPlanks }
 }

--- a/feature-crowdloan-api/src/main/java/io/novafoundation/nova/feature_crowdloan_api/domain/contributions/ContributionsInteractor.kt
+++ b/feature-crowdloan-api/src/main/java/io/novafoundation/nova/feature_crowdloan_api/domain/contributions/ContributionsInteractor.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_crowdloan_api.domain.contributions
 
 import io.novafoundation.nova.core.updater.Updater
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainAssetId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
@@ -12,7 +13,11 @@ interface ContributionsInteractor {
 
     fun observeTotalContributedByAssets(): Flow<Map<FullChainAssetId, BigInteger>>
 
-    fun observeSelectedChainContributions(): Flow<ContributionsWithTotalAmount>
+    fun observeSelectedChainContributionsWithMetadata(): Flow<ContributionsWithTotalAmount<ContributionWithMetadata>>
 
-    fun observeChainContributions(chainId: ChainId, assetId: ChainAssetId): Flow<ContributionsWithTotalAmount>
+    fun observeChainContributions(
+        metaAccount: MetaAccount,
+        chainId: ChainId,
+        assetId: ChainAssetId
+    ): Flow<ContributionsWithTotalAmount<Contribution>>
 }

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/main/statefull/StatefulCrowdloanProvider.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/main/statefull/StatefulCrowdloanProvider.kt
@@ -10,6 +10,7 @@ import io.novafoundation.nova.feature_crowdloan_impl.domain.main.CrowdloanIntera
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.getCurrentAsset
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
+import io.novafoundation.nova.runtime.ext.utilityAsset
 import io.novafoundation.nova.runtime.state.SingleAssetSharedState
 import io.novafoundation.nova.runtime.state.selectedChainFlow
 import kotlinx.coroutines.CoroutineScope
@@ -59,8 +60,9 @@ class StatefulCrowdloanProvider(
     }
         .shareInBackground()
 
-    override val contributionsInfoFlow = contributionsInteractor.observeSelectedChainContributions()
-        .withLoading()
+    override val contributionsInfoFlow = chainAndAccount.withLoading { (chain, account) ->
+        contributionsInteractor.observeChainContributions(account, chain.id, chain.utilityAsset.id)
+    }
         .mapLoading {
             val amountModel = mapAmountToAmountModel(
                 it.totalContributed,

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contributions/UserContributionsViewModel.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contributions/UserContributionsViewModel.kt
@@ -34,7 +34,7 @@ class UserContributionsViewModel(
     private val tokenFlow = tokenUseCase.currentTokenFlow()
         .shareInBackground()
 
-    private val contributionsWitTotalAmountFlow = interactor.observeSelectedChainContributions()
+    private val contributionsWitTotalAmountFlow = interactor.observeSelectedChainContributionsWithMetadata()
         .shareInBackground()
 
     private val contributionsFlow = contributionsWitTotalAmountFlow


### PR DESCRIPTION
* Fix - crash when loading contributions with no metadata
* Optimize contributions loading - remove metadata loading on balance details and crowdloan list
* Fix - no loading state when switching between accounts / chains on crowdloan list
#30qz3y8
What can also be improved: use contributions cache while loading crowdloans to improve crowdloan list loading time