### PR TITLE
Disable socket logging for production

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/data/network/AndroidLogger.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/network/AndroidLogger.kt
@@ -6,12 +6,18 @@ import jp.co.soramitsu.fearless_utils.wsrpc.logging.Logger
 
 const val TAG = "AndroidLogger"
 
-class AndroidLogger : Logger {
+class AndroidLogger(
+    private val debug: Boolean
+) : Logger {
     override fun log(message: String?) {
-        Log.d(TAG, message.toString())
+        if (debug) {
+            Log.d(TAG, message.toString())
+        }
     }
 
     override fun log(throwable: Throwable?) {
-        throwable?.printStackTrace()
+        if (debug) {
+            throwable?.printStackTrace()
+        }
     }
 }

--- a/common/src/main/java/io/novafoundation/nova/common/di/modules/NetworkModule.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/di/modules/NetworkModule.kt
@@ -80,7 +80,7 @@ class NetworkModule {
 
     @Provides
     @ApplicationScope
-    fun provideLogger(): Logger = AndroidLogger()
+    fun provideLogger(): Logger = AndroidLogger(debug = BuildConfig.DEBUG)
 
     @Provides
     @ApplicationScope


### PR DESCRIPTION
Since we fetch A LOT of data from sockets, disabling logging should positively impact performance