### PR TITLE
Fix broken foreign keys on some devices

### DIFF
--- a/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
@@ -51,6 +51,7 @@ import io.novafoundation.nova.core_db.migrations.ChangeAsset_3_4
 import io.novafoundation.nova.core_db.migrations.ChangeChainNodes_20_21
 import io.novafoundation.nova.core_db.migrations.ChangeDAppAuthorization_10_11
 import io.novafoundation.nova.core_db.migrations.ChangeTokens_19_20
+import io.novafoundation.nova.core_db.migrations.FixBrokenForeignKeys_28_29
 import io.novafoundation.nova.core_db.migrations.FixMigrationConflicts_13_14
 import io.novafoundation.nova.core_db.migrations.GovernanceFlagToEnum_26_27
 import io.novafoundation.nova.core_db.migrations.NullableSubstrateAccountId_21_22
@@ -84,7 +85,7 @@ import io.novafoundation.nova.core_db.model.chain.ChainRuntimeInfoLocal
 import io.novafoundation.nova.core_db.model.chain.MetaAccountLocal
 
 @Database(
-    version = 28,
+    version = 29,
     entities = [
         AccountLocal::class,
         NodeLocal::class,
@@ -146,7 +147,7 @@ abstract class AppDatabase : RoomDatabase() {
                     .addMigrations(NullableSubstrateAccountId_21_22, AddLocks_22_23, AddContributions_23_24)
                     .addMigrations(AddGovernanceFlagToChains_24_25, AddGovernanceDapps_25_26, GovernanceFlagToEnum_26_27)
                     .addMigrations(AddGovernanceExternalApiToChain_27_28)
-                    .fallbackToDestructiveMigration()
+                    .addMigrations(FixBrokenForeignKeys_28_29)
                     .build()
             }
             return instance!!

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/28_29_FixBrokenForeignKeys.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/28_29_FixBrokenForeignKeys.kt
@@ -1,0 +1,260 @@
+package io.novafoundation.nova.core_db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Due to previous migration of chain & meta account tables by means of rename-create-insert-delete strategy
+ * foreign keys to these tables got renamed and now points to wrong table which causes crashes for subset of users
+ * This migration recreates (lets hope) all affected tables
+ */
+val FixBrokenForeignKeys_28_29 = object : Migration(28, 29) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // foreign key to ChainLocal
+        recreateChainAssets(database)
+
+        // foreign key to ChainAssetLocal which was recreated above
+        recreateAssets(database)
+
+        // foreign key to MetaAccountLocal
+        recreateChainAccount(database)
+
+        // foreign key to ChainLocal
+        recreateChainRuntimeInfo(database)
+
+        // foreign key to ChainLocal
+        recreateChainExplorers(database)
+
+        // foreign key to ChainLocal
+        recreateChainNodes(database)
+
+        // foreign key to ChainLocal, ChainAssetLocal, MetaAccount
+        recreateBalanceLocks(database)
+    }
+
+    private fun recreateChainAssets(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP INDEX IF EXISTS `index_chain_assets_chainId`")
+
+        database.execSQL("ALTER TABLE chain_assets RENAME TO chain_assets_old")
+
+        database.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `chain_assets` (
+            `id` INTEGER NOT NULL,
+            `chainId` TEXT NOT NULL,
+            `name` TEXT NOT NULL,
+            `symbol` TEXT NOT NULL,
+            `priceId` TEXT,
+            `staking` TEXT NOT NULL,
+            `precision` INTEGER NOT NULL,
+            `icon` TEXT,
+            `type` TEXT,
+            `buyProviders` TEXT,
+            `typeExtras` TEXT,
+            PRIMARY KEY(`chainId`,`id`),
+            FOREIGN KEY(`chainId`) REFERENCES `chains`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE 
+            )
+        """.trimIndent()
+        )
+
+        database.execSQL(
+            """
+            INSERT INTO chain_assets
+            SELECT * FROM chain_assets_old
+        """.trimIndent()
+        )
+
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_chain_assets_chainId` ON `chain_assets` (`chainId`)")
+
+        database.execSQL("DROP TABLE chain_assets_old")
+    }
+
+    private fun recreateAssets(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP INDEX IF EXISTS `index_assets_metaId`")
+        database.execSQL("ALTER TABLE assets RENAME TO assets_old")
+
+        database.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `assets` (
+            `assetId` INTEGER NOT NULL,
+            `chainId` TEXT NOT NULL,
+            `metaId` INTEGER NOT NULL,
+            `freeInPlanks` TEXT NOT NULL,
+            `frozenInPlanks` TEXT NOT NULL,
+            `reservedInPlanks` TEXT NOT NULL,
+            `bondedInPlanks` TEXT NOT NULL,
+            `redeemableInPlanks` TEXT NOT NULL,
+            `unbondingInPlanks` TEXT NOT NULL,
+            PRIMARY KEY(`assetId`,`chainId`,`metaId`),
+            FOREIGN KEY(`assetId`,`chainId`) REFERENCES `chain_assets`(`id`, `chainId`) ON UPDATE NO ACTION ON DELETE CASCADE 
+            )
+        """.trimIndent()
+        )
+
+        database.execSQL(
+            """
+            INSERT INTO assets
+            SELECT * FROM assets_old
+        """.trimIndent()
+        )
+
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_assets_metaId` ON `assets` (`metaId`)")
+
+        database.execSQL("DROP TABLE assets_old")
+    }
+
+    private fun recreateChainAccount(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP INDEX IF EXISTS `index_chain_accounts_chainId`")
+        database.execSQL("DROP INDEX IF EXISTS `index_chain_accounts_metaId`")
+        database.execSQL("DROP INDEX IF EXISTS `index_chain_accounts_accountId`")
+
+        database.execSQL("ALTER TABLE chain_accounts RENAME TO chain_accounts_old")
+
+        database.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `chain_accounts` (
+            `metaId` INTEGER NOT NULL,
+            `chainId` TEXT NOT NULL,
+            `publicKey` BLOB,
+            `accountId` BLOB NOT NULL,
+            `cryptoType` TEXT, PRIMARY KEY(`metaId`,
+            `chainId`),
+             FOREIGN KEY(`metaId`) REFERENCES `meta_accounts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE 
+            )
+        """.trimIndent()
+        )
+
+        database.execSQL(
+            """
+            INSERT INTO chain_accounts
+            SELECT * FROM chain_accounts_old
+        """.trimIndent()
+        )
+
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_chain_accounts_chainId` ON `chain_accounts` (`chainId`)")
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_chain_accounts_metaId` ON `chain_accounts` (`metaId`)")
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_chain_accounts_accountId` ON `chain_accounts` (`accountId`)")
+
+        database.execSQL("DROP TABLE chain_accounts_old")
+    }
+
+    private fun recreateChainRuntimeInfo(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP INDEX IF EXISTS `index_chain_runtimes_chainId`")
+
+        database.execSQL("ALTER TABLE chain_runtimes RENAME TO chain_runtimes_old")
+
+        database.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `chain_runtimes` (
+            `chainId` TEXT NOT NULL,
+            `syncedVersion` INTEGER NOT NULL,
+            `remoteVersion` INTEGER NOT NULL,
+            PRIMARY KEY(`chainId`),
+            FOREIGN KEY(`chainId`) REFERENCES `chains`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+             )
+        """.trimIndent()
+        )
+
+        database.execSQL(
+            """
+            INSERT INTO chain_runtimes
+            SELECT * FROM chain_runtimes_old
+        """.trimIndent()
+        )
+
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_chain_runtimes_chainId` ON `chain_runtimes` (`chainId`)")
+
+        database.execSQL("DROP TABLE chain_runtimes_old")
+    }
+
+    private fun recreateChainExplorers(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP INDEX IF EXISTS `index_chain_explorers_chainId`")
+
+        database.execSQL("ALTER TABLE chain_explorers RENAME TO chain_explorers_old")
+
+        database.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `chain_explorers` (
+            `chainId` TEXT NOT NULL,
+            `name` TEXT NOT NULL,
+            `extrinsic` TEXT,
+            `account` TEXT,
+            `event` TEXT,
+            PRIMARY KEY(`chainId`, `name`),
+            FOREIGN KEY(`chainId`) REFERENCES `chains`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE 
+            )
+        """.trimIndent()
+        )
+
+        database.execSQL(
+            """
+            INSERT INTO chain_explorers
+            SELECT * FROM chain_explorers_old
+        """.trimIndent()
+        )
+
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_chain_explorers_chainId` ON `chain_explorers` (`chainId`)")
+
+        database.execSQL("DROP TABLE chain_explorers_old")
+    }
+
+    private fun recreateChainNodes(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP INDEX IF EXISTS `index_chain_nodes_chainId`")
+
+        database.execSQL("ALTER TABLE chain_nodes RENAME TO chain_nodes_old")
+
+        database.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `chain_nodes` (
+            `chainId` TEXT NOT NULL,
+            `url` TEXT NOT NULL,
+            `name` TEXT NOT NULL,
+            `orderId` INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY(`chainId`, `url`),
+            FOREIGN KEY(`chainId`) REFERENCES `chains`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE 
+            )
+        """.trimIndent()
+        )
+
+        database.execSQL(
+            """
+            INSERT INTO chain_nodes
+            SELECT * FROM chain_nodes_old
+        """.trimIndent()
+        )
+
+        database.execSQL("CREATE INDEX IF NOT EXISTS `index_chain_nodes_chainId` ON `chain_nodes` (`chainId`)")
+
+        database.execSQL("DROP TABLE chain_nodes_old")
+    }
+
+    private fun recreateBalanceLocks(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE locks RENAME TO locks_old")
+
+        database.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `locks` (
+            `metaId` INTEGER NOT NULL,
+            `chainId` TEXT NOT NULL,
+            `assetId` INTEGER NOT NULL,
+            `type` TEXT NOT NULL,
+            `amount` TEXT NOT NULL,
+            PRIMARY KEY(`metaId`, `chainId`, `assetId`, `type`), 
+            FOREIGN KEY(`metaId`) REFERENCES `meta_accounts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+            FOREIGN KEY(`chainId`) REFERENCES `chains`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE ,
+            FOREIGN KEY(`assetId`, `chainId`) REFERENCES `chain_assets`(`id`, `chainId`) ON UPDATE NO ACTION ON DELETE CASCADE 
+            )
+        """.trimIndent()
+        )
+
+        database.execSQL(
+            """
+            INSERT INTO locks
+            SELECT * FROM locks_old
+        """.trimIndent()
+        )
+
+        database.execSQL("DROP TABLE locks_old")
+    }
+}


### PR DESCRIPTION
Recreate tables that have foreign keys to Chain and MetaAccount in attempt to fix the issue with database migration on some devices