### PR TITLE
Adding integration tests workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -6,6 +6,7 @@ on:
       - develop
   workflow_dispatch:
   pull_request:
+    types: [labeled]
 
 
 env:
@@ -31,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.label.name, 'integratio_tests') ||
+      contains(github.event.label.name, 'integration_tests') ||
       github.event.action != 'labeled'
     timeout-minutes: 30
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -6,9 +6,7 @@ on:
       - develop
   workflow_dispatch:
   pull_request:
-    branches:
-      - develop
-    types: [labeled]
+    types: [labeled, pushed]
 
 env:
   TEST_CLASSES: io.novafoundation.nova.balances.BalancesIntegrationTest

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,9 +1,18 @@
 name: Integration tests
 
 on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
   pull_request:
+    branches:
+      - develop
+    types: [labeled]
 
 env:
+  TEST_CLASSES: io.novafoundation.nova.balances.BalancesIntegrationTest
+
   ACALA_PROD_AUTH_TOKEN: 'token'
   ACALA_TEST_AUTH_TOKEN: 'token'
   MOONBEAM_PROD_AUTH_TOKEN: 'token'
@@ -23,6 +32,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.label.name, 'integratio_tests') ||
+      github.event.action != 'labeled'
     timeout-minutes: 30
 
     steps:
@@ -74,7 +86,7 @@ jobs:
           disable-animations: true
           profile: Nexus 5X
           api-level: 28
-          script: .github/workflows/run_integration_tests.sh io.novafoundation.nova.balances.BalancesIntegrationTest
+          script: .github/workflows/run_integration_tests.sh ${{ env.TEST_CLASSES }}
 
       - uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,4 +1,4 @@
-name: Pull request
+name: Integration tests
 
 on:
   pull_request:
@@ -101,3 +101,25 @@ jobs:
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           keep-reports-history: 30
+
+  alert:
+    runs-on: ubuntu-latest
+    needs: report
+    if: always() && (needs.integration-tests.result == 'failure')
+    env:
+      GITHUB_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Report
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          message: |
+            Integration tests failed on ${{ github.ref }} branch
+
+            Failed run:
+            ${{ env.GITHUB_WORKFLOW_URL }}
+
+            Report:
+            https://improved-enigma-vryoz6l.pages.github.io/${{ github.run_number }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,88 @@
+name: Pull request
+
+on:
+  pull_request:
+
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@master
+
+      - name: ☕️ Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+
+      - name: 🏗 Build app for testing
+        run: ./gradlew :app:assembleDebugAndroidTest
+
+      - name: 🧪 Build instrumential test
+        run: ./gradlew :app:assembleInstrumentialTest
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: apk
+          path: |
+            app/build/outputs/apk/instrumentialTest/
+            app/build/outputs/apk/androidTest/debug/
+
+  integration-tests:
+    needs: build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Download built artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: apk
+          path: app
+
+      - name: Debug
+        run: |
+          ls -R
+
+      - name: Add permissions
+        run: chmod +x .github/workflows/run_integration_tests.sh
+
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          disable-animations: true
+          profile: Nexus 5X
+          api-level: 28
+          script: .github/workflows/run_integration_tests.sh io.novafoundation.nova.balances.BalancesIntegrationTest
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: anroid-results
+          path: ./allure-results.tar
+
+  report:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    if: always() && (needs.build.result == 'success')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download built artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Unzip results
+        run: |
+          tar -xvf artifacts/anroid-results/allure-results.tar
+
+      - uses: ./.github/workflows/report
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          keep-reports-history: 30

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -6,7 +6,7 @@ on:
       - develop
   workflow_dispatch:
   pull_request:
-    types: [labeled, pushed]
+
 
 env:
   TEST_CLASSES: io.novafoundation.nova.balances.BalancesIntegrationTest

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,6 +3,21 @@ name: Pull request
 on:
   pull_request:
 
+env:
+  ACALA_PROD_AUTH_TOKEN: 'token'
+  ACALA_TEST_AUTH_TOKEN: 'token'
+  MOONBEAM_PROD_AUTH_TOKEN: 'token'
+  MOONBEAM_TEST_AUTH_TOKEN: 'token'
+  MOONPAY_PRODUCTION_SECRET: 'token'
+  MOONPAY_TEST_SECRET: 'token'
+  MERCURYO_PRODUCTION_SECRET: 'token'
+  MERCURYO_TEST_SECRET: 'token'
+  EHTERSCAN_API_KEY_MOONBEAM: 'token'
+  EHTERSCAN_API_KEY_MOONRIVER=: 'token'
+
+  CI_KEYSTORE_PASS: 'token'
+  CI_KEYSTORE_KEY_ALIAS: 'token'
+  CI_KEYSTORE_KEY_PASS: 'token'
 
 jobs:
 

--- a/.github/workflows/report/action.yml
+++ b/.github/workflows/report/action.yml
@@ -1,0 +1,37 @@
+name: Publish report to gh-pages
+description: That workflow will publish report to the github-pages
+inputs:
+  secret-token:
+    description: 'Secret token for gh deployment'
+    required: true
+  keep-reports-history:
+    description: 'History storage depth, integer'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+      - name: Get Allure history
+        uses: actions/checkout@v2
+        if: always()
+        continue-on-error: true
+        with:
+          repository: nova-wallet/test-runner
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Allure Report action
+        uses: simple-elf/allure-report-action@master
+        if: always()
+        with:
+          allure_results: allure-results
+          allure_history: allure-history
+          keep_reports: ${{ inputs.keep-reports-history }}
+
+      - name: Deploy report to Github Pages
+        if: always()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          PERSONAL_TOKEN: ${{ inputs.secret-token }}
+          PUBLISH_BRANCH: gh-pages
+          PUBLISH_DIR: allure-history

--- a/.github/workflows/report/action.yml
+++ b/.github/workflows/report/action.yml
@@ -16,7 +16,6 @@ runs:
         if: always()
         continue-on-error: true
         with:
-          repository: nova-wallet/test-runner
           ref: gh-pages
           path: gh-pages
 

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+adb devices
+
+# Install debug app
+adb -s emulator-5554 install app/androidTest/debug/app-debug-androidTest.apk
+
+# Install instrumental tests
+adb -s emulator-5554 install app/instrumentialTest/app-instrumentialTest.apk
+
+export TEST_CLASSES=$@
+
+# Run tests
+adb logcat -c &&
+python - <<END
+import os
+import re
+import subprocess as sp
+import sys
+import threading
+import time
+done = False
+def update():
+  # prevent CI from killing the process for inactivity
+  while not done:
+    time.sleep(5)
+    print ("Running...")
+t = threading.Thread(target=update)
+t.dameon = True
+t.start()
+test_classes = os.getenv("TEST_CLASSES")
+def run():
+  os.system('adb wait-for-device')
+  p = sp.Popen(f"adb shell am instrument -w -m -e debug false -e class {test_classes} io.novafoundation.nova.debug.test/io.qameta.allure.android.runners.AllureAndroidJUnitRunner",
+               shell=True, stdout=sp.PIPE, stderr=sp.PIPE, stdin=sp.PIPE)
+  return p.communicate()
+success = re.compile(r'OK \(\d+ tests\)')
+stdout, stderr = run()
+done = True
+print (stderr)
+print (stdout)
+if success.search(stderr + stdout):
+  sys.exit(0)
+else:
+  sys.exit(1) # make sure we fail if the tests fail
+END
+EXIT_CODE=$?
+adb logcat -d '*:E'
+
+# Export results
+adb exec-out run-as io.novafoundation.nova.debug sh -c 'cd /data/data/io.novafoundation.nova.debug/files && tar cf - allure-results' > allure-results.tar
+
+exit $EXIT_CODE

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -28,10 +28,10 @@ t = threading.Thread(target=update)
 t.dameon = True
 t.start()
 test_classes = os.getenv("TEST_CLASSES")
+run_command = f"adb shell am instrument -w -m -e debug false -e class {test_classes} io.novafoundation.nova.debug.test/io.qameta.allure.android.runners.AllureAndroidJUnitRunner"
 def run():
   os.system('adb wait-for-device')
-  p = sp.Popen(f"adb shell am instrument -w -m -e debug false -e class {test_classes} io.novafoundation.nova.debug.test/io.qameta.allure.android.runners.AllureAndroidJUnitRunner",
-               shell=True, stdout=sp.PIPE, stderr=sp.PIPE, stdin=sp.PIPE)
+  p = sp.Popen(run_command,shell=True, stdout=sp.PIPE, stderr=sp.PIPE, stdin=sp.PIPE)
   return p.communicate()
 success = re.compile(r'OK \(\d+ tests\)')
 stdout, stderr = run()

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -28,7 +28,7 @@ t = threading.Thread(target=update)
 t.dameon = True
 t.start()
 test_classes = os.getenv("TEST_CLASSES")
-run_command = f"adb shell am instrument -w -m -e debug false -e class {test_classes} io.novafoundation.nova.debug.test/io.qameta.allure.android.runners.AllureAndroidJUnitRunner"
+run_command = 'adb shell am instrument -w -m -e debug false -e class %s io.novafoundation.nova.debug.test/io.qameta.allure.android.runners.AllureAndroidJUnitRunner' % test_classes
 def run():
   os.system('adb wait-for-device')
   p = sp.Popen(run_command,shell=True, stdout=sp.PIPE, stderr=sp.PIPE, stdin=sp.PIPE)


### PR DESCRIPTION
This PR adds workflow to run integration tests, results will publish in github pages, if something went wrong - notification will be sent in telegram channel.

## Inputs
The tests are run by the script - .github/workflows/run_integration_tests.sh, for this script you need to pass as an argument the path of the class to the tests to be run, example:

```python
.github/workflows/run_integration_tests.sh io.novafoundation.nova.balances.BalancesIntegrationTest 
```
it should be specify in yaml file:
<img width="700" alt="Screenshot 2023-02-07 at 10 56 06" src="https://user-images.githubusercontent.com/40560660/217185139-2e7a9c2e-9028-4b1a-953b-7f990408db3b.png">


## Trigger
I suggest to use triggers:
- [Push event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-to-specific-branches-occurs), when some PullRequest was merged in `develop` branch
- [Workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch), to run from any branch manually
- [Create label ](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#label)- `integration_tests`, to run in particular PullRequest before merge

## Results
Results will be publish to gh-pages branch and deploy to project pages. It will store history of 30 runs.
Example:
https://improved-enigma-vryoz6l.pages.github.io

## Notifications
If any run will be failed, that notification will be sent in https://t.me/+4GvFtoLqufcyMTZi

Example:
```md
Integration tests failed on `feature/add_integration_tests` branch

Failed run:
https://github.com/nova-wallet/nova-wallet-android/actions/runs/4111336376

Report:
https://improved-enigma-vryoz6l.pages.github.io/6/
```