### PR TITLE
Fix - wrong type used for multi assets

### DIFF
--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/PalletXcmRepository.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/PalletXcmRepository.kt
@@ -14,7 +14,7 @@ interface PalletXcmRepository {
 
     suspend fun lowestPresentMultiLocationVersion(chainId: ChainId): XcmVersion?
 
-    suspend fun lowestPresentMultiAssetVersion(chainId: ChainId): XcmVersion?
+    suspend fun lowestPresentMultiAssetsVersion(chainId: ChainId): XcmVersion?
 }
 
 class RealPalletXcmRepository(
@@ -25,8 +25,8 @@ class RealPalletXcmRepository(
         return lowestPresentXcmTypeVersion(chainId, "xcm.VersionedMultiLocation")
     }
 
-    override suspend fun lowestPresentMultiAssetVersion(chainId: ChainId): XcmVersion? {
-        return lowestPresentXcmTypeVersion(chainId, "xcm.VersionedMultiAsset")
+    override suspend fun lowestPresentMultiAssetsVersion(chainId: ChainId): XcmVersion? {
+        return lowestPresentXcmTypeVersion(chainId, "xcm.VersionedMultiAssets")
     }
 
     private suspend fun lowestPresentXcmTypeVersion(chainId: ChainId, typeName: String): XcmVersion? {

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
@@ -151,7 +151,7 @@ class RealCrossChainTransactor(
         callName: String
     ) {
         val lowestMultiLocationVersion = palletXcmRepository.lowestPresentMultiLocationVersion(assetTransfer.originChain.id)
-        val lowestMultiAssetVersion = palletXcmRepository.lowestPresentMultiAssetVersion(assetTransfer.originChain.id)
+        val lowestMultiAssetsVersion = palletXcmRepository.lowestPresentMultiAssetsVersion(assetTransfer.originChain.id)
 
         val multiAsset = configuration.multiAssetFor(assetTransfer, crossChainFee)
 
@@ -161,7 +161,7 @@ class RealCrossChainTransactor(
             arguments = mapOf(
                 "dest" to configuration.destinationChainLocation.versioned(lowestMultiLocationVersion).toEncodableInstance(),
                 "beneficiary" to assetTransfer.beneficiaryLocation().versioned(lowestMultiLocationVersion).toEncodableInstance(),
-                "assets" to listOf(multiAsset).versioned(lowestMultiAssetVersion).toEncodableInstance(),
+                "assets" to listOf(multiAsset).versioned(lowestMultiAssetsVersion).toEncodableInstance(),
                 "fee_asset_item" to BigInteger.ZERO,
                 "weight_limit" to WeightLimit.Limited(weigher.estimateRequiredDestWeight(configuration)).toVersionedEncodableInstance(runtime)
             )


### PR DESCRIPTION
#860q67yft

The asset type that is used in `polkadotXcm.transfer` is named `xcm.VersionedMultiAssets` (plural). We used `xcm.VersionedMultiAsset` which always has similar structure to `VersionedMultiAssets` but it might be missing in runtime metadata (e.g. Robonomics).

![image](https://user-images.githubusercontent.com/70131744/224293469-55dfeff9-49c8-4b0c-b744-694e2f2438b8.png)
