### PR TITLE
Fix - handle empty page arriving on empty progress

### DIFF
--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/mixin/TransactionStateMachine.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/mixin/TransactionStateMachine.kt
@@ -124,6 +124,11 @@ object TransactionStateMachine {
                         }
                     }
 
+                    action.newPage.isEmpty() -> State.Empty(
+                        allAvailableFilters = state.allAvailableFilters,
+                        usedFilters = state.usedFilters
+                    )
+
                     else -> State.FullData(
                         data = action.newPage,
                         allAvailableFilters = state.allAvailableFilters,
@@ -178,12 +183,19 @@ object TransactionStateMachine {
                                 if (page.items.size < PAGE_SIZE) {
                                     sideEffectListener(SideEffect.LoadPage(nextPageOffset, state.usedFilters))
 
-                                    State.NewPageProgress(
-                                        nextPageOffset = nextPageOffset,
-                                        data = page,
-                                        allAvailableFilters = state.allAvailableFilters,
-                                        usedFilters = state.usedFilters
-                                    )
+                                    if (page.items.isEmpty()) {
+                                        State.EmptyProgress(
+                                            allAvailableFilters = state.allAvailableFilters,
+                                            usedFilters = state.usedFilters
+                                        )
+                                    } else {
+                                        State.NewPageProgress(
+                                            nextPageOffset = nextPageOffset,
+                                            data = page,
+                                            allAvailableFilters = state.allAvailableFilters,
+                                            usedFilters = state.usedFilters
+                                        )
+                                    }
                                 } else {
                                     State.Data(
                                         nextPageOffset = nextPageOffset,


### PR DESCRIPTION
#860q99nd2

Handle two additional cases
* Cached page is empty and its cursor is not loadable
* Page arrived to `EmptyProgress` is empty & loadable => we need to use `State.EmptyProgress` instead of `State.NewPageProgress`