### PR TITLE
Fix for GovernanceIntegrationTest in delegates function interface

### DIFF
--- a/app/src/androidTest/java/io/novafoundation/nova/GovernanceIntegrationTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/GovernanceIntegrationTest.kt
@@ -151,7 +151,8 @@ class GovernanceIntegrationTest : BaseIntegrationTest() {
 
         val chain = kusama()
         val delegates = interactor.getDelegates(
-            governanceOption = supportedGovernanceOption(chain, Chain.Governance.V2)
+            governanceOption = supportedGovernanceOption(chain, Chain.Governance.V2),
+            scope = this
         )
         Log.d(this@GovernanceIntegrationTest.LOG_TAG, delegates.toString())
     }


### PR DESCRIPTION
This PR was created In order to fix:
```
e: /home/runner/work/test-runner/test-runner/app/src/androidTest/java/io/novafoundation/nova/GovernanceIntegrationTest.kt: (155, 9): No value passed for parameter 'scope'
```
https://github.com/nova-wallet/test-runner/actions/runs/4476855731/jobs/7867670793

<img width="300" alt="Screenshot 2023-03-21 at 11 53 01" src="https://user-images.githubusercontent.com/40560660/226557381-7e73f39e-3805-41b6-896f-319aa40edd2a.png">

