### PR TITLE
Fix - ether realtime updates do not always work

### DIFF
--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/evmNative/EvmNativeAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/evmNative/EvmNativeAssetHistory.kt
@@ -105,8 +105,8 @@ class EvmNativeAssetHistory(
         return from.ethAccountIdMatches(accountId) || to.ethAccountIdMatches(accountId)
     }
 
-    private fun String.ethAccountIdMatches(other: AccountId): Boolean {
-        return ethereumAddressToAccountId().contentEquals(other)
+    private fun String?.ethAccountIdMatches(other: AccountId): Boolean {
+        return other.contentEquals(this?.ethereumAddressToAccountId())
     }
 
     private fun mapRemoteNormalTxToOperation(


### PR DESCRIPTION
In Ethereum, some transactions have `to: null`