### PR TITLE
Fix democracy scheduler approval detection

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -78,6 +78,13 @@ inline fun <reified T> Any?.castOrNull(): T? {
     return this as? T
 }
 
+fun ByteArray.padEnd(expectedSize: Int, padding: Byte = 0): ByteArray {
+    if (size >= expectedSize) return this
+
+    val padded = ByteArray(expectedSize) { padding }
+    return copyInto(padded)
+}
+
 fun <K, V> Map<K, V>.reversed() = HashMap<V, K>().also { newMap ->
     entries.forEach { newMap[it.value] = it.key }
 }


### PR DESCRIPTION
#860qav5ru

Fixed two issues:
1. Democracy pads referendum ids from [the end](https://github.com/paritytech/substrate/blob/master/frame/democracy/src/lib.rs#L1184) to create a scheduler key
2. Collisions between pre- and post- v4 keys caused non-тnull values to be lost
![image](https://user-images.githubusercontent.com/70131744/227916117-ad1ecb62-8576-4982-a2ef-2edefccd493b.png)
![image](https://user-images.githubusercontent.com/70131744/227916216-29de6011-792c-4de1-a870-bee7fea41fda.png)
