### PR TITLE
Fix - delegate descriptions might go outside of delegate card

### DIFF
--- a/feature-governance-impl/src/main/res/layout/item_delegate.xml
+++ b/feature-governance-impl/src/main/res/layout/item_delegate.xml
@@ -62,12 +62,11 @@
         <TextView
             android:id="@+id/itemDelegateDescription"
             style="@style/TextAppearance.NovaFoundation.Regular.Footnote.Secondary"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="12dp"
             android:layout_marginTop="16dp"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/itemDelegateIcon"
             tools:text="@tools:sample/lorem[10]" />


### PR DESCRIPTION
width should be "match constraints"
height should be "wrap content"

![image](https://user-images.githubusercontent.com/70131744/227924574-94534145-5bb9-49e2-a197-06837a2d5c5e.png)
