### PR TITLE
Fix namespace approval logic

### DIFF
--- a/feature-wallet-connect-impl/src/main/java/io/novafoundation/nova/feature_wallet_connect_impl/presentation/service/RealWalletConnectService.kt
+++ b/feature-wallet-connect-impl/src/main/java/io/novafoundation/nova/feature_wallet_connect_impl/presentation/service/RealWalletConnectService.kt
@@ -56,7 +56,6 @@ internal class RealWalletConnectService(
     private val interactor: WalletConnectSessionInteractor,
     private val dAppSignRequester: ExternalSignRequester,
     private val selectedAccountUseCase: SelectedAccountUseCase,
-
 ) : WalletConnectService,
     CoroutineScope by parentScope,
     WithCoroutineScopeExtensions by WithCoroutineScopeExtensions(parentScope) {
@@ -108,6 +107,9 @@ internal class RealWalletConnectService(
 
         if (allowed) {
             interactor.approveSession(proposal, metaAccount)
+                .onFailure {
+                    Log.d("WalletConnect", "Session approve failed", it)
+                }
         } else {
             interactor.rejectSession(proposal)
         }


### PR DESCRIPTION
Map's `plus` operation caused the erasion of `required` namespaces that are also present in `optional` namespaces.

Now the connection to moonbeam dApp works