### PR TITLE
Fix using referendaListInteractor in integration tests

### DIFF
--- a/app/src/androidTest/java/io/novafoundation/nova/GovernanceIntegrationTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/GovernanceIntegrationTest.kt
@@ -3,13 +3,14 @@ package io.novafoundation.nova
 import android.util.Log
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.LOG_TAG
+import io.novafoundation.nova.common.utils.firstLoaded
 import io.novafoundation.nova.common.utils.inBackground
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.ReferendumId
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.VoteType
 import io.novafoundation.nova.feature_governance_api.data.source.SupportedGovernanceOption
 import io.novafoundation.nova.feature_governance_api.di.GovernanceFeatureApi
-import io.novafoundation.nova.feature_governance_api.domain.delegation.delegate.list.model.DelegateFiltering
-import io.novafoundation.nova.feature_governance_api.domain.delegation.delegate.list.model.DelegateSorting
+import io.novafoundation.nova.feature_governance_api.domain.referendum.filters.ReferendumType
+import io.novafoundation.nova.feature_governance_api.domain.referendum.filters.ReferendumTypeFilter
 import io.novafoundation.nova.feature_governance_impl.data.RealGovernanceAdditionalState
 import io.novafoundation.nova.runtime.ext.externalApi
 import io.novafoundation.nova.runtime.ext.utilityAsset
@@ -17,8 +18,10 @@ import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import jp.co.soramitsu.fearless_utils.ss58.SS58Encoder.toAccountId
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -96,7 +99,12 @@ class GovernanceIntegrationTest : BaseIntegrationTest() {
         val chain = chain()
         val selectedGovernance = supportedGovernanceOption(chain, Chain.Governance.V1)
 
-        val referendaByGroup = referendaListInteractor.referendaListStateFlow(accountId, selectedGovernance).first()
+        val filterFlow: Flow<ReferendumTypeFilter> = flow {
+            val referendaFilter = ReferendumTypeFilter(ReferendumType.ALL)
+            emit(referendaFilter)
+        }
+
+        val referendaByGroup = referendaListInteractor.referendaListStateFlow(accountId, selectedGovernance, this, filterFlow).firstLoaded()
         val referenda = referendaByGroup.groupedReferenda.values.flatten()
 
         Log.d(this@GovernanceIntegrationTest.LOG_TAG, referenda.joinToString("\n"))


### PR DESCRIPTION
This PR was created In order to fix build error:

```bash
e: /home/runner/work/test-runner/test-runner/app/src/androidTest/java/io/novafoundation/nova/GovernanceIntegrationTest.kt: (99, 108): No value passed for parameter 'coroutineScope'

> Task :app:compileDebugAndroidTestKotlin FAILED
e: /home/runner/work/test-runner/test-runner/app/src/androidTest/java/io/novafoundation/nova/GovernanceIntegrationTest.kt: (99, 108): No value passed for parameter 'referendumTypeFilterFlow'
e: /home/runner/work/test-runner/test-runner/app/src/androidTest/java/io/novafoundation/nova/GovernanceIntegrationTest.kt: (100, 42): Unresolved reference: groupedReferenda

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileDebugAndroidTestKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details
```
In integration tests:
https://github.com/nova-wallet/test-runner/actions/runs/5070904996/jobs/9106593568