### PR TITLE
Staking dashboard/improved offchain sync

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/CollectionDiffer.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/CollectionDiffer.kt
@@ -57,6 +57,29 @@ object CollectionDiffer {
 
         return Diff(added = added, updated = updated, removed = removed, all = newItems)
     }
+
+    fun <K, V> findDiff(
+        newItems: Map<K, V>,
+        oldItems: Map<K, V>,
+        forceUseNewItems: Boolean
+    ): Diff<Map.Entry<K, V>> {
+        val added = mutableListOf<Map.Entry<K, V>>()
+        val updated = mutableListOf<Map.Entry<K, V>>()
+
+        newItems.forEach { newEntry ->
+            val (key, newValue) = newEntry
+            val oldValue = oldItems[key]
+
+            when {
+                key !in oldItems -> added.add(newEntry)
+                oldValue != newValue || forceUseNewItems -> updated.add(newEntry)
+            }
+        }
+
+        val removed = oldItems.mapNotNull { entry -> entry.takeIf { entry.key !in newItems } }
+
+        return Diff(added = added, updated = updated, removed = removed, all = newItems.entries.toList())
+    }
 }
 
 fun <T, R> CollectionDiffer.Diff<T>.map(mapper: (T) -> R) = CollectionDiffer.Diff(

--- a/common/src/main/java/io/novafoundation/nova/common/utils/FlowExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/FlowExt.kt
@@ -494,3 +494,7 @@ fun <T> Flow<T>.observeInLifecycle(
 fun <T> Map<out T, MutableStateFlow<Boolean>>.checkEnabled(key: T) = get(key)?.value ?: false
 
 suspend inline fun <reified T> Flow<T?>.firstNotNull(): T = first { it != null } as T
+
+inline fun <T, R> Flow<IndexedValue<T>>.mapIndexed(crossinline transform: suspend (T) -> R): Flow<IndexedValue<R>> {
+    return map { IndexedValue(it.index, transform(it.value)) }
+}

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/dao/StakingDashboardDao.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/dao/StakingDashboardDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import io.novafoundation.nova.core_db.model.StakingDashboardItemLocal
+import io.novafoundation.nova.core_db.model.StakingDashboardPrimaryAccountView
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -28,6 +29,9 @@ interface StakingDashboardDao {
 
     @Query("SELECT * FROM staking_dashboard_items WHERE metaId = :metaId")
     fun dashboardItemsFlow(metaId: Long): Flow<List<StakingDashboardItemLocal>>
+
+    @Query("SELECT chainId, chainAssetId, stakingType, primaryStakingAccountId from staking_dashboard_items WHERE metaId = :metaId")
+    fun stakingAccountsViewFlow(metaId: Long): Flow<List<StakingDashboardPrimaryAccountView>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertItem(dashboardItemLocal: StakingDashboardItemLocal)

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/StakingDashboardItemLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/StakingDashboardItemLocal.kt
@@ -6,6 +6,7 @@ import androidx.room.ForeignKey
 import io.novafoundation.nova.core_db.model.chain.ChainAssetLocal
 import io.novafoundation.nova.core_db.model.chain.ChainLocal
 import io.novafoundation.nova.core_db.model.chain.MetaAccountLocal
+import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import java.math.BigInteger
 
 @Entity(
@@ -42,6 +43,7 @@ class StakingDashboardItemLocal(
     val status: Status?,
     val rewards: BigInteger?,
     val estimatedEarnings: Double?,
+    val primaryStakingAccountId: AccountId?,
 ) {
 
     companion object {
@@ -61,7 +63,8 @@ class StakingDashboardItemLocal(
             stake = null,
             status = null,
             rewards = null,
-            estimatedEarnings = estimatedEarnings
+            estimatedEarnings = estimatedEarnings,
+            primaryStakingAccountId = null
         )
 
         fun staking(
@@ -69,6 +72,7 @@ class StakingDashboardItemLocal(
             chainAssetId: Int,
             stakingType: String,
             stake: BigInteger,
+            primaryStakingAccountId: AccountId,
             metaId: Long,
             status: Status?,
             rewards: BigInteger?,
@@ -82,7 +86,8 @@ class StakingDashboardItemLocal(
             stake = stake,
             status = status,
             rewards = rewards,
-            estimatedEarnings = estimatedEarnings
+            estimatedEarnings = estimatedEarnings,
+            primaryStakingAccountId = primaryStakingAccountId
         )
     }
 
@@ -90,3 +95,11 @@ class StakingDashboardItemLocal(
         ACTIVE, INACTIVE, WAITING
     }
 }
+
+
+class StakingDashboardPrimaryAccountView(
+    val chainId: String,
+    val chainAssetId: Int,
+    val stakingType: String,
+    val primaryStakingAccountId: AccountId?
+)

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/StakingDashboardItemLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/StakingDashboardItemLocal.kt
@@ -96,7 +96,6 @@ class StakingDashboardItemLocal(
     }
 }
 
-
 class StakingDashboardPrimaryAccountView(
     val chainId: String,
     val chainAssetId: Int,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/model/StakingDashboardPrimaryAccountView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/model/StakingDashboardPrimaryAccountView.kt
@@ -7,7 +7,7 @@ import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.Staking
 data class StakingDashboardPrimaryAccount(
     val stakingOptionId: StakingOptionId,
     val primaryStakingAccountId: AccountIdKey?
-): Identifiable {
+) : Identifiable {
 
     override val identifier: String = "${stakingOptionId.chainId}:${stakingOptionId.chainAssetId}:${stakingOptionId.stakingType}"
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/model/StakingDashboardPrimaryAccountView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/model/StakingDashboardPrimaryAccountView.kt
@@ -1,0 +1,13 @@
+package io.novafoundation.nova.feature_staking_impl.data.dashboard.model
+
+import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.utils.Identifiable
+import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingOptionId
+
+data class StakingDashboardPrimaryAccount(
+    val stakingOptionId: StakingOptionId,
+    val primaryStakingAccountId: AccountIdKey?
+): Identifiable {
+
+    override val identifier: String = "${stakingOptionId.chainId}:${stakingOptionId.chainAssetId}:${stakingOptionId.stakingType}"
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/StakingStatsDataSource.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/StakingStatsDataSource.kt
@@ -31,7 +31,7 @@ class RealStakingStatsDataSource(
 ) : StakingStatsDataSource {
 
     override suspend fun fetchStakingStats(
-        stakingAccounts: Map<StakingOptionId, AccountIdKey?>,
+        stakingAccounts: StakingAccounts,
         stakingChains: List<Chain>
     ): MultiChainStakingStats = withContext(Dispatchers.IO) {
         retryUntilDone {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/StakingStatsDataSource.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/StakingStatsDataSource.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats
 
+import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.data.network.subquery.SubQueryNodes
 import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.common.utils.orZero
@@ -15,13 +16,14 @@ import io.novafoundation.nova.runtime.ext.supportedStakingOptions
 import io.novafoundation.nova.runtime.ext.utilityAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.mappers.mapStakingStringToStakingType
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
+typealias StakingAccounts = Map<StakingOptionId, AccountIdKey?>
+
 interface StakingStatsDataSource {
 
-    suspend fun fetchStakingStats(stakingAccounts: Map<StakingOptionId, AccountId?>, stakingChains: List<Chain>): MultiChainStakingStats
+    suspend fun fetchStakingStats(stakingAccounts: StakingAccounts, stakingChains: List<Chain>): MultiChainStakingStats
 }
 
 class RealStakingStatsDataSource(
@@ -29,7 +31,7 @@ class RealStakingStatsDataSource(
 ) : StakingStatsDataSource {
 
     override suspend fun fetchStakingStats(
-        stakingAccounts: Map<StakingOptionId, AccountId?>,
+        stakingAccounts: Map<StakingOptionId, AccountIdKey?>,
         stakingChains: List<Chain>
     ): MultiChainStakingStats = withContext(Dispatchers.IO) {
         retryUntilDone {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/api/StakingStatsRequest.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/api/StakingStatsRequest.kt
@@ -1,10 +1,10 @@
 package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats.api
 
-import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.data.network.subquery.SubQueryFilters
 import io.novafoundation.nova.common.data.network.subquery.SubqueryExpressions.and
 import io.novafoundation.nova.common.data.network.subquery.SubqueryExpressions.anyOf
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingOptionId
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats.StakingAccounts
 import io.novafoundation.nova.runtime.ext.addressOf
 import io.novafoundation.nova.runtime.ext.supportedStakingOptions
 import io.novafoundation.nova.runtime.ext.utilityAsset
@@ -13,7 +13,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import jp.co.soramitsu.fearless_utils.extensions.requireHexPrefix
 
-class StakingStatsRequest(stakingAccounts: Map<StakingOptionId, AccountIdKey?>, chains: List<Chain>) {
+class StakingStatsRequest(stakingAccounts: StakingAccounts, chains: List<Chain>) {
 
     @Transient
     private val chainAddressesFilter = constructChainAddressesFilter(stakingAccounts, chains)
@@ -52,7 +52,7 @@ class StakingStatsRequest(stakingAccounts: Map<StakingOptionId, AccountIdKey?>, 
     """.trimIndent()
 
     private fun constructChainAddressesFilter(
-        stakingAccounts: Map<StakingOptionId, AccountIdKey?>,
+        stakingAccounts: StakingAccounts,
         chains: List<Chain>
     ): String = with(SubQueryFilters) {
         val perChain = chains.mapNotNull { chain ->
@@ -68,7 +68,7 @@ class StakingStatsRequest(stakingAccounts: Map<StakingOptionId, AccountIdKey?>, 
 
     private fun SubQueryFilters.Companion.hasTypeAndAddressOptions(
         chain: Chain,
-        stakingAccounts: Map<StakingOptionId, AccountIdKey?>
+        stakingAccounts: StakingAccounts
     ): List<String> {
         val utilityAsset = chain.utilityAsset
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/api/StakingStatsRequest.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/api/StakingStatsRequest.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats.api
 
+import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.data.network.subquery.SubQueryFilters
 import io.novafoundation.nova.common.data.network.subquery.SubqueryExpressions.and
 import io.novafoundation.nova.common.data.network.subquery.SubqueryExpressions.anyOf
@@ -11,9 +12,8 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.mappers.mapStakingTypeT
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import jp.co.soramitsu.fearless_utils.extensions.requireHexPrefix
-import jp.co.soramitsu.fearless_utils.runtime.AccountId
 
-class StakingStatsRequest(stakingAccounts: Map<StakingOptionId, AccountId?>, chains: List<Chain>) {
+class StakingStatsRequest(stakingAccounts: Map<StakingOptionId, AccountIdKey?>, chains: List<Chain>) {
 
     @Transient
     private val chainAddressesFilter = constructChainAddressesFilter(stakingAccounts, chains)
@@ -52,7 +52,7 @@ class StakingStatsRequest(stakingAccounts: Map<StakingOptionId, AccountId?>, cha
     """.trimIndent()
 
     private fun constructChainAddressesFilter(
-        stakingAccounts: Map<StakingOptionId, AccountId?>,
+        stakingAccounts: Map<StakingOptionId, AccountIdKey?>,
         chains: List<Chain>
     ): String = with(SubQueryFilters) {
         val perChain = chains.mapNotNull { chain ->
@@ -68,7 +68,7 @@ class StakingStatsRequest(stakingAccounts: Map<StakingOptionId, AccountId?>, cha
 
     private fun SubQueryFilters.Companion.hasTypeAndAddressOptions(
         chain: Chain,
-        stakingAccounts: Map<StakingOptionId, AccountId?>
+        stakingAccounts: Map<StakingOptionId, AccountIdKey?>
     ): List<String> {
         val utilityAsset = chain.utilityAsset
 
@@ -77,7 +77,7 @@ class StakingStatsRequest(stakingAccounts: Map<StakingOptionId, AccountId?>, cha
             val accountId = stakingAccounts[stakingOptionId] ?: return@mapNotNull null
             val stakingTypeString = mapStakingTypeToStakingString(stakingType) ?: return@mapNotNull null
 
-            hasAddress(chain.addressOf(accountId)) and hasStakingType(stakingTypeString)
+            hasAddress(chain.addressOf(accountId.value)) and hasStakingType(stakingTypeString)
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/StakingDashboardUpdateSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/StakingDashboardUpdateSystem.kt
@@ -63,7 +63,6 @@ class RealStakingDashboardUpdateSystem(
     override val syncedItemsFlow: MutableStateFlow<SyncingStageMap> = MutableStateFlow(emptyMap())
     private val latestOffChainSyncIndex: MutableStateFlow<Int> = MutableStateFlow(EMPTY_OFF_CHAIN_SYNC_INDEX)
 
-
     override fun start(): Flow<Updater.SideEffect> {
         return accountRepository.selectedMetaAccountFlow().flatMapLatest { metaAccount ->
             val accountScope = CoroutineScope(coroutineContext)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/StakingDashboardUpdateSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/StakingDashboardUpdateSystem.kt
@@ -1,6 +1,5 @@
 package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters
 
-import android.util.Log
 import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.address.intoKey
 import io.novafoundation.nova.common.utils.CollectionDiffer
@@ -129,7 +128,6 @@ class RealStakingDashboardUpdateSystem(
         val result = syncedItemsFlow.value.toMutableMap()
 
         changedPrimaryAccounts.forEach { (stakingOptionId, _) ->
-            Log.d("RX", "Marking syncing for ${stakingOptionId.chainId}")
             result[stakingOptionId] = result.getSyncingStage(stakingOptionId).coerceAtMost(SyncingStage.SYNCING_SECONDARY)
         }
 
@@ -166,10 +164,7 @@ class RealStakingDashboardUpdateSystem(
             is StakingDashboardUpdaterEvent.AllSynced -> {
                 // we only mark option as synced if there are no fresher syncs
                 if (event.indexOfUsedOffChainSync >= latestOffChainSyncIndex.value) {
-                    Log.d("RX", "Processing synced event for ${event.option.chainId}")
                     syncedItemsFlow.value = syncedItemsFlow.value.inserted(event.option, SyncingStage.SYNCED)
-                } else {
-                    Log.d("RX", "Ignoring outdated secondary synced event for ${event.option.chainId}")
                 }
             }
             is StakingDashboardUpdaterEvent.PrimarySynced -> {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/StakingDashboardUpdateSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/StakingDashboardUpdateSystem.kt
@@ -1,34 +1,54 @@
 package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters
 
+import android.util.Log
+import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.address.intoKey
+import io.novafoundation.nova.common.utils.CollectionDiffer
 import io.novafoundation.nova.common.utils.inserted
+import io.novafoundation.nova.common.utils.mapIndexed
+import io.novafoundation.nova.common.utils.zipWithPrevious
 import io.novafoundation.nova.core.updater.Updater
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.feature_account_api.domain.model.accountIdIn
 import io.novafoundation.nova.feature_staking_api.data.dashboard.StakingDashboardUpdateSystem
 import io.novafoundation.nova.feature_staking_api.data.dashboard.SyncingStageMap
+import io.novafoundation.nova.feature_staking_api.data.dashboard.getSyncingStage
+import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.AggregatedStakingDashboardOption.SyncingStage
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingOptionId
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.common.stakingChains
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardPrimaryAccount
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats.MultiChainStakingStats
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats.StakingAccounts
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats.StakingStatsDataSource
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.chain.StakingDashboardUpdaterEvent
-import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.chain.StakingDashboardUpdaterEvent.PrimaryStakingAccountResolved
-import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.chain.StakingDashboardUpdaterEvent.SyncingStageUpdated
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.chain.StakingDashboardUpdaterFactory
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.StakingDashboardRepository
 import io.novafoundation.nova.runtime.ethereum.StorageSharedRequestsBuilderFactory
-import io.novafoundation.nova.runtime.ethereum.subscribe
 import io.novafoundation.nova.runtime.ext.supportedStakingOptions
 import io.novafoundation.nova.runtime.ext.utilityAsset
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
-import jp.co.soramitsu.fearless_utils.runtime.AccountId
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.flow.withIndex
 import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+private const val EMPTY_OFF_CHAIN_SYNC_INDEX = -1
 
 class RealStakingDashboardUpdateSystem(
     private val stakingStatsDataSource: StakingStatsDataSource,
@@ -36,36 +56,38 @@ class RealStakingDashboardUpdateSystem(
     private val chainRegistry: ChainRegistry,
     private val updaterFactory: StakingDashboardUpdaterFactory,
     private val sharedRequestsBuilderFactory: StorageSharedRequestsBuilderFactory,
+    private val stakingDashboardRepository: StakingDashboardRepository,
+    private val offChainSyncDebounceRate: Duration = 2.seconds
 ) : StakingDashboardUpdateSystem {
 
     override val syncedItemsFlow: MutableStateFlow<SyncingStageMap> = MutableStateFlow(emptyMap())
+    private val latestOffChainSyncIndex: MutableStateFlow<Int> = MutableStateFlow(EMPTY_OFF_CHAIN_SYNC_INDEX)
 
-    private val resolvedPrimaryStakingAccountsFlow = MutableStateFlow(emptyMap<StakingOptionId, AccountId?>())
 
     override fun start(): Flow<Updater.SideEffect> {
         return accountRepository.selectedMetaAccountFlow().flatMapLatest { metaAccount ->
+            val accountScope = CoroutineScope(coroutineContext)
+
             syncedItemsFlow.emit(emptyMap())
-            resolvedPrimaryStakingAccountsFlow.emit(emptyMap())
+            latestOffChainSyncIndex.emit(EMPTY_OFF_CHAIN_SYNC_INDEX)
 
             val stakingChains = chainRegistry.stakingChains()
-            val supportedOptionsSize = stakingChains.sumOf { it.utilityAsset.supportedStakingOptions().size }
+            val stakingOptionsWithChain = stakingChains.associateWithStakingOptions()
 
-            val statsDeferred = CoroutineScope(coroutineContext).async {
-                val resolvedPrimaryStakingAccounts = resolvedPrimaryStakingAccountsFlow.awaitSize(supportedOptionsSize)
-                stakingStatsDataSource.fetchStakingStats(resolvedPrimaryStakingAccounts, stakingChains)
-            }
+            val offChainSyncFlow = debouncedOffChainSyncFlow(metaAccount, stakingOptionsWithChain, stakingChains)
+                .shareIn(accountScope, started = SharingStarted.Eagerly, replay = 1)
 
             val updateFlows = stakingChains.flatMap { stakingChain ->
                 val sharedRequestsBuilder = sharedRequestsBuilderFactory.create(stakingChain.id)
 
                 val chainUpdates = stakingChain.utilityAsset.supportedStakingOptions().mapNotNull { stakingType ->
-                    val updater = updaterFactory.createUpdater(stakingChain, stakingType, metaAccount, statsDeferred)
+                    val updater = updaterFactory.createUpdater(stakingChain, stakingType, metaAccount, offChainSyncFlow)
                         ?: return@mapNotNull null
 
                     updater.listenForUpdates(sharedRequestsBuilder)
                 }
 
-                sharedRequestsBuilder.subscribe(coroutineContext)
+                sharedRequestsBuilder.subscribe(accountScope)
 
                 chainUpdates
             }
@@ -76,22 +98,84 @@ class RealStakingDashboardUpdateSystem(
         }
             .onCompletion {
                 syncedItemsFlow.emit(emptyMap())
-                resolvedPrimaryStakingAccountsFlow.emit(emptyMap())
             }
+    }
+
+    private fun debouncedOffChainSyncFlow(
+        metaAccount: MetaAccount,
+        stakingOptionsWithChain: Map<StakingOptionId, Chain>,
+        stakingChains: List<Chain>
+    ): Flow<IndexedValue<MultiChainStakingStats>> {
+        return stakingDashboardRepository.stakingAccountsFlow(metaAccount.id)
+            .map { stakingPrimaryAccounts -> constructStakingAccounts(stakingOptionsWithChain, metaAccount, stakingPrimaryAccounts) }
+            .zipWithPrevious()
+            .transform { (previousAccounts, currentAccounts) ->
+                if (previousAccounts != null) {
+                    val diff = CollectionDiffer.findDiff(previousAccounts, currentAccounts, forceUseNewItems = false)
+                    if (diff.newOrUpdated.isNotEmpty()) {
+                        markSyncingSecondaryFor(diff.newOrUpdated)
+                        emit(currentAccounts)
+                    }
+                } else {
+                    emit(currentAccounts)
+                }
+            }
+            .withIndex()
+            .onEach { latestOffChainSyncIndex.value = it.index }
+            .debounce { (index) -> if (index == 0) 0.milliseconds else offChainSyncDebounceRate }
+            .mapIndexed { stakingAccounts -> stakingStatsDataSource.fetchStakingStats(stakingAccounts, stakingChains) }
+    }
+
+    private fun markSyncingSecondaryFor(changedPrimaryAccounts: List<Map.Entry<StakingOptionId, AccountIdKey?>>) {
+        val result = syncedItemsFlow.value.toMutableMap()
+
+        changedPrimaryAccounts.forEach { (stakingOptionId, _) ->
+            Log.d("RX", "Marking syncing for ${stakingOptionId.chainId}")
+            result[stakingOptionId] = result.getSyncingStage(stakingOptionId).coerceAtMost(SyncingStage.SYNCING_SECONDARY)
+        }
+
+        syncedItemsFlow.value = result
+    }
+
+    private fun List<Chain>.associateWithStakingOptions(): Map<StakingOptionId, Chain> {
+        return flatMap { chain ->
+            chain.assets.flatMap { asset ->
+                asset.supportedStakingOptions().map {
+                    StakingOptionId(chain.id, asset.id, it) to chain
+                }
+            }
+        }.toMap()
+    }
+
+    private fun constructStakingAccounts(
+        stakingOptionIds: Map<StakingOptionId, Chain>,
+        metaAccount: MetaAccount,
+        knownPrimaryAccounts: List<StakingDashboardPrimaryAccount>
+    ): StakingAccounts {
+        val knownPrimaryAccountsByOptionId = knownPrimaryAccounts.associateBy(StakingDashboardPrimaryAccount::stakingOptionId)
+
+        return stakingOptionIds.mapValues { (optionId, chain) ->
+            val accountId = knownPrimaryAccountsByOptionId[optionId]?.primaryStakingAccountId?.value
+                ?: metaAccount.accountIdIn(chain)
+
+            accountId?.intoKey()
+        }
     }
 
     private fun handleUpdaterEvent(event: StakingDashboardUpdaterEvent) {
         when (event) {
-            is PrimaryStakingAccountResolved -> {
-                resolvedPrimaryStakingAccountsFlow.value = resolvedPrimaryStakingAccountsFlow.value.inserted(event.option, event.primaryAccount)
+            is StakingDashboardUpdaterEvent.AllSynced -> {
+                // we only mark option as synced if there are no fresher syncs
+                if (event.indexOfUsedOffChainSync >= latestOffChainSyncIndex.value) {
+                    Log.d("RX", "Processing synced event for ${event.option.chainId}")
+                    syncedItemsFlow.value = syncedItemsFlow.value.inserted(event.option, SyncingStage.SYNCED)
+                } else {
+                    Log.d("RX", "Ignoring outdated secondary synced event for ${event.option.chainId}")
+                }
             }
-            is SyncingStageUpdated -> {
-                syncedItemsFlow.value = syncedItemsFlow.value.inserted(event.option, event.syncingStage)
+            is StakingDashboardUpdaterEvent.PrimarySynced -> {
+                syncedItemsFlow.value = syncedItemsFlow.value.inserted(event.option, SyncingStage.SYNCING_SECONDARY)
             }
         }
-    }
-
-    private suspend fun <K, V> Flow<Map<K, V>>.awaitSize(size: Int): Map<K, V> {
-        return first { it.size >= size }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/BaseStakingDashboardUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/BaseStakingDashboardUpdater.kt
@@ -3,7 +3,6 @@ package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updat
 import io.novafoundation.nova.core.updater.GlobalScopeUpdater
 import io.novafoundation.nova.core_db.model.StakingDashboardItemLocal
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
-import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.AggregatedStakingDashboardOption
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingOptionId
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.cache.StakingDashboardCache
 import io.novafoundation.nova.runtime.multiNetwork.chain.mappers.mapStakingTypeToStakingString
@@ -20,8 +19,12 @@ abstract class BaseStakingDashboardUpdater(
 
     override val requiredModules: List<String> = emptyList()
 
-    protected fun AggregatedStakingDashboardOption.SyncingStage.asUpdaterEvent(): StakingDashboardUpdaterEvent {
-        return StakingDashboardUpdaterEvent.SyncingStageUpdated(stakingOptionId(), this)
+    protected fun primarySynced(): StakingDashboardUpdaterEvent {
+        return StakingDashboardUpdaterEvent.PrimarySynced(stakingOptionId())
+    }
+
+    protected fun secondarySynced(indexOfUsedOffChainSync: Int): StakingDashboardUpdaterEvent {
+        return StakingDashboardUpdaterEvent.AllSynced(stakingOptionId(), indexOfUsedOffChainSync)
     }
 
     protected fun stakingOptionId(): StakingOptionId {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardRelayStakingUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardRelayStakingUpdater.kt
@@ -11,14 +11,12 @@ import io.novafoundation.nova.core_db.model.StakingDashboardItemLocal
 import io.novafoundation.nova.core_db.model.StakingDashboardItemLocal.Status
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.accountIdIn
-import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.AggregatedStakingDashboardOption.SyncingStage
 import io.novafoundation.nova.feature_staking_api.domain.model.EraIndex
 import io.novafoundation.nova.feature_staking_api.domain.model.Nominations
 import io.novafoundation.nova.feature_staking_api.domain.model.StakingLedger
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.cache.StakingDashboardCache
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats.ChainStakingStats
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.stats.MultiChainStakingStats
-import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.chain.StakingDashboardUpdaterEvent.PrimaryStakingAccountResolved
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.bindActiveEra
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.bindNominationsOrNull
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.bindStakingLedgerOrNull
@@ -29,9 +27,9 @@ import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novafoundation.nova.runtime.storage.source.query.metadata
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import jp.co.soramitsu.fearless_utils.runtime.metadata.storage
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -42,7 +40,7 @@ class StakingDashboardRelayStakingUpdater(
     chainAsset: Chain.Asset,
     stakingType: Chain.Asset.StakingType,
     metaAccount: MetaAccount,
-    private val stakingStatsAsync: Deferred<MultiChainStakingStats>,
+    private val stakingStatsFlow: Flow<IndexedValue<MultiChainStakingStats>>,
     private val stakingDashboardCache: StakingDashboardCache,
     private val remoteStorageSource: StorageDataSource
 ) : BaseStakingDashboardUpdater(chain, chainAsset, stakingType, metaAccount) {
@@ -67,19 +65,17 @@ class StakingDashboardRelayStakingUpdater(
 
             combineToPair(baseInfo, activeEraFlow)
         }.transformLatest { (relaychainStakingState, activeEra) ->
-            emit(PrimaryStakingAccountResolved(stakingOptionId(), relaychainStakingState?.stakingLedger?.stashId))
+            saveItem(relaychainStakingState, secondaryInfo = null)
+            emit(primarySynced())
 
-            if (stakingStatsAsync.isActive) {
-                // we only save base state if secondary is still loading, to avoid unnecessary writes to db
-                saveItem(relaychainStakingState, secondaryInfo = null)
-                emit(SyncingStage.SYNCING_SECONDARY.asUpdaterEvent())
+            val secondarySyncFlow = stakingStatsFlow.map {  (index, stakingStats) ->
+                val secondaryInfo = constructSecondaryInfo(relaychainStakingState, activeEra, stakingStats)
+                saveItem(relaychainStakingState, secondaryInfo)
+
+                secondarySynced(index)
             }
 
-            val stakingStats = stakingStatsAsync.await()
-            val secondaryInfo = constructSecondaryInfo(relaychainStakingState, activeEra, stakingStats)
-            saveItem(relaychainStakingState, secondaryInfo)
-
-            emit(SyncingStage.SYNCED.asUpdaterEvent())
+            emitAll(secondarySyncFlow)
         }
     }
 
@@ -116,7 +112,8 @@ class StakingDashboardRelayStakingUpdater(
                 stake = relaychainStakingBaseInfo.stakingLedger.active,
                 status = secondaryInfo?.status ?: fromCache?.status,
                 rewards = secondaryInfo?.rewards ?: fromCache?.rewards,
-                estimatedEarnings = secondaryInfo?.estimatedEarnings ?: fromCache?.estimatedEarnings
+                estimatedEarnings = secondaryInfo?.estimatedEarnings ?: fromCache?.estimatedEarnings,
+                primaryStakingAccountId = relaychainStakingBaseInfo.stakingLedger.stashId,
             )
         } else {
             StakingDashboardItemLocal.notStaking(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardRelayStakingUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardRelayStakingUpdater.kt
@@ -68,7 +68,7 @@ class StakingDashboardRelayStakingUpdater(
             saveItem(relaychainStakingState, secondaryInfo = null)
             emit(primarySynced())
 
-            val secondarySyncFlow = stakingStatsFlow.map {  (index, stakingStats) ->
+            val secondarySyncFlow = stakingStatsFlow.map { (index, stakingStats) ->
                 val secondaryInfo = constructSecondaryInfo(relaychainStakingState, activeEra, stakingStats)
                 saveItem(relaychainStakingState, secondaryInfo)
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardUpdaterFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardUpdaterFactory.kt
@@ -9,7 +9,7 @@ import io.novafoundation.nova.runtime.ext.group
 import io.novafoundation.nova.runtime.ext.utilityAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
-import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.Flow
 
 class StakingDashboardUpdaterFactory(
     private val stakingDashboardCache: StakingDashboardCache,
@@ -20,11 +20,11 @@ class StakingDashboardUpdaterFactory(
         chain: Chain,
         stakingType: Chain.Asset.StakingType,
         metaAccount: MetaAccount,
-        stakingStatsAsync: Deferred<MultiChainStakingStats>,
+        stakingStatsFlow: Flow<IndexedValue<MultiChainStakingStats>>,
     ): Updater? {
         return when (stakingType.group()) {
-            StakingTypeGroup.RELAYCHAIN -> relayChain(chain, stakingType, metaAccount, stakingStatsAsync)
-            StakingTypeGroup.PARACHAIN -> parachain(chain, stakingType, metaAccount, stakingStatsAsync)
+            StakingTypeGroup.RELAYCHAIN -> relayChain(chain, stakingType, metaAccount, stakingStatsFlow)
+            StakingTypeGroup.PARACHAIN -> parachain(chain, stakingType, metaAccount, stakingStatsFlow)
             StakingTypeGroup.UNSUPPORTED -> null
         }
     }
@@ -33,14 +33,14 @@ class StakingDashboardUpdaterFactory(
         chain: Chain,
         stakingType: Chain.Asset.StakingType,
         metaAccount: MetaAccount,
-        stakingStatsAsync: Deferred<MultiChainStakingStats>,
+        stakingStatsFlow: Flow<IndexedValue<MultiChainStakingStats>>,
     ): Updater {
         return StakingDashboardRelayStakingUpdater(
             chain = chain,
             chainAsset = chain.utilityAsset,
             stakingType = stakingType,
             metaAccount = metaAccount,
-            stakingStatsAsync = stakingStatsAsync,
+            stakingStatsFlow = stakingStatsFlow,
             stakingDashboardCache = stakingDashboardCache,
             remoteStorageSource = remoteStorageSource
         )
@@ -50,14 +50,14 @@ class StakingDashboardUpdaterFactory(
         chain: Chain,
         stakingType: Chain.Asset.StakingType,
         metaAccount: MetaAccount,
-        stakingStatsAsync: Deferred<MultiChainStakingStats>,
+        stakingStatsFlow: Flow<IndexedValue<MultiChainStakingStats>>,
     ): Updater {
         return StakingDashboardParachainStakingUpdater(
             chain = chain,
             chainAsset = chain.utilityAsset,
             stakingType = stakingType,
             metaAccount = metaAccount,
-            stakingStatsAsync = stakingStatsAsync,
+            stakingStatsFlow = stakingStatsFlow,
             stakingDashboardCache = stakingDashboardCache,
             remoteStorageSource = remoteStorageSource
         )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/SyncingStageUpdated.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/SyncingStageUpdated.kt
@@ -1,13 +1,11 @@
 package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.chain
 
 import io.novafoundation.nova.core.updater.Updater
-import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.AggregatedStakingDashboardOption.SyncingStage
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingOptionId
-import jp.co.soramitsu.fearless_utils.runtime.AccountId
 
 sealed class StakingDashboardUpdaterEvent : Updater.SideEffect {
 
-    class SyncingStageUpdated(val option: StakingOptionId, val syncingStage: SyncingStage) : StakingDashboardUpdaterEvent()
+    class AllSynced(val option: StakingOptionId, val indexOfUsedOffChainSync: Int): StakingDashboardUpdaterEvent()
 
-    class PrimaryStakingAccountResolved(val option: StakingOptionId, val primaryAccount: AccountId?) : StakingDashboardUpdaterEvent()
+    class PrimarySynced(val option: StakingOptionId) : StakingDashboardUpdaterEvent()
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/SyncingStageUpdated.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/SyncingStageUpdated.kt
@@ -5,7 +5,7 @@ import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.Staking
 
 sealed class StakingDashboardUpdaterEvent : Updater.SideEffect {
 
-    class AllSynced(val option: StakingOptionId, val indexOfUsedOffChainSync: Int): StakingDashboardUpdaterEvent()
+    class AllSynced(val option: StakingOptionId, val indexOfUsedOffChainSync: Int) : StakingDashboardUpdaterEvent()
 
     class PrimarySynced(val option: StakingOptionId) : StakingDashboardUpdaterEvent()
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/repository/StakingDashboardRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/repository/StakingDashboardRepository.kt
@@ -1,14 +1,18 @@
 package io.novafoundation.nova.feature_staking_impl.data.dashboard.repository
 
+import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.domain.ExtendedLoadingState
 import io.novafoundation.nova.common.domain.fromOption
 import io.novafoundation.nova.common.utils.asPercent
 import io.novafoundation.nova.common.utils.mapList
 import io.novafoundation.nova.core_db.dao.StakingDashboardDao
 import io.novafoundation.nova.core_db.model.StakingDashboardItemLocal
+import io.novafoundation.nova.core_db.model.StakingDashboardPrimaryAccountView
+import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingOptionId
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardItem
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardItem.StakeState.HasStake
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardItem.StakeState.NoStake
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardPrimaryAccount
 import io.novafoundation.nova.runtime.multiNetwork.chain.mappers.mapStakingStringToStakingType
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import kotlinx.coroutines.flow.Flow
@@ -16,6 +20,8 @@ import kotlinx.coroutines.flow.Flow
 interface StakingDashboardRepository {
 
     fun dashboardItemsFlow(metaAccountId: Long): Flow<List<StakingDashboardItem>>
+
+    fun stakingAccountsFlow(metaAccountId: Long): Flow<List<StakingDashboardPrimaryAccount>>
 }
 
 class RealStakingDashboardRepository(
@@ -26,6 +32,10 @@ class RealStakingDashboardRepository(
         return dao.dashboardItemsFlow(metaAccountId).mapList(::mapDashboardItemFromLocal)
     }
 
+    override fun stakingAccountsFlow(metaAccountId: Long): Flow<List<StakingDashboardPrimaryAccount>> {
+        return dao.stakingAccountsViewFlow(metaAccountId).mapList(::mapStakingAccountViewFromLocal)
+    }
+
     private fun mapDashboardItemFromLocal(localItem: StakingDashboardItemLocal): StakingDashboardItem {
         return StakingDashboardItem(
             fullChainAssetId = FullChainAssetId(
@@ -34,6 +44,17 @@ class RealStakingDashboardRepository(
             ),
             stakingType = mapStakingStringToStakingType(localItem.stakingType),
             stakeState = if (localItem.hasStake) hasStakeState(localItem) else noStakeState(localItem)
+        )
+    }
+
+    private fun mapStakingAccountViewFromLocal(localItem: StakingDashboardPrimaryAccountView): StakingDashboardPrimaryAccount {
+        return StakingDashboardPrimaryAccount(
+            stakingOptionId = StakingOptionId(
+                chainId = localItem.chainId,
+                chainAssetId = localItem.chainAssetId,
+                stakingType = mapStakingStringToStakingType(localItem.stakingType),
+            ),
+            primaryStakingAccountId = localItem.primaryStakingAccountId?.let(::AccountIdKey)
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/dashboard/StakingDashboardModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/dashboard/StakingDashboardModule.kt
@@ -63,12 +63,14 @@ class StakingDashboardModule {
         chainRegistry: ChainRegistry,
         updaterFactory: StakingDashboardUpdaterFactory,
         sharedRequestsBuilderFactory: StorageSharedRequestsBuilderFactory,
+        stakingDashboardRepository: StakingDashboardRepository,
     ): StakingDashboardUpdateSystem = RealStakingDashboardUpdateSystem(
         stakingStatsDataSource = stakingStatsDataSource,
         accountRepository = accountRepository,
         chainRegistry = chainRegistry,
         updaterFactory = updaterFactory,
-        sharedRequestsBuilderFactory = sharedRequestsBuilderFactory
+        sharedRequestsBuilderFactory = sharedRequestsBuilderFactory,
+        stakingDashboardRepository = stakingDashboardRepository
     )
 
     @Provides

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/common/list/DashboardNoStakeAdapter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/common/list/DashboardNoStakeAdapter.kt
@@ -33,6 +33,7 @@ class DashboardNoStakeAdapter(
             when (it) {
                 NoStakeItem::earnings -> holder.bindEarnings(item)
                 NoStakeItem::availableBalance -> holder.bindAvailableBalance(item)
+                NoStakeItem::chainUi -> holder.bindChainUi(item)
             }
         }
     }
@@ -50,7 +51,10 @@ class DashboardNoStakeViewHolder(
     fun bind(model: NoStakeItem) {
         bindEarnings(model)
         bindAvailableBalance(model)
+        bindChainUi(model)
+    }
 
+    fun bindChainUi(model: NoStakeItem) {
         containerView.setChainUi(model.chainUi)
     }
 
@@ -69,7 +73,7 @@ class DashboardNoStakeViewHolder(
 
 private class DashboardNoStakeDiffCallback : DiffUtil.ItemCallback<NoStakeItem>() {
 
-    private val payloadGenerator = PayloadGenerator(NoStakeItem::earnings, NoStakeItem::availableBalance)
+    private val payloadGenerator = PayloadGenerator(NoStakeItem::earnings, NoStakeItem::availableBalance, NoStakeItem::chainUi)
 
     override fun areItemsTheSame(oldItem: NoStakeItem, newItem: NoStakeItem): Boolean {
         return oldItem.chainUi.data.id == newItem.chainUi.data.id && oldItem.assetId == newItem.assetId


### PR DESCRIPTION
### Main idea

* We don't wait until all controller accounts are resolved from on-chain to fetch off-chain info
* Instead, we optimistically sync using known controllers, fallback to accountId of wallet
* We observe synced controller accounts. If we see a change, we schedule an off-chain sync in 2 seconds. We also mark the corresponding staking option as SYNCING_SECONDARY
* Individual chain updaters observe off-chain sync results and update corresponding db entries once new information is available

Given the flow above, we have the following scenarios:
1. No controller present (optimistic case) - only single offchain sync will be made immediately, without waiting for on-chain syncs
2. 1+ controller present - additional sync(s) will be made every two seconds. Realistically, since on-chain data loads nearly at the same time for all networks, only single additional sync will be made at most of the times
