### PR TITLE
Fix - long network names overlap rest of no stake item content

### DIFF
--- a/feature-staking-impl/src/main/res/layout/item_dashboard_no_stake.xml
+++ b/feature-staking-impl/src/main/res/layout/item_dashboard_no_stake.xml
@@ -39,6 +39,8 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="16dp"
+            android:ellipsize="end"
+            android:singleLine="true"
             tools:text="Polkadot" />
 
     </com.facebook.shimmer.ShimmerFrameLayout>
@@ -133,5 +135,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="left"
-        app:constraint_referenced_ids="itemDashboardNoStakeEarnings,itemDashboardNoStakeEarningsShimmer, itemDashboardNoStakeEarningsSuffix, itemDashboardNoStakeEarningsSuffixShimmer" />
+        app:constraint_referenced_ids="itemDashboardNoStakeEarningsContainer, itemDashboardNoStakeEarningsSuffixContainer" />
 </merge>


### PR DESCRIPTION
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/d8770774-b9dd-4361-b421-951beedddb9d)
