### PR TITLE
Integrate nomination pool staking type and prepare for multiple staking types per asset

### DIFF
--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/StakingSharedState.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/StakingSharedState.kt
@@ -7,6 +7,8 @@ import io.novafoundation.nova.runtime.state.SelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.SelectedAssetOptionSharedState.SupportedAssetOption
 import kotlinx.coroutines.flow.Flow
 
+typealias StakingOption = SupportedAssetOption<StakingSharedState.OptionAdditionalData>
+
 class StakingSharedState : SelectedAssetOptionSharedState<StakingSharedState.OptionAdditionalData> {
 
     class OptionAdditionalData(val stakingType: Chain.Asset.StakingType)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardUpdaterFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardUpdaterFactory.kt
@@ -25,6 +25,7 @@ class StakingDashboardUpdaterFactory(
         return when (stakingType.group()) {
             StakingTypeGroup.RELAYCHAIN -> relayChain(chain, stakingType, metaAccount, stakingStatsFlow)
             StakingTypeGroup.PARACHAIN -> parachain(chain, stakingType, metaAccount, stakingStatsFlow)
+            StakingTypeGroup.NOMINATION_POOL -> null // TODO nomination pools
             StakingTypeGroup.UNSUPPORTED -> null
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/StakingUpdateSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/StakingUpdateSystem.kt
@@ -26,7 +26,7 @@ class StakingUpdateSystem(
 
     override fun getUpdaters(selectedAssetOption: StakingOption): List<Updater> {
         return commonUpdaters + when (selectedAssetOption.additional.stakingType) {
-            UNSUPPORTED-> emptyList()
+            UNSUPPORTED -> emptyList()
             RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO -> relaychainUpdaters
             PARACHAIN -> parachainUpdaters
             TURING -> parachainUpdaters + turingExtraUpdaters

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/StakingUpdateSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/StakingUpdateSystem.kt
@@ -1,17 +1,18 @@
 package io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters
 
 import io.novafoundation.nova.core.updater.Updater
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.runtime.ethereum.StorageSharedRequestsBuilderFactory
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.ALEPH_ZERO
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.UNSUPPORTED
 import io.novafoundation.nova.runtime.network.updaters.SingleChainUpdateSystem
-import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 
 class StakingUpdateSystem(
     private val relaychainUpdaters: List<Updater>,
@@ -19,17 +20,17 @@ class StakingUpdateSystem(
     private val commonUpdaters: List<Updater>,
     private val turingExtraUpdaters: List<Updater>,
     chainRegistry: ChainRegistry,
-    singleAssetSharedState: AnySelectedAssetOptionSharedState,
+    singleAssetSharedState: StakingSharedState,
     storageSharedRequestsBuilderFactory: StorageSharedRequestsBuilderFactory,
-) : SingleChainUpdateSystem(chainRegistry, singleAssetSharedState, storageSharedRequestsBuilderFactory) {
+) : SingleChainUpdateSystem<StakingSharedState.OptionAdditionalData>(chainRegistry, singleAssetSharedState, storageSharedRequestsBuilderFactory) {
 
-    override fun getUpdaters(chain: Chain, chainAsset: Chain.Asset): List<Updater> {
-        // TODO staking dashboard - switch by selected staking option
-        return commonUpdaters + when (chainAsset.staking.firstOrNull()) {
-            UNSUPPORTED, null -> emptyList()
+    override fun getUpdaters(selectedAssetOption: StakingOption): List<Updater> {
+        return commonUpdaters + when (selectedAssetOption.additional.stakingType) {
+            UNSUPPORTED-> emptyList()
             RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO -> relaychainUpdaters
             PARACHAIN -> parachainUpdaters
             TURING -> parachainUpdaters + turingExtraUpdaters
+            NOMINATION_POOLS -> emptyList() // TODO nomination pools
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/consensus/ElectionsSessionRegistry.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/consensus/ElectionsSessionRegistry.kt
@@ -1,16 +1,16 @@
 package io.novafoundation.nova.feature_staking_impl.data.repository.consensus
 
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
+import io.novafoundation.nova.feature_staking_impl.domain.nominationPools.findStakingTypeBackingNominationPools
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.ALEPH_ZERO
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.UNSUPPORTED
 
 interface ElectionsSessionRegistry {
 
-    fun electionsSessionFor(chainAsset: Chain.Asset): ElectionsSession
+    fun electionsSessionFor(stakingOption: StakingOption): ElectionsSession
 }
 
 class RealElectionsSessionRegistry(
@@ -18,12 +18,22 @@ class RealElectionsSessionRegistry(
     private val auraSession: AuraSession
 ) : ElectionsSessionRegistry {
 
-    override fun electionsSessionFor(chainAsset: Chain.Asset): ElectionsSession {
-        return when (chainAsset.staking.firstOrNull()) {
-            // TODO staking dashboard - switch by selected staking option
+    override fun electionsSessionFor(stakingOption: StakingOption): ElectionsSession {
+        return when (val stakingType = stakingOption.additional.stakingType) {
+            NOMINATION_POOLS -> {
+                val backingStakingType = stakingOption.assetWithChain.asset.findStakingTypeBackingNominationPools()
+                electionsFor(backingStakingType)
+            }
+
+            else -> electionsFor(stakingType)
+        }
+    }
+
+    private fun electionsFor(stakingType: Chain.Asset.StakingType): ElectionsSession {
+        return when (stakingType) {
             RELAYCHAIN -> babeSession
             RELAYCHAIN_AURA, ALEPH_ZERO -> auraSession
-            null, UNSUPPORTED, PARACHAIN, TURING -> throw IllegalArgumentException("Unsupported staking type in RealStakingSessionRegistry")
+            else -> throw IllegalArgumentException("Unsupported staking type in RealStakingSessionRegistry")
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/unbond/StakingUnbondModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/unbond/StakingUnbondModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_staking_api.domain.api.StakingRepository
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.domain.common.EraTimeCalculatorFactory
 import io.novafoundation.nova.feature_staking_impl.domain.staking.unbond.UnbondInteractor
 import io.novafoundation.nova.feature_staking_impl.presentation.common.hints.StakingHintsUseCase
@@ -19,7 +20,8 @@ class StakingUnbondModule {
         extrinsicService: ExtrinsicService,
         stakingRepository: StakingRepository,
         eraTimeCalculatorFactory: EraTimeCalculatorFactory,
-    ) = UnbondInteractor(extrinsicService, stakingRepository, eraTimeCalculatorFactory)
+        stakingSharedState: StakingSharedState
+    ) = UnbondInteractor(extrinsicService, stakingRepository, eraTimeCalculatorFactory, stakingSharedState)
 
     @Provides
     @FeatureScope

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/StakingInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/StakingInteractor.kt
@@ -44,6 +44,7 @@ import io.novafoundation.nova.runtime.state.assetWithChain
 import io.novafoundation.nova.runtime.state.chain
 import io.novafoundation.nova.runtime.state.chainAndAsset
 import io.novafoundation.nova.runtime.state.chainAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import jp.co.soramitsu.fearless_utils.extensions.toHexString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -256,7 +257,7 @@ class StakingInteractor(
     }
 
     private suspend fun getEraTimeCalculator(): EraTimeCalculator {
-        return factory.create(stakingSharedState.chainAsset())
+        return factory.create(stakingSharedState.selectedOption())
     }
 
     private fun remainingEras(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/EraCalculatorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/EraCalculatorFactory.kt
@@ -2,9 +2,9 @@ package io.novafoundation.nova.feature_staking_impl.domain.common
 
 import io.novafoundation.nova.feature_staking_api.domain.api.StakingRepository
 import io.novafoundation.nova.feature_staking_api.domain.model.EraIndex
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.repository.SessionRepository
 import io.novafoundation.nova.feature_staking_impl.data.repository.consensus.ElectionsSessionRegistry
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import java.math.BigInteger
 import kotlin.time.Duration
@@ -64,9 +64,9 @@ class EraTimeCalculatorFactory(
     private val electionsSessionRegistry: ElectionsSessionRegistry,
 ) {
 
-    suspend fun create(chainAsset: Chain.Asset): EraTimeCalculator {
-        val chainId = chainAsset.chainId
-        val electionsSession = electionsSessionRegistry.electionsSessionFor(chainAsset)
+    suspend fun create(stakingOption: StakingOption): EraTimeCalculator {
+        val chainId = stakingOption.assetWithChain.asset.chainId
+        val electionsSession = electionsSessionRegistry.electionsSessionFor(stakingOption)
 
         val activeEra = stakingRepository.getActiveEraIndex(chainId)
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/StakingSharedComputation.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/StakingSharedComputation.kt
@@ -9,6 +9,7 @@ import io.novafoundation.nova.feature_staking_api.domain.api.StakingRepository
 import io.novafoundation.nova.feature_staking_api.domain.model.EraIndex
 import io.novafoundation.nova.feature_staking_api.domain.model.Exposure
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.repository.BagListRepository
 import io.novafoundation.nova.feature_staking_impl.data.repository.bagListLocatorOrNull
 import io.novafoundation.nova.feature_staking_impl.domain.bagList.BagListScoreConverter
@@ -17,7 +18,6 @@ import io.novafoundation.nova.feature_staking_impl.domain.rewards.RewardCalculat
 import io.novafoundation.nova.feature_staking_impl.domain.rewards.RewardCalculatorFactory
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.repository.TotalIssuanceRepository
 import kotlinx.coroutines.CoroutineScope
@@ -94,13 +94,15 @@ class StakingSharedComputation(
     }
 
     suspend fun rewardCalculator(
-        chainAsset: Chain.Asset,
+        stakingOption: StakingOption,
         scope: CoroutineScope
     ): RewardCalculator {
-        val key = "REWARD_CALCULATOR:${chainAsset.chainId}:${chainAsset.id}"
+        val chainAsset = stakingOption.assetWithChain.asset
+
+        val key = "REWARD_CALCULATOR:${chainAsset.chainId}:${chainAsset.id}:${stakingOption.additional.stakingType}"
 
         return computationalCache.useCache(key, scope) {
-            rewardCalculatorFactory.create(chainAsset, scope)
+            rewardCalculatorFactory.create(stakingOption, scope)
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/dashboard/RealStakingDashboardInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/dashboard/RealStakingDashboardInteractor.kt
@@ -445,6 +445,7 @@ class RealStakingDashboardInteractor(
         return when (stakingType.group()) {
             StakingTypeGroup.RELAYCHAIN -> freeInPlanks
             StakingTypeGroup.PARACHAIN -> freeInPlanks
+            StakingTypeGroup.NOMINATION_POOL -> transferableInPlanks
             StakingTypeGroup.UNSUPPORTED -> Balance.ZERO
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/ChainExt.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/ChainExt.kt
@@ -1,0 +1,7 @@
+package io.novafoundation.nova.feature_staking_impl.domain.nominationPools
+
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+
+fun Chain.Asset.findStakingTypeBackingNominationPools(): Chain.Asset.StakingType {
+    return staking.first { it != Chain.Asset.StakingType.NOMINATION_POOLS }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/common/CollatorsUseCase.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/common/CollatorsUseCase.kt
@@ -3,14 +3,14 @@ package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.comm
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.AddressModel
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.ParachainStakingConstantsRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.systemForcedMinStake
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.model.Collator
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.model.SelectedCollator
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.common.collators.collatorAddressModel
-import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
-import io.novafoundation.nova.runtime.state.chainAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import jp.co.soramitsu.fearless_utils.extensions.toHexString
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import kotlinx.coroutines.Dispatchers
@@ -38,37 +38,39 @@ interface CollatorsUseCase {
 }
 
 class RealCollatorsUseCase(
-    private val singleAssetSharedState: AnySelectedAssetOptionSharedState,
+    private val stakingSharedState: StakingSharedState,
     private val parachainStakingConstantsRepository: ParachainStakingConstantsRepository,
     private val collatorProvider: CollatorProvider,
     private val addressIconGenerator: AddressIconGenerator,
 ) : CollatorsUseCase {
 
     override suspend fun maxRewardedDelegatorsPerCollator(): Int {
-        val chainId = singleAssetSharedState.chainId()
+        val chainId = stakingSharedState.chainId()
 
         return parachainStakingConstantsRepository.maxRewardedDelegatorsPerCollator(chainId).toInt()
     }
 
     override suspend fun defaultMinimumStake(): BigInteger {
-        return parachainStakingConstantsRepository.systemForcedMinStake(singleAssetSharedState.chainId())
+        return parachainStakingConstantsRepository.systemForcedMinStake(stakingSharedState.chainId())
     }
 
     override suspend fun collatorAddressModel(collator: Collator): AddressModel {
         return addressIconGenerator.collatorAddressModel(
             collator = collator,
-            chain = singleAssetSharedState.chain()
+            chain = stakingSharedState.chain()
         )
     }
 
     override suspend fun getCollator(collatorId: AccountId): Collator = withContext(Dispatchers.IO) {
-        collatorProvider.getCollator(singleAssetSharedState.chainAsset(), collatorId)
+        collatorProvider.getCollator(stakingSharedState.selectedOption(), collatorId)
     }
 
     override suspend fun getSelectedCollators(
         delegatorState: DelegatorState,
         sorting: SelectedCollatorSorting
     ): List<SelectedCollator> {
+        val stakingOption = stakingSharedState.selectedOption()
+
         return when (delegatorState) {
             is DelegatorState.Delegator -> {
                 val delegationAmountByCollator = delegatorState.delegations.associateBy(
@@ -79,7 +81,7 @@ class RealCollatorsUseCase(
 
                 val collatorSource = CollatorProvider.CollatorSource.Custom(stakedCollatorsIds)
 
-                collatorProvider.getCollators(delegatorState.chainAsset, collatorSource)
+                collatorProvider.getCollators(stakingOption, collatorSource)
                     .map { collator ->
                         SelectedCollator(
                             collator = collator,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/common/recommendations/CollatorRecommendator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/common/recommendations/CollatorRecommendator.kt
@@ -1,10 +1,10 @@
 package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.recommendations
 
 import io.novafoundation.nova.common.data.memory.ComputationalCache
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.CollatorProvider
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.CollatorProvider.CollatorSource
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.model.Collator
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import kotlinx.coroutines.CoroutineScope
 
 class CollatorRecommendator(private val allCollators: List<Collator>) {
@@ -21,8 +21,8 @@ class CollatorRecommendatorFactory(
     private val computationalCache: ComputationalCache
 ) {
 
-    suspend fun create(chainAsset: Chain.Asset, scope: CoroutineScope) = computationalCache.useCache(COLLATORS_CACHE, scope) {
-        val collators = collatorProvider.getCollators(chainAsset, CollatorSource.Elected)
+    suspend fun create(stakingOption: StakingOption, scope: CoroutineScope) = computationalCache.useCache(COLLATORS_CACHE, scope) {
+        val collators = collatorProvider.getCollators(stakingOption, CollatorSource.Elected)
 
         CollatorRecommendator(collators)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/recommendations/ValidatorRecommendatorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/recommendations/ValidatorRecommendatorFactory.kt
@@ -5,7 +5,7 @@ import io.novafoundation.nova.feature_staking_api.domain.model.Validator
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.domain.validators.ValidatorProvider
 import io.novafoundation.nova.feature_staking_impl.domain.validators.ValidatorSource
-import io.novafoundation.nova.runtime.state.chainAndAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -23,9 +23,9 @@ class ValidatorRecommendatorFactory(
     }
 
     private suspend fun loadValidators(scope: CoroutineScope) = computationalCache.useCache(ELECTED_VALIDATORS_CACHE, scope) {
-        val (chain, chainAsset) = sharedState.chainAndAsset()
+        val stakingOption = sharedState.selectedOption()
 
-        validatorProvider.getValidators(chain, chainAsset, ValidatorSource.Elected, scope)
+        validatorProvider.getValidators(stakingOption, ValidatorSource.Elected, scope)
     }
 
     suspend fun create(scope: CoroutineScope): ValidatorRecommendator = withContext(Dispatchers.IO) {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validators/current/CurrentValidatorsInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validators/current/CurrentValidatorsInteractor.kt
@@ -18,7 +18,7 @@ import io.novafoundation.nova.feature_staking_impl.domain.validations.controller
 import io.novafoundation.nova.feature_staking_impl.domain.validations.controller.controllerAccountAccess
 import io.novafoundation.nova.feature_staking_impl.domain.validators.ValidatorProvider
 import io.novafoundation.nova.feature_staking_impl.domain.validators.ValidatorSource
-import io.novafoundation.nova.runtime.state.chainAndAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import jp.co.soramitsu.fearless_utils.extensions.toHexString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -43,7 +43,8 @@ class CurrentValidatorsInteractor(
             return flowOf(emptyGroupedList())
         }
 
-        val (chain, chainAsset) = stakingSharedState.chainAndAsset()
+        val stakingOption = stakingSharedState.selectedOption()
+        val chain = stakingOption.assetWithChain.chain
         val chainId = chain.id
 
         return stakingRepository.observeActiveEraIndex(chainId).map { activeEra ->
@@ -62,8 +63,7 @@ class CurrentValidatorsInteractor(
             val maxRewardedNominators = stakingConstantsRepository.maxRewardedNominatorPerValidator(chainId)
 
             val groupedByStatusClass = validatorProvider.getValidators(
-                chain = chain,
-                chainAsset = chainAsset,
+                stakingOption = stakingOption,
                 source = ValidatorSource.Custom(nominatedValidatorIds.toList()),
                 scope = scope
             )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/collator/current/di/CurrentCollatorsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/collator/current/di/CurrentCollatorsModule.kt
@@ -31,9 +31,11 @@ class CurrentCollatorsModule {
     fun provideInteractor(
         currentRoundRepository: CurrentRoundRepository,
         collatorProvider: CollatorProvider,
+        stakingSharedState: StakingSharedState,
     ): CurrentCollatorInteractor = RealCurrentCollatorInteractor(
         currentRoundRepository = currentRoundRepository,
-        collatorProvider = collatorProvider
+        collatorProvider = collatorProvider,
+        stakingSharedState = stakingSharedState
     )
 
     @Provides

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/collator/search/SearchCollatorViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/collator/search/SearchCollatorViewModel.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.invoke
 import io.novafoundation.nova.common.utils.lazyAsync
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.collator.search.SearchCollatorsInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.CollatorsUseCase
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.model.Collator
@@ -23,9 +24,8 @@ import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.change.StakeTargetModel
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.details.StakeTargetDetailsPayload
 import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
-import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
-import io.novafoundation.nova.runtime.state.chainAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.mapLatest
@@ -39,7 +39,7 @@ class SearchCollatorViewModel(
     private val addressIconGenerator: AddressIconGenerator,
     private val selectCollatorInterScreenResponder: SelectCollatorInterScreenResponder,
     private val collatorRecommendatorFactory: CollatorRecommendatorFactory,
-    private val singleAssetSharedState: AnySelectedAssetOptionSharedState,
+    private val singleAssetSharedState: StakingSharedState,
     private val collatorsUseCase: CollatorsUseCase,
     resourceManager: ResourceManager,
     tokenUseCase: TokenUseCase,
@@ -49,9 +49,9 @@ class SearchCollatorViewModel(
         .share()
 
     private val electedCollators by lazyAsync {
-        val chainAsset = singleAssetSharedState.chainAsset()
+        val stakingOption = singleAssetSharedState.selectedOption()
 
-        collatorRecommendatorFactory.create(chainAsset, scope = viewModelScope)
+        collatorRecommendatorFactory.create(stakingOption, scope = viewModelScope)
             .recommendations(CollatorRecommendationConfig.DEFAULT)
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/collator/select/SelectCollatorViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/collator/select/SelectCollatorViewModel.kt
@@ -8,6 +8,7 @@ import io.novafoundation.nova.common.utils.inBackground
 import io.novafoundation.nova.common.utils.invoke
 import io.novafoundation.nova.common.utils.lazyAsync
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.CollatorsUseCase
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.model.Collator
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.recommendations.CollatorRecommendationConfig
@@ -28,9 +29,8 @@ import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.details.StakeTargetDetailsPayload
 import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.Token
-import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
-import io.novafoundation.nova.runtime.state.chainAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -50,11 +50,11 @@ class SelectCollatorViewModel(
     private val addressIconGenerator: AddressIconGenerator,
     private val resourceManager: ResourceManager,
     private val tokenUseCase: TokenUseCase,
-    private val selectedAssetState: AnySelectedAssetOptionSharedState,
+    private val selectedAssetState: StakingSharedState,
 ) : BaseViewModel() {
 
     private val collatorRecommendator by lazyAsync {
-        collatorRecommendatorFactory.create(selectedAssetState.chainAsset(), scope = viewModelScope)
+        collatorRecommendatorFactory.create(selectedAssetState.selectedOption(), scope = viewModelScope)
     }
 
     private val recommendationConfigFlow = MutableStateFlow(defaultConfig())

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/start/setup/rewards/RealParachainStakingRewardsComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/start/setup/rewards/RealParachainStakingRewardsComponent.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.invoke
 import io.novafoundation.nova.common.utils.lazyAsync
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.rewards.ParachainStakingRewardCalculatorFactory
 import io.novafoundation.nova.feature_staking_impl.presentation.mappers.RewardSuffix
 import io.novafoundation.nova.feature_staking_impl.presentation.mappers.mapPeriodReturnsToRewardEstimation
@@ -12,8 +13,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.start.setup.rewards.ParachainStakingRewardsComponent.RewardsConfiguration
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.start.setup.rewards.ParachainStakingRewardsComponent.State
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
-import io.novafoundation.nova.runtime.state.chainAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,7 +23,7 @@ import java.math.BigDecimal
 
 class RealParachainStakingRewardsComponentFactory(
     private val rewardCalculatorFactory: ParachainStakingRewardCalculatorFactory,
-    private val singleAssetSharedState: AnySelectedAssetOptionSharedState,
+    private val singleAssetSharedState: StakingSharedState,
     private val resourceManager: ResourceManager,
 ) {
 
@@ -41,14 +41,14 @@ class RealParachainStakingRewardsComponentFactory(
 
 private class RealParachainStakingRewardsComponent(
     private val rewardCalculatorFactory: ParachainStakingRewardCalculatorFactory,
-    private val singleAssetSharedState: AnySelectedAssetOptionSharedState,
+    private val singleAssetSharedState: StakingSharedState,
     private val resourceManager: ResourceManager,
     private val parentScope: CoroutineScope,
     private val assetFlow: Flow<Asset>,
 ) : ParachainStakingRewardsComponent, CoroutineScope by parentScope {
 
     private val rewardCalculator by lazyAsync {
-        rewardCalculatorFactory.create(singleAssetSharedState.chainAsset())
+        rewardCalculatorFactory.create(singleAssetSharedState.selectedOption())
     }
 
     override val events = MutableLiveData<Event<Nothing>>()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/setup/SetupStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/setup/SetupStakingViewModel.kt
@@ -13,6 +13,7 @@ import io.novafoundation.nova.common.validation.ValidationSystem
 import io.novafoundation.nova.common.validation.progressConsumer
 import io.novafoundation.nova.feature_staking_api.domain.model.RewardDestination
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.data.mappers.mapRewardDestinationModelToRewardDestination
 import io.novafoundation.nova.feature_staking_impl.domain.StakingInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
@@ -29,8 +30,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.common.validatio
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
-import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
-import io.novafoundation.nova.runtime.state.chainAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -47,7 +47,7 @@ class SetupStakingViewModel(
     private val validationExecutor: ValidationExecutor,
     private val feeLoaderMixin: FeeLoaderMixin.Presentation,
     private val rewardDestinationMixin: RewardDestinationMixin.Presentation,
-    private val selectedAssetSharedState: AnySelectedAssetOptionSharedState,
+    private val selectedAssetSharedState: StakingSharedState,
     private val stakingSharedComputation: StakingSharedComputation,
     amountChooserMixinFactory: AmountChooserMixin.Factory,
 ) : BaseViewModel(),
@@ -66,7 +66,7 @@ class SetupStakingViewModel(
 
     private val rewardCalculator = viewModelScope.async {
         stakingSharedComputation.rewardCalculator(
-            chainAsset = selectedAssetSharedState.chainAsset(),
+            stakingOption = selectedAssetSharedState.selectedOption(),
             scope = viewModelScope
         )
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/CompoundStatefullComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/CompoundStatefullComponent.kt
@@ -5,15 +5,15 @@ import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.WithCoroutineScopeExtensions
 import io.novafoundation.nova.common.utils.switchMap
 import io.novafoundation.nova.common.utils.withItemScope
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.ALEPH_ZERO
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.UNSUPPORTED
-import io.novafoundation.nova.runtime.state.SelectedAssetOptionSharedState
-import io.novafoundation.nova.runtime.state.assetWithChain
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -21,10 +21,10 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
-typealias ComponentCreator<S, E, A> = (ChainWithAsset, hostContext: ComponentHostContext) -> StatefullComponent<S, E, A>
+typealias ComponentCreator<S, E, A> = (StakingOption, hostContext: ComponentHostContext) -> StatefullComponent<S, E, A>
 
 class CompoundStakingComponentFactory(
-    private val singleAssetSharedState: SelectedAssetOptionSharedState<*>,
+    private val stakingSharedState: StakingSharedState,
 ) {
 
     fun <S, E, A> create(
@@ -36,13 +36,13 @@ class CompoundStakingComponentFactory(
         relaychainComponentCreator = relaychainComponentCreator,
         parachainComponentCreator = parachainComponentCreator,
         turingComponentCreator = turingComponentCreator,
-        singleAssetSharedState = singleAssetSharedState,
+        singleAssetSharedState = stakingSharedState,
         hostContext = hostContext
     )
 }
 
 private class CompoundStakingComponent<S, E, A>(
-    singleAssetSharedState: SelectedAssetOptionSharedState<*>,
+    singleAssetSharedState: StakingSharedState,
 
     private val relaychainComponentCreator: ComponentCreator<S, E, A>,
     private val parachainComponentCreator: ComponentCreator<S, E, A>,
@@ -50,11 +50,11 @@ private class CompoundStakingComponent<S, E, A>(
     private val hostContext: ComponentHostContext,
 ) : StatefullComponent<S, E, A>, CoroutineScope by hostContext.scope, WithCoroutineScopeExtensions by WithCoroutineScopeExtensions(hostContext.scope) {
 
-    private val delegateFlow = singleAssetSharedState.assetWithChain
+    private val delegateFlow = singleAssetSharedState.selectedOption
         .withItemScope(parentScope = hostContext.scope)
-        .map { (chainWithAsset, itemScope) ->
+        .map { (stakingOption, itemScope) ->
             val childHostContext = hostContext.copy(scope = itemScope)
-            createDelegate(chainWithAsset, childHostContext)
+            createDelegate(stakingOption, childHostContext)
         }.shareInBackground()
 
     override val events: LiveData<Event<E>> = delegateFlow
@@ -71,13 +71,14 @@ private class CompoundStakingComponent<S, E, A>(
         }
     }
 
-    private fun createDelegate(assetWithChain: ChainWithAsset, childHostContext: ComponentHostContext): StatefullComponent<S, E, A> {
-        // TODO staking dashboard - switch by selected staking option
-        return when (assetWithChain.asset.staking.firstOrNull()) {
-            null, UNSUPPORTED -> UnsupportedComponent()
-            RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO -> relaychainComponentCreator(assetWithChain, childHostContext)
-            PARACHAIN -> parachainComponentCreator(assetWithChain, childHostContext)
-            TURING -> turingComponentCreator(assetWithChain, childHostContext)
+    private fun createDelegate(stakingOption: StakingOption, childHostContext: ComponentHostContext): StatefullComponent<S, E, A> {
+        return when (stakingOption.additional.stakingType) {
+            UNSUPPORTED -> UnsupportedComponent()
+            RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO -> relaychainComponentCreator(stakingOption, childHostContext)
+            PARACHAIN -> parachainComponentCreator(stakingOption, childHostContext)
+            TURING -> turingComponentCreator(stakingOption, childHostContext)
+            // TODO nomination pools
+            NOMINATION_POOLS -> UnsupportedComponent()
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/alerts/parachain/ParachainAlertsComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/alerts/parachain/ParachainAlertsComponent.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.WithCoroutineScopeExtensions
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.DelegatorStateUseCase
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.alerts.ParachainStakingAlert
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.alerts.ParachainStakingAlertsInteractor
@@ -18,7 +19,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.common.parachainStaking.loadDelegatingState
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -32,13 +32,13 @@ class ParachainAlertsComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext,
     ): AlertsComponent = ParachainAlertsComponent(
         delegatorStateUseCase = delegatorStateUseCase,
         interactor = interactor,
         resourceManager = resourceManager,
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext,
         router = router
     )
@@ -49,7 +49,7 @@ private class ParachainAlertsComponent(
     private val interactor: ParachainStakingAlertsInteractor,
     private val resourceManager: ResourceManager,
 
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
     private val hostContext: ComponentHostContext,
     private val router: ParachainStakingRouter
 ) : AlertsComponent,
@@ -60,7 +60,7 @@ private class ParachainAlertsComponent(
 
     override val state = delegatorStateUseCase.loadDelegatingState(
         hostContext = hostContext,
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         stateProducer = ::stateFor
     )
         .shareInBackground()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/alerts/relaychain/RelaychainAlertsComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/alerts/relaychain/RelaychainAlertsComponent.kt
@@ -9,6 +9,7 @@ import io.novafoundation.nova.common.utils.withLoading
 import io.novafoundation.nova.feature_currency_api.presentation.formatters.formatAsCurrency
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.alerts.Alert
 import io.novafoundation.nova.feature_staking_impl.domain.alerts.Alert.ChangeValidators.Reason
 import io.novafoundation.nova.feature_staking_impl.domain.alerts.AlertsInteractor
@@ -25,7 +26,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.mainStakingValidationFailure
 import io.novafoundation.nova.feature_wallet_api.domain.model.Token
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -45,7 +45,7 @@ class RelaychainAlertsComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext,
     ): AlertsComponent = RelaychainAlertsComponent(
         stakingSharedComputation = stakingSharedComputation,
@@ -54,8 +54,7 @@ class RelaychainAlertsComponentFactory(
         redeemValidationSystem = redeemValidationSystem,
         bondMoreValidationSystem = bondMoreValidationSystem,
         router = router,
-
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext
     )
 }
@@ -66,7 +65,7 @@ private class RelaychainAlertsComponent(
     private val stakingSharedComputation: StakingSharedComputation,
 
     private val hostContext: ComponentHostContext,
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
 
     private val redeemValidationSystem: StakeActionsValidationSystem,
     private val bondMoreValidationSystem: StakeActionsValidationSystem,
@@ -76,7 +75,7 @@ private class RelaychainAlertsComponent(
     WithCoroutineScopeExtensions by WithCoroutineScopeExtensions(hostContext.scope) {
 
     private val selectedAccountStakingStateFlow = stakingSharedComputation.selectedAccountStakingStateFlow(
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         scope = hostContext.scope
     )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/networkInfo/parachain/ParachainNetworkInfoComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/networkInfo/parachain/ParachainNetworkInfoComponent.kt
@@ -6,13 +6,13 @@ import io.novafoundation.nova.common.utils.LOG_TAG
 import io.novafoundation.nova.common.utils.inBackground
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.DelegatorStateUseCase
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.ParachainNetworkInfoInteractor
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.ComponentHostContext
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.networkInfo.BaseNetworkInfoComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.networkInfo.NetworkInfoComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.networkInfo.NetworkInfoItem
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -27,13 +27,13 @@ class ParachainNetworkInfoComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext
     ): NetworkInfoComponent = ParachainNetworkInfoComponent(
         interactor = interactor,
         delegatorStateUseCase = delegatorStateUseCase,
         resourceManager = resourceManager,
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext
     )
 }
@@ -46,11 +46,11 @@ private class ParachainNetworkInfoComponent(
     resourceManager: ResourceManager,
 
     private val hostContext: ComponentHostContext,
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
 ) : BaseNetworkInfoComponent(resourceManager, hostContext.scope) {
 
     private val delegatorStateFlow = hostContext.selectedAccount.flatMapLatest {
-        delegatorStateUseCase.delegatorStateFlow(it, assetWithChain.chain, assetWithChain.asset)
+        delegatorStateUseCase.delegatorStateFlow(it, stakingOption.assetWithChain.chain, stakingOption.assetWithChain.asset)
     }.shareInBackground()
 
     init {
@@ -77,7 +77,7 @@ private class ParachainNetworkInfoComponent(
     private fun updateContentState() {
         combine(
             hostContext.assetFlow,
-            interactor.observeNetworkInfo(assetWithChain.chain.id)
+            interactor.observeNetworkInfo(stakingOption.assetWithChain.chain.id)
         ) { asset, networkInfo ->
             val items = createNetworkInfoItems(asset, networkInfo, nominatorsLabel = NOMINATORS_TITLE_RES)
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/networkInfo/relaychain/RelaychainNetworkInfoComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/networkInfo/relaychain/RelaychainNetworkInfoComponent.kt
@@ -6,13 +6,13 @@ import io.novafoundation.nova.common.utils.LOG_TAG
 import io.novafoundation.nova.common.utils.inBackground
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.StakingInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.ComponentHostContext
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.networkInfo.BaseNetworkInfoComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.networkInfo.NetworkInfoComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.networkInfo.NetworkInfoItem
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -26,12 +26,12 @@ class RelaychainNetworkInfoComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext
     ): NetworkInfoComponent = RelaychainNetworkInfoComponent(
         stakingInteractor = stakingInteractor,
         resourceManager = resourceManager,
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext,
         stakingSharedComputation = stakingSharedComputation
     )
@@ -45,11 +45,11 @@ private class RelaychainNetworkInfoComponent(
     resourceManager: ResourceManager,
 
     private val hostContext: ComponentHostContext,
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
 ) : BaseNetworkInfoComponent(resourceManager, hostContext.scope) {
 
     private val selectedAccountStakingStateFlow = stakingSharedComputation.selectedAccountStakingStateFlow(
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         scope = hostContext.scope
     )
 
@@ -77,7 +77,7 @@ private class RelaychainNetworkInfoComponent(
     private fun updateContentState() {
         combine(
             hostContext.assetFlow,
-            stakingInteractor.observeNetworkInfoState(assetWithChain.chain.id, hostContext.scope)
+            stakingInteractor.observeNetworkInfoState(stakingOption.assetWithChain.chain.id, hostContext.scope)
         ) { asset, networkInfo ->
             val items = createNetworkInfoItems(asset, networkInfo, nominatorsLabel = NOMINATORS_TITLE_RES)
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeActions/parachain/ParachainStakeActionsComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeActions/parachain/ParachainStakeActionsComponent.kt
@@ -10,6 +10,7 @@ import io.novafoundation.nova.common.utils.formatting.format
 import io.novafoundation.nova.common.validation.ValidationExecutor
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.DelegatorStateUseCase
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.unbond.validations.preliminary.ParachainStakingUnbondPreliminaryValidationPayload
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.unbond.validations.preliminary.ParachainStakingUnbondPreliminaryValidationSystem
@@ -27,7 +28,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeActions.StakeActionsState
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeActions.bondMore
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeActions.unbond
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -42,12 +42,12 @@ class ParachainStakeActionsComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext
     ): StakeActionsComponent = ParachainStakeActionsComponent(
         delegatorStateUseCase = delegatorStateUseCase,
         resourceManager = resourceManager,
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext,
         router = router,
         validationExecutor = validationExecutor,
@@ -60,7 +60,7 @@ internal open class ParachainStakeActionsComponent(
     private val resourceManager: ResourceManager,
     private val router: ParachainStakingRouter,
 
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
     private val hostContext: ComponentHostContext,
 
     private val unbondValidationSystem: ParachainStakingUnbondPreliminaryValidationSystem,
@@ -73,7 +73,7 @@ internal open class ParachainStakeActionsComponent(
 
     override val state = delegatorStateUseCase.loadDelegatingState(
         hostContext = hostContext,
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         stateProducer = ::stateFor
     )
         .map { it?.dataOrNull } // we don't need loading state in this component

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeActions/parachain/turing/TuringStakeActionsComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeActions/parachain/turing/TuringStakeActionsComponent.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.common.validation.ValidationExecutor
 import io.novafoundation.nova.feature_staking_api.data.parachainStaking.turing.repository.TuringAutomationTasksRepository
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.DelegatorStateUseCase
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.unbond.validations.preliminary.ParachainStakingUnbondPreliminaryValidationSystem
 import io.novafoundation.nova.feature_staking_impl.presentation.ParachainStakingRouter
@@ -15,7 +16,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeActions.StakeActionsComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeActions.StakeActionsState
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeActions.parachain.ParachainStakeActionsComponent
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
@@ -33,12 +33,12 @@ class TuringStakeActionsComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext
     ): StakeActionsComponent = TuringStakeActionsComponent(
         delegatorStateUseCase = delegatorStateUseCase,
         resourceManager = resourceManager,
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext,
         router = router,
         validationExecutor = validationExecutor,
@@ -51,7 +51,7 @@ private class TuringStakeActionsComponent(
     delegatorStateUseCase: DelegatorStateUseCase,
     private val resourceManager: ResourceManager,
     private val router: ParachainStakingRouter,
-    assetWithChain: ChainWithAsset,
+    stakingOption: StakingOption,
     private val hostContext: ComponentHostContext,
     unbondValidationSystem: ParachainStakingUnbondPreliminaryValidationSystem,
     validationExecutor: ValidationExecutor,
@@ -60,7 +60,7 @@ private class TuringStakeActionsComponent(
     delegatorStateUseCase = delegatorStateUseCase,
     resourceManager = resourceManager,
     router = router,
-    assetWithChain = assetWithChain,
+    stakingOption = stakingOption,
     hostContext = hostContext,
     unbondValidationSystem = unbondValidationSystem,
     validationExecutor = validationExecutor

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeActions/relaychain/RelaychainStakeActionsComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeActions/relaychain/RelaychainStakeActionsComponent.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.WithCoroutineScopeExtensions
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.validations.main.SYSTEM_MANAGE_CONTROLLER
 import io.novafoundation.nova.feature_staking_impl.domain.validations.main.SYSTEM_MANAGE_PAYOUTS
@@ -28,7 +29,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeActions.unbond
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeActions.validators
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.mainStakingValidationFailure
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
@@ -43,14 +43,14 @@ class RelaychainStakeActionsComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext
     ): StakeActionsComponent = RelaychainStakeActionsComponent(
         stakingSharedComputation = stakingSharedComputation,
         resourceManager = resourceManager,
         router = router,
         stakeActionsValidations = stakeActionsValidations,
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext
     )
 }
@@ -62,7 +62,7 @@ private class RelaychainStakeActionsComponent(
     private val stakeActionsValidations: Map<String, StakeActionsValidationSystem>,
 
     private val hostContext: ComponentHostContext,
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
 ) : StakeActionsComponent,
     CoroutineScope by hostContext.scope,
     WithCoroutineScopeExtensions by WithCoroutineScopeExtensions(hostContext.scope) {
@@ -70,7 +70,7 @@ private class RelaychainStakeActionsComponent(
     override val events = MutableLiveData<Event<StakeActionsEvent>>()
 
     private val selectedAccountStakingStateFlow = stakingSharedComputation.selectedAccountStakingStateFlow(
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         scope = hostContext.scope
     )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeSummary/parachain/ParachainStakeSummaryComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeSummary/parachain/ParachainStakeSummaryComponent.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.activeBonded
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.DelegatorStateUseCase
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.stakeSummary.DelegatorStatus
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.stakeSummary.ParachainStakingStakeSummaryInteractor
@@ -15,7 +16,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeSummary.StakeSummaryModel
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeSummary.StakeSummaryState
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapLatest
@@ -28,11 +28,11 @@ class ParachainStakeSummaryComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext,
     ): StakeSummaryComponent = ParachainStakeSummaryComponent(
         resourceManager = resourceManager,
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext,
         delegatorStateUseCase = delegatorStateUseCase,
         interactor = interactor
@@ -45,13 +45,13 @@ private class ParachainStakeSummaryComponent(
     private val interactor: ParachainStakingStakeSummaryInteractor,
     private val resourceManager: ResourceManager,
 
-    assetWithChain: ChainWithAsset,
+    stakingOption: StakingOption,
     private val hostContext: ComponentHostContext,
 ) : BaseStakeSummaryComponent(hostContext.scope) {
 
     override val state: Flow<StakeSummaryState?> = delegatorStateUseCase.loadDelegatingState(
         hostContext = hostContext,
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         stateProducer = ::delegatorSummaryStateFlow
     )
         .shareInBackground()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeSummary/relaychain/RelaychainStakeSummaryComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/stakeSummary/relaychain/RelaychainStakeSummaryComponent.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.withLoading
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.StakingInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.model.NominatorStatus
@@ -19,7 +20,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeSummary.StakeSummaryModel
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.stakeSummary.StakeSummaryState
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
@@ -33,12 +33,12 @@ class RelaychainStakeSummaryComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext
     ): StakeSummaryComponent = RelaychainStakeSummaryComponent(
         stakingInteractor = stakingInteractor,
         resourceManager = resourceManager,
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext,
         stakingSharedComputation = stakingSharedComputation,
     )
@@ -47,13 +47,13 @@ class RelaychainStakeSummaryComponentFactory(
 private class RelaychainStakeSummaryComponent(
     private val stakingInteractor: StakingInteractor,
     private val stakingSharedComputation: StakingSharedComputation,
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
     private val hostContext: ComponentHostContext,
     private val resourceManager: ResourceManager,
 ) : BaseStakeSummaryComponent(hostContext.scope) {
 
     private val selectedAccountStakingStateFlow = stakingSharedComputation.selectedAccountStakingStateFlow(
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         scope = hostContext.scope
     )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/startStaking/BaseStartStakingState.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/startStaking/BaseStartStakingState.kt
@@ -10,8 +10,8 @@ import io.novafoundation.nova.common.utils.flowOf
 import io.novafoundation.nova.common.utils.formatting.formatFractionAsPercentage
 import io.novafoundation.nova.common.utils.withLoading
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.ComponentHostContext
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -28,7 +28,7 @@ private const val PERIOD_MONTH = 30
 private const val PERIOD_YEAR = 365
 
 abstract class BaseStartStakingComponent(
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
     private val hostContext: ComponentHostContext,
     private val resourceManager: ResourceManager,
 ) : StartStakingComponent,
@@ -84,7 +84,7 @@ abstract class BaseStartStakingComponent(
     }
 
     private fun estimateEarningsTitle(): String {
-        val assetSymbol = assetWithChain.asset.symbol
+        val assetSymbol = stakingOption.assetWithChain.asset.symbol
 
         return resourceManager.getString(R.string.staking_estimate_earning_title_v2_2_0, assetSymbol)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/unbonding/parachain/ParachainUnbondingComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/unbonding/parachain/ParachainUnbondingComponent.kt
@@ -10,6 +10,7 @@ import io.novafoundation.nova.common.utils.withFlagSet
 import io.novafoundation.nova.feature_account_api.presenatation.account.icon.createAccountAddressModel
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.DelegatorStateUseCase
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.unbondings.DelegationRequestWithCollatorInfo
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.unbondings.ParachainStakingUnbondingsInteractor
@@ -27,8 +28,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.unbonding.UnbondingState
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.unbonding.from
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
-
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -47,10 +46,10 @@ class ParachainUnbondingComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext,
     ): UnbondingComponent = ParachainUnbondingComponent(
-        assetWithChain = assetWithChain,
+        stakingOption = stakingOption,
         hostContext = hostContext,
         delegatorStateUseCase = delegatorStateUseCase,
         interactor = interactor,
@@ -66,7 +65,7 @@ private class ParachainUnbondingComponent(
     private val addressIconGenerator: AddressIconGenerator,
     private val resourceManager: ResourceManager,
 
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
     private val hostContext: ComponentHostContext,
     private val router: ParachainStakingRouter
 ) : UnbondingComponent,
@@ -77,7 +76,7 @@ private class ParachainUnbondingComponent(
 
     override val state = delegatorStateUseCase.loadDelegatingState(
         hostContext = hostContext,
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         stateProducer = ::delegatorSummaryStateFlow
     )
         .shareInBackground()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/unbonding/relaychain/RelaychainUnbondingComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/unbonding/relaychain/RelaychainUnbondingComponent.kt
@@ -11,6 +11,7 @@ import io.novafoundation.nova.common.utils.withLoading
 import io.novafoundation.nova.common.validation.ValidationExecutor
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.model.Unbonding
 import io.novafoundation.nova.feature_staking_impl.domain.staking.unbond.UnbondInteractor
@@ -28,7 +29,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.mainStakingValidationFailure
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.rebond.confirm.ConfirmRebondPayload
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
@@ -55,7 +55,7 @@ class RelaychainUnbondingComponentFactory(
 ) {
 
     fun create(
-        assetWithChain: ChainWithAsset,
+        stakingOption: StakingOption,
         hostContext: ComponentHostContext,
     ): UnbondingComponent = RelaychainUnbondingComponent(
         unbondInteractor = unbondInteractor,
@@ -66,7 +66,7 @@ class RelaychainUnbondingComponentFactory(
         router = router,
         hostContext = hostContext,
         stakingSharedComputation = stakingSharedComputation,
-        assetWithChain = assetWithChain
+        stakingOption = stakingOption
     )
 }
 
@@ -79,7 +79,7 @@ private class RelaychainUnbondingComponent(
     private val router: StakingRouter,
     private val resourceManager: ResourceManager,
 
-    private val assetWithChain: ChainWithAsset,
+    private val stakingOption: StakingOption,
     private val hostContext: ComponentHostContext,
 ) : UnbondingComponent,
     CoroutineScope by hostContext.scope,
@@ -88,7 +88,7 @@ private class RelaychainUnbondingComponent(
     override val events = MutableLiveData<Event<UnbondingEvent>>()
 
     private val selectedAccountStakingStateFlow = stakingSharedComputation.selectedAccountStakingStateFlow(
-        assetWithChain = assetWithChain,
+        assetWithChain = stakingOption.assetWithChain,
         scope = hostContext.scope
     )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/userRewards/relaychain/RelaychainUserRewardsComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/userRewards/relaychain/RelaychainUserRewardsComponent.kt
@@ -15,7 +15,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.userRewards.UserRewardsState
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AmountModel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/rewardDestination/select/SelectRewardDestinationViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/rewardDestination/select/SelectRewardDestinationViewModel.kt
@@ -12,6 +12,7 @@ import io.novafoundation.nova.common.validation.ValidationExecutor
 import io.novafoundation.nova.common.validation.progressConsumer
 import io.novafoundation.nova.feature_staking_api.domain.model.RewardDestination
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.data.mappers.mapRewardDestinationModelToRewardDestination
 import io.novafoundation.nova.feature_staking_impl.domain.StakingInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
@@ -24,8 +25,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.common.rewardDes
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.rewardDestination.confirm.parcel.ConfirmRewardDestinationPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.rewardDestination.confirm.parcel.RewardDestinationParcelModel
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
-import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
-import io.novafoundation.nova.runtime.state.chainAsset
+import io.novafoundation.nova.runtime.state.selectedOption
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
@@ -46,7 +46,7 @@ class SelectRewardDestinationViewModel(
     private val validationExecutor: ValidationExecutor,
     private val feeLoaderMixin: FeeLoaderMixin.Presentation,
     private val rewardDestinationMixin: RewardDestinationMixin.Presentation,
-    private val selectedAssetSharedState: AnySelectedAssetOptionSharedState,
+    private val selectedAssetSharedState: StakingSharedState,
     private val stakingSharedComputation: StakingSharedComputation,
 ) : BaseViewModel(),
     Retriable,
@@ -59,7 +59,7 @@ class SelectRewardDestinationViewModel(
 
     private val rewardCalculator = viewModelScope.async {
         stakingSharedComputation.rewardCalculator(
-            chainAsset = selectedAssetSharedState.chainAsset(),
+            stakingOption = selectedAssetSharedState.selectedOption(),
             scope = viewModelScope
         )
     }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
@@ -9,6 +9,7 @@ import io.novafoundation.nova.common.utils.formatNamed
 import io.novafoundation.nova.common.utils.substrateAccountId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.ALEPH_ZERO
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
@@ -57,7 +58,7 @@ fun Chain.Asset.supportedStakingOptions(): List<Chain.Asset.StakingType> {
 
 enum class StakingTypeGroup {
 
-    RELAYCHAIN, PARACHAIN, UNSUPPORTED
+    RELAYCHAIN, PARACHAIN, NOMINATION_POOL, UNSUPPORTED
 }
 
 fun Chain.Asset.StakingType.group(): StakingTypeGroup {
@@ -65,6 +66,7 @@ fun Chain.Asset.StakingType.group(): StakingTypeGroup {
         UNSUPPORTED -> StakingTypeGroup.UNSUPPORTED
         RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO -> StakingTypeGroup.RELAYCHAIN
         PARACHAIN, TURING -> StakingTypeGroup.PARACHAIN
+        NOMINATION_POOLS -> StakingTypeGroup.NOMINATION_POOL
     }
 }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
@@ -169,6 +169,7 @@ fun mapStakingStringToStakingType(stakingString: String?): Chain.Asset.StakingTy
         null -> Chain.Asset.StakingType.UNSUPPORTED
         "relaychain" -> Chain.Asset.StakingType.RELAYCHAIN
         "parachain" -> Chain.Asset.StakingType.PARACHAIN
+        "nomination-pools" -> Chain.Asset.StakingType.NOMINATION_POOLS
         "aura-relaychain" -> Chain.Asset.StakingType.RELAYCHAIN_AURA
         "turing" -> Chain.Asset.StakingType.TURING
         "aleph-zero" -> Chain.Asset.StakingType.ALEPH_ZERO
@@ -184,6 +185,7 @@ fun mapStakingTypeToStakingString(stakingType: Chain.Asset.StakingType): String?
         Chain.Asset.StakingType.RELAYCHAIN_AURA -> "aura-relaychain"
         Chain.Asset.StakingType.TURING -> "turing"
         Chain.Asset.StakingType.ALEPH_ZERO -> "aleph-zero"
+        Chain.Asset.StakingType.NOMINATION_POOLS -> "nomination-pools"
     }
 }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
@@ -98,7 +98,8 @@ data class Chain(
         enum class StakingType {
             UNSUPPORTED,
             RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO, // relaychain like
-            PARACHAIN, TURING // parachain-staking like
+            PARACHAIN, TURING, // parachain-staking like
+            NOMINATION_POOLS
         }
 
         override val identifier = "$chainId:$id"

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/state/SelectedAssetOptionSharedState.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/state/SelectedAssetOptionSharedState.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.map
 
 typealias AnySelectedAssetOptionSharedState = SelectedAssetOptionSharedState<*>
 
-interface SelectedAssetOptionSharedState<A> : ChainIdHolder {
+interface SelectedAssetOptionSharedState<out A> : ChainIdHolder {
 
     val selectedOption: Flow<SupportedAssetOption<A>>
 


### PR DESCRIPTION
This PR is focused around two things:
1. Add new staking type for nomination pools
2. Propretly use stakingOption inside staking flow instead of just selecting first available staking type of an asset