### PR TITLE
Limit dashboard update frequency

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/FlowExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/FlowExt.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -43,6 +45,7 @@ import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.launch
 import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
 
 inline fun <T, R> Flow<List<T>>.mapList(crossinline mapper: suspend (T) -> R) = map { list ->
     list.map { item -> mapper(item) }
@@ -499,3 +502,25 @@ suspend inline fun <reified T> Flow<T?>.firstNotNull(): T = first { it != null }
 inline fun <T, R> Flow<IndexedValue<T>>.mapLatestIndexed(crossinline transform: suspend (T) -> R): Flow<IndexedValue<R>> {
     return mapLatest { IndexedValue(it.index, transform(it.value)) }
 }
+
+/**
+ * Emits first element from upstream and then emits last element emitted by upstream during specified time window
+ *
+ * ```
+ * flow {
+ *  for (num in 1..15) {
+ *      emit(num)
+ *      delay(25)
+ *  }
+ * }.throttleLast(100)
+ *  .onEach { println(it) }
+ *  .collect()  // Prints 1, 5, 9, 13, 15
+ *
+ * ```
+ */
+fun <T> Flow<T>.throttleLast(delay: Duration): Flow<T> = this
+    .conflate()
+    .transform {
+        emit(it)
+        delay(delay)
+    }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.firstLoaded
 import io.novafoundation.nova.common.utils.formatting.format
 import io.novafoundation.nova.common.utils.inBackground
+import io.novafoundation.nova.common.utils.throttleLast
 import io.novafoundation.nova.feature_account_api.data.mappers.mapChainToUi
 import io.novafoundation.nova.feature_account_api.domain.interfaces.SelectedAccountUseCase
 import io.novafoundation.nova.feature_staking_api.data.dashboard.StakingDashboardUpdateSystem
@@ -28,6 +29,8 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 class StakingDashboardViewModel(
     private val interactor: StakingDashboardInteractor,
@@ -37,6 +40,7 @@ class StakingDashboardViewModel(
     private val router: StakingRouter,
     private val stakingSharedState: StakingSharedState,
     private val presentationMapper: StakingDashboardPresentationMapper,
+    private val dashboardUpdatePeriod: Duration = 200.milliseconds
 ) : BaseViewModel() {
 
     val walletUi = accountUseCase.selectedWalletModelFlow()
@@ -46,6 +50,7 @@ class StakingDashboardViewModel(
         .shareInBackground()
 
     val stakingDashboardUiFlow = stakingDashboardFlow
+        .throttleLast(dashboardUpdatePeriod)
         .map { dashboardLoading -> dashboardLoading.map(::mapDashboardToUi) }
         .shareInBackground()
 


### PR DESCRIPTION
Each state arrival triggers UI state construction, diffing with previous state e.t.c.
Given that new state emiited each time any item state updates, we want to limit frequency of dashboard updates for optimizations as well as to minize glitches related to submitting updated state
