### PR TITLE
Fix - mismatch between presets and same custom period

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -13,6 +13,7 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.MathContext
 import java.util.Collections
+import java.util.Date
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
@@ -85,8 +86,6 @@ fun BigInteger.divideToDecimal(divisor: BigInteger, mathContext: MathContext = M
 fun BigInteger.atLeastZero() = coerceAtLeast(BigInteger.ZERO)
 
 fun Long.daysFromMillis() = TimeUnit.MILLISECONDS.toDays(this)
-
-fun Number.daysToMillis() = TimeUnit.DAYS.toMillis(this.toLong())
 
 inline fun <T> Collection<T>.sumByBigInteger(extractor: (T) -> BigInteger) = fold(BigInteger.ZERO) { acc, element ->
     acc + extractor(element)
@@ -337,3 +336,11 @@ inline fun CoroutineScope.withChildScope(action: CoroutineScope.() -> Unit) {
 }
 
 fun <T> List<T>.associateWithIndex() = withIndex().associateBy(keySelector = { it.value }, valueTransform = { it.index })
+
+fun Date.atTheBeginningOfTheDay(): Date {
+    return Date(time).apply {
+        hours = 0
+        minutes = 0
+        seconds = 0
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/datasource/SubqueryStakingRewardsDataSource.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/datasource/SubqueryStakingRewardsDataSource.kt
@@ -12,7 +12,6 @@ import io.novafoundation.nova.feature_staking_impl.domain.model.TotalReward
 import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriod
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
-import java.util.Date
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
@@ -30,8 +29,8 @@ class SubqueryStakingRewardsDataSource(
 
     override suspend fun sync(accountAddress: String, chain: Chain, chainAsset: Chain.Asset, rewardPeriod: RewardPeriod) {
         val stakingExternalApi = chain.stakingExternalApi() ?: return
-        val start = rewardPeriod.getStartDate()?.timestamp()
-        val end = rewardPeriod.getEndDate()?.timestamp()
+        val start = rewardPeriod.start?.timestamp()
+        val end = rewardPeriod.end?.timestamp()
 
         val response = stakingApi.getRewardsByPeriod(
             url = stakingExternalApi.url,
@@ -47,17 +46,5 @@ class SubqueryStakingRewardsDataSource(
         )
 
         stakingTotalRewardDao.insert(totalRewardLocal)
-    }
-
-    private fun RewardPeriod.getStartDate(): Date? {
-        if (this is RewardPeriod.OffsetFromCurrent) {
-            return Date(System.currentTimeMillis() - this.offsetMillis)
-        }
-
-        return start
-    }
-
-    private fun RewardPeriod.getEndDate(): Date? {
-        return end
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/period/RewardPeriod.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/period/RewardPeriod.kt
@@ -1,63 +1,82 @@
 package io.novafoundation.nova.feature_staking_impl.domain.period
 
-import io.novafoundation.nova.common.utils.daysToMillis
+import io.novafoundation.nova.common.utils.atTheBeginningOfTheDay
 import java.util.Date
-import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
 
 sealed interface RewardPeriod {
+
     val type: RewardPeriodType
+
     val start: Date?
+
     val end: Date?
 
     data class OffsetFromCurrent(
-        val offsetMillis: Long,
-        override val type: RewardPeriodType
+        val offset: Duration,
+        override val type: RewardPeriodType.Preset
     ) : RewardPeriod {
-        override val start: Date? = null
+
+        override val start: Date
+            get() = Date(System.currentTimeMillis() - offset.inWholeMilliseconds).atTheBeginningOfTheDay()
+
         override val end: Date? = null
     }
 
     data class CustomRange(override val start: Date, override val end: Date?) : RewardPeriod {
-        override val type = RewardPeriodType.CUSTOM
+        override val type = RewardPeriodType.Custom
     }
 
     object AllTime : RewardPeriod {
-        override val type = RewardPeriodType.ALL_TIME
+        override val type = RewardPeriodType.AllTime
+
         override val start: Date? = null
         override val end: Date? = null
     }
 
     companion object {
-        fun getOffsetByType(type: RewardPeriodType): Long {
-            return when (type) {
-                RewardPeriodType.WEEK -> 7.daysToMillis()
-                RewardPeriodType.MONTH -> 30.daysToMillis()
-                RewardPeriodType.QUARTER -> 90.daysToMillis()
-                RewardPeriodType.HALF_YEAR -> 180.daysToMillis()
-                RewardPeriodType.YEAR -> 365.daysToMillis()
-                else -> -1
+        fun getPresetOffset(type: RewardPeriodType.Preset): Duration {
+            val numberOfDays = when (type) {
+                RewardPeriodType.Preset.WEEK -> 7
+                RewardPeriodType.Preset.MONTH -> 30
+                RewardPeriodType.Preset.QUARTER -> 90
+                RewardPeriodType.Preset.HALF_YEAR -> 180
+                RewardPeriodType.Preset.YEAR -> 365
             }
+
+            return numberOfDays.days
         }
     }
 }
 
-enum class RewardPeriodType {
-    ALL_TIME,
-    WEEK,
-    MONTH,
-    QUARTER,
-    HALF_YEAR,
-    YEAR,
-    CUSTOM
+sealed interface RewardPeriodType {
+
+    object AllTime : RewardPeriodType
+
+    enum class Preset : RewardPeriodType {
+        WEEK,
+        MONTH,
+        QUARTER,
+        HALF_YEAR,
+        YEAR
+    }
+
+    object Custom : RewardPeriodType
 }
 
 fun RewardPeriod.getPeriodDays(): Long {
     return when (this) {
-        is RewardPeriod.OffsetFromCurrent -> TimeUnit.MILLISECONDS.toDays(offsetMillis)
+        is RewardPeriod.OffsetFromCurrent -> offset.inWholeDays
+
         is RewardPeriod.CustomRange -> {
             val endTime = end ?: Date()
-            TimeUnit.MILLISECONDS.toDays(endTime.time - start.time)
+            val durationMillis = endTime.time - start.time
+
+            durationMillis.milliseconds.inWholeDays
         }
+
         else -> -1
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/period/RewardPeriodMapping.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/period/RewardPeriodMapping.kt
@@ -3,23 +3,18 @@ package io.novafoundation.nova.feature_staking_impl.presentation.period
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriod
-import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriodType.ALL_TIME
-import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriodType.WEEK
-import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriodType.MONTH
-import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriodType.QUARTER
-import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriodType.HALF_YEAR
-import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriodType.YEAR
+import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriodType
 import io.novafoundation.nova.feature_staking_impl.domain.period.getPeriodDays
 
 fun mapRewardPeriodToString(resourceManager: ResourceManager, rewardPeriod: RewardPeriod): String {
     return when (rewardPeriod.type) {
-        ALL_TIME -> resourceManager.getString(R.string.staking_period_all_short)
-        WEEK -> resourceManager.getString(R.string.staking_period_week_short)
-        MONTH -> resourceManager.getString(R.string.staking_period_month_short)
-        QUARTER -> resourceManager.getString(R.string.staking_period_quarter_short)
-        HALF_YEAR -> resourceManager.getString(R.string.staking_period_half_year_short)
-        YEAR -> resourceManager.getString(R.string.staking_period_year_short)
-        else -> {
+        RewardPeriodType.AllTime -> resourceManager.getString(R.string.staking_period_all_short)
+        RewardPeriodType.Preset.WEEK -> resourceManager.getString(R.string.staking_period_week_short)
+        RewardPeriodType.Preset.MONTH -> resourceManager.getString(R.string.staking_period_month_short)
+        RewardPeriodType.Preset.QUARTER -> resourceManager.getString(R.string.staking_period_quarter_short)
+        RewardPeriodType.Preset.HALF_YEAR -> resourceManager.getString(R.string.staking_period_half_year_short)
+        RewardPeriodType.Preset.YEAR -> resourceManager.getString(R.string.staking_period_year_short)
+        RewardPeriodType.Custom -> {
             resourceManager.getString(R.string.staking_period_custom_short, rewardPeriod.getPeriodDays())
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/period/StakingPeriodViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/period/StakingPeriodViewModel.kt
@@ -7,7 +7,6 @@ import io.novafoundation.nova.common.base.BaseViewModel
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.event
-import io.novafoundation.nova.common.utils.reversed
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.domain.period.RewardPeriod
@@ -17,25 +16,32 @@ import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.runtime.state.chain
 import io.novafoundation.nova.runtime.state.chainAsset
 import io.novafoundation.nova.runtime.state.selectedOption
-import java.util.Date
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import java.util.Date
+import java.util.concurrent.TimeUnit
 
 private val PERIOD_TYPES_TO_IDS = mapOf(
-    RewardPeriodType.ALL_TIME to R.id.allTimeStakingPeriod,
-    RewardPeriodType.WEEK to R.id.weekStakingPeriod,
-    RewardPeriodType.MONTH to R.id.monthStakingPeriod,
-    RewardPeriodType.QUARTER to R.id.quarterStakingPeriod,
-    RewardPeriodType.HALF_YEAR to R.id.halfYearStakingPeriod,
-    RewardPeriodType.YEAR to R.id.yearStakingPeriod,
-    RewardPeriodType.CUSTOM to R.id.customStakingPeriod
+    RewardPeriodType.AllTime to R.id.allTimeStakingPeriod,
+    RewardPeriodType.Preset.WEEK to R.id.weekStakingPeriod,
+    RewardPeriodType.Preset.MONTH to R.id.monthStakingPeriod,
+    RewardPeriodType.Preset.QUARTER to R.id.quarterStakingPeriod,
+    RewardPeriodType.Preset.HALF_YEAR to R.id.halfYearStakingPeriod,
+    RewardPeriodType.Preset.YEAR to R.id.yearStakingPeriod,
+    RewardPeriodType.Custom to R.id.customStakingPeriod
 )
 
-private val IDS_TO_PERIOD_TYPES = PERIOD_TYPES_TO_IDS.reversed()
+private val PRESETS_BY_IDS = mapOf(
+    R.id.weekStakingPeriod to RewardPeriodType.Preset.WEEK,
+    R.id.monthStakingPeriod to RewardPeriodType.Preset.MONTH,
+    R.id.quarterStakingPeriod to RewardPeriodType.Preset.QUARTER,
+    R.id.halfYearStakingPeriod to RewardPeriodType.Preset.HALF_YEAR,
+    R.id.yearStakingPeriod to RewardPeriodType.Preset.YEAR,
+)
+
 
 data class CustomPeriod(
     val start: Long? = null,
@@ -158,9 +164,9 @@ class StakingPeriodViewModel(
         return when {
             periodId == R.id.allTimeStakingPeriod -> RewardPeriod.AllTime
             periodId == R.id.customStakingPeriod -> mapCustomPeriodToEntity(customPeriod)
-            IDS_TO_PERIOD_TYPES.containsKey(periodId) -> {
-                val type = IDS_TO_PERIOD_TYPES.getValue(periodId)
-                RewardPeriod.OffsetFromCurrent(RewardPeriod.getOffsetByType(type), type)
+            PRESETS_BY_IDS.containsKey(periodId) -> {
+                val type = PRESETS_BY_IDS.getValue(periodId)
+                RewardPeriod.OffsetFromCurrent(RewardPeriod.getPresetOffset(type), type)
             }
             else -> null
         }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/period/StakingPeriodViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/period/StakingPeriodViewModel.kt
@@ -42,7 +42,6 @@ private val PRESETS_BY_IDS = mapOf(
     R.id.yearStakingPeriod to RewardPeriodType.Preset.YEAR,
 )
 
-
 data class CustomPeriod(
     val start: Long? = null,
     val end: Long? = null,


### PR DESCRIPTION
Difference was casued by the fact that preset uses date with time as a starting point whereas custom period uses beginning of a day
Also performed minor refactoring to improve type safety of `RewardPeriodType`

#85ztj1nqr