### PR TITLE
Warn users when sending tokens to system account

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -49,7 +49,7 @@ inline fun <K, V> List<V>.associateByMultiple(keysExtractor: (V) -> Iterable<K>)
 fun ByteArray.startsWith(prefix: ByteArray): Boolean {
     if (prefix.size > size) return false
 
-    prefix.forEachIndexed { index, byte  ->
+    prefix.forEachIndexed { index, byte ->
         if (get(index) != byte) return false
     }
 

--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -46,6 +46,16 @@ inline fun <K, V> List<V>.associateByMultiple(keysExtractor: (V) -> Iterable<K>)
     return destination
 }
 
+fun ByteArray.startsWith(prefix: ByteArray): Boolean {
+    if (prefix.size > size) return false
+
+    prefix.forEachIndexed { index, byte  ->
+        if (get(index) != byte) return false
+    }
+
+    return true
+}
+
 /**
  * Compares two BigDecimals taking into account only values but not scale unlike `==` operator
  */

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -4,6 +4,9 @@
     <string name="common_fee_changed_message">The estimated network fee %s is much higher than the default network fee (%s). This might be due to temporary network congestion. You can refresh to wait for a lower network fee.</string>
     <string name="common_refresh_fee">Refresh fee</string>
 
+    <string name="send_recipient_system_account_title">Recipient is a system account</string>
+    <string name="send_recipient_system_account_message">Recipient is a system account. It is not controlled by any company or individual. Are you sure you still want to perform this transfer?</string>
+
     <string name="asset_add_evm_token_already_exist_title">This token already exists</string>
 <!--    <string name="asset_add_evm_token_already_exist_title">This token already exist</string>-->
     <string name="asset_add_evm_token_already_exist_modifiable_message">The entered contract address is present in Nova as a %s token. Are you sure you want to modify it?</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -4,8 +4,8 @@
     <string name="common_fee_changed_message">The estimated network fee %s is much higher than the default network fee (%s). This might be due to temporary network congestion. You can refresh to wait for a lower network fee.</string>
     <string name="common_refresh_fee">Refresh fee</string>
 
-    <string name="send_recipient_system_account_title">Recipient is a system account</string>
-    <string name="send_recipient_system_account_message">Recipient is a system account. It is not controlled by any company or individual. Are you sure you still want to perform this transfer?</string>
+    <string name="send_recipient_system_account_title">Tokens will be lost</string>
+    <string name="send_recipient_system_account_message">Recipient is a system account. It is not controlled by any company or individual.\nAre you sure you still want to perform this transfer?</string>
 
     <string name="asset_add_evm_token_already_exist_title">This token already exists</string>
 <!--    <string name="asset_add_evm_token_already_exist_title">This token already exist</string>-->

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/CompoundSystemAccountMatcher.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/CompoundSystemAccountMatcher.kt
@@ -1,0 +1,14 @@
+package io.novafoundation.nova.feature_account_api.domain.account.system
+
+import jp.co.soramitsu.fearless_utils.runtime.AccountId
+
+class CompoundSystemAccountMatcher(
+    private val delegates: List<SystemAccountMatcher>
+): SystemAccountMatcher {
+
+    constructor(vararg delegates: SystemAccountMatcher): this(delegates.toList())
+
+    override fun isSystemAccount(accountId: AccountId): Boolean {
+        return delegates.any { it.isSystemAccount(accountId) }
+    }
+}

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/CompoundSystemAccountMatcher.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/CompoundSystemAccountMatcher.kt
@@ -4,9 +4,9 @@ import jp.co.soramitsu.fearless_utils.runtime.AccountId
 
 class CompoundSystemAccountMatcher(
     private val delegates: List<SystemAccountMatcher>
-): SystemAccountMatcher {
+) : SystemAccountMatcher {
 
-    constructor(vararg delegates: SystemAccountMatcher): this(delegates.toList())
+    constructor(vararg delegates: SystemAccountMatcher) : this(delegates.toList())
 
     override fun isSystemAccount(accountId: AccountId): Boolean {
         return delegates.any { it.isSystemAccount(accountId) }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/PrefixSystemAccountMatcher.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/PrefixSystemAccountMatcher.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_account_api.domain.account.system
 import io.novafoundation.nova.common.utils.startsWith
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 
-class PrefixSystemAccountMatcher(prefix: String):  SystemAccountMatcher {
+class PrefixSystemAccountMatcher(prefix: String) : SystemAccountMatcher {
 
     private val prefixBytes = prefix.encodeToByteArray()
 

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/PrefixSystemAccountMatcher.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/PrefixSystemAccountMatcher.kt
@@ -1,0 +1,13 @@
+package io.novafoundation.nova.feature_account_api.domain.account.system
+
+import io.novafoundation.nova.common.utils.startsWith
+import jp.co.soramitsu.fearless_utils.runtime.AccountId
+
+class PrefixSystemAccountMatcher(prefix: String):  SystemAccountMatcher {
+
+    private val prefixBytes = prefix.encodeToByteArray()
+
+    override fun isSystemAccount(accountId: AccountId): Boolean {
+        return accountId.startsWith(prefixBytes)
+    }
+}

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/SystemAccountMatcher.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/SystemAccountMatcher.kt
@@ -1,0 +1,23 @@
+package io.novafoundation.nova.feature_account_api.domain.account.system
+
+import jp.co.soramitsu.fearless_utils.runtime.AccountId
+
+interface SystemAccountMatcher {
+    
+    companion object
+
+    fun isSystemAccount(accountId: AccountId): Boolean
+}
+
+fun SystemAccountMatcher.Companion.default(): SystemAccountMatcher {
+    return CompoundSystemAccountMatcher(
+        // Pallet-specific technical accounts, e.g. crowdloan-fund, nomination pool,
+        PrefixSystemAccountMatcher("modl"),
+        // Parachain sovereign accounts on relaychain
+        PrefixSystemAccountMatcher("para"),
+        // Relaychain sovereign account on parachains
+        PrefixSystemAccountMatcher("Parent"),
+        // Sibling parachain soveregin accounts
+        PrefixSystemAccountMatcher("sibl")
+    )
+}

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/SystemAccountMatcher.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/SystemAccountMatcher.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_account_api.domain.account.system
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 
 interface SystemAccountMatcher {
-    
+
     companion object
 
     fun isSystemAccount(accountId: AccountId): Boolean

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/validation/SystemAccountRecipientValidation.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/validation/SystemAccountRecipientValidation.kt
@@ -1,0 +1,42 @@
+package io.novafoundation.nova.feature_account_api.domain.validation
+
+import io.novafoundation.nova.common.base.TitleAndMessage
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.validation.Validation
+import io.novafoundation.nova.common.validation.ValidationStatus
+import io.novafoundation.nova.common.validation.ValidationSystemBuilder
+import io.novafoundation.nova.common.validation.isFalseOrWarning
+import io.novafoundation.nova.common.validation.valid
+import io.novafoundation.nova.feature_account_api.R
+import io.novafoundation.nova.feature_account_api.domain.account.system.SystemAccountMatcher
+import io.novafoundation.nova.feature_account_api.domain.account.system.default
+import jp.co.soramitsu.fearless_utils.runtime.AccountId
+
+class SystemAccountRecipientValidation<P, E>(
+    private val accountId: (P) -> AccountId?,
+    private val error: (AccountId) -> E,
+    private val matcher: SystemAccountMatcher = SystemAccountMatcher.default(),
+) : Validation<P, E>{
+
+    override suspend fun validate(value: P): ValidationStatus<E> {
+        val accountId = accountId(value) ?: return valid()
+
+        return matcher.isSystemAccount(accountId) isFalseOrWarning {
+            error(accountId)
+        }
+    }
+}
+
+fun <P, E> ValidationSystemBuilder<P, E>.notSystemAccount(
+    accountId: (P) -> AccountId?,
+    error: (AccountId) -> E,
+) {
+    validate(SystemAccountRecipientValidation(accountId, error))
+}
+
+
+fun handleSystemAccountValidationFailure(resourceManager: ResourceManager): TitleAndMessage {
+    return resourceManager.getString(R.string.send_recipient_system_account_title) to
+        resourceManager.getString(R.string.send_recipient_system_account_message)
+}
+

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/validation/SystemAccountRecipientValidation.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/validation/SystemAccountRecipientValidation.kt
@@ -16,7 +16,7 @@ class SystemAccountRecipientValidation<P, E>(
     private val accountId: (P) -> AccountId?,
     private val error: (AccountId) -> E,
     private val matcher: SystemAccountMatcher = SystemAccountMatcher.default(),
-) : Validation<P, E>{
+) : Validation<P, E> {
 
     override suspend fun validate(value: P): ValidationStatus<E> {
         val accountId = accountId(value) ?: return valid()
@@ -34,9 +34,7 @@ fun <P, E> ValidationSystemBuilder<P, E>.notSystemAccount(
     validate(SystemAccountRecipientValidation(accountId, error))
 }
 
-
 fun handleSystemAccountValidationFailure(resourceManager: ResourceManager): TitleAndMessage {
     return resourceManager.getString(R.string.send_recipient_system_account_title) to
         resourceManager.getString(R.string.send_recipient_system_account_message)
 }
-

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/TransferAssetValidationFailureUi.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/TransferAssetValidationFailureUi.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.validation.TransformedFailure
 import io.novafoundation.nova.common.validation.TransformedFailure.Default
 import io.novafoundation.nova.common.validation.ValidationFlowActions
 import io.novafoundation.nova.common.validation.ValidationStatus
+import io.novafoundation.nova.feature_account_api.domain.validation.handleSystemAccountValidationFailure
 import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransferPayload
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransferValidationFailure
@@ -89,6 +90,10 @@ fun CoroutineScope.mapAssetTransferValidationFailureToUI(
             resourceManager = resourceManager,
             feeLoaderMixin = feeLoaderMixin,
             actions = actions,
+        )
+
+        AssetTransferValidationFailure.RecipientIsSystemAccount -> Default(
+            handleSystemAccountValidationFailure(resourceManager)
         )
     }
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransferValidations.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransferValidations.kt
@@ -58,6 +58,8 @@ sealed class AssetTransferValidationFailure {
     object RecipientCannotAcceptTransfer : AssetTransferValidationFailure()
 
     class FeeChangeDetected(override val payload: FeeChangeDetectedFailure.Payload) : AssetTransferValidationFailure(), FeeChangeDetectedFailure
+
+    object RecipientIsSystemAccount : AssetTransferValidationFailure()
 }
 
 data class AssetTransferPayload(

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/BaseAssetTransfers.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/BaseAssetTransfers.kt
@@ -17,6 +17,7 @@ import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.notDeadRecipientInUsedAsset
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.notPhishingRecipient
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.positiveAmount
+import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.recipientIsNotSystemAccount
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientBalanceInUsedAsset
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientCommissionBalanceToStayAboveED
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientTransferableBalanceToPayOriginFee
@@ -68,6 +69,7 @@ abstract class BaseAssetTransfers(
 
     protected fun defaultValidationSystem(): AssetTransfersValidationSystem = ValidationSystem {
         validAddress()
+        recipientIsNotSystemAccount()
 
         notPhishingRecipient(phishingValidationFactory)
 

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/equilibrium/EquilibriumAssetTransfers.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/equilibrium/EquilibriumAssetTransfers.kt
@@ -14,6 +14,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.validation.PhishingValid
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.BaseAssetTransfers
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.notDeadRecipientInUsedAsset
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.positiveAmount
+import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.recipientIsNotSystemAccount
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientBalanceInUsedAsset
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientTransferableBalanceToPayOriginFee
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.validAddress
@@ -42,6 +43,8 @@ class EquilibriumAssetTransfers(
 
     override val validationSystem: AssetTransfersValidationSystem = ValidationSystem {
         validAddress()
+        recipientIsNotSystemAccount()
+
         positiveAmount()
         sufficientBalanceInUsedAsset()
         sufficientTransferableBalanceToPayOriginFee()

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/evmErc20/EvmErc20AssetTransfers.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/evmErc20/EvmErc20AssetTransfers.kt
@@ -11,6 +11,7 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.t
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.amountInPlanks
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.checkForFeeChanges
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.positiveAmount
+import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.recipientIsNotSystemAccount
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientBalanceInUsedAsset
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientTransferableBalanceToPayOriginFee
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.validAddress
@@ -33,6 +34,7 @@ class EvmErc20AssetTransfers(
 
     override val validationSystem: AssetTransfersValidationSystem = ValidationSystem {
         validAddress()
+        recipientIsNotSystemAccount()
 
         positiveAmount()
 

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/evmNative/EvmNativeAssetTransfers.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/evmNative/EvmNativeAssetTransfers.kt
@@ -11,6 +11,7 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.t
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.amountInPlanks
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.checkForFeeChanges
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.positiveAmount
+import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.recipientIsNotSystemAccount
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientBalanceInUsedAsset
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientTransferableBalanceToPayOriginFee
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.validAddress
@@ -29,6 +30,7 @@ class EvmNativeAssetTransfers(
 
     override val validationSystem: AssetTransfersValidationSystem = ValidationSystem {
         validAddress()
+        recipientIsNotSystemAccount()
 
         positiveAmount()
 

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/validations/Common.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/validations/Common.kt
@@ -1,11 +1,13 @@
 package io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations
 
+import io.novafoundation.nova.feature_account_api.domain.validation.notSystemAccount
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.AssetSourceRegistry
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransfer
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransferPayload
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransferValidationFailure
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransferValidationFailure.WillRemoveAccount
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransfersValidationSystemBuilder
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.recipientOrNull
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.sendingAmountInCommissionAsset
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.domain.validation.AmountProducer
@@ -93,6 +95,11 @@ fun AssetTransfersValidationSystemBuilder.sufficientBalanceInUsedAsset() = suffi
     amount = { it.transfer.amount },
     fee = { BigDecimal.ZERO },
     error = { _, _ -> AssetTransferValidationFailure.NotEnoughFunds.InUsedAsset }
+)
+
+fun AssetTransfersValidationSystemBuilder.recipientIsNotSystemAccount() = notSystemAccount(
+    accountId = { it.transfer.recipientOrNull() },
+    error = { AssetTransferValidationFailure.RecipientIsSystemAccount }
 )
 
 private suspend fun AssetSourceRegistry.existentialDepositForUsedAsset(transfer: AssetTransfer): BigDecimal {

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
@@ -26,6 +26,7 @@ import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.notDeadRecipientInUsedAsset
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.notPhishingRecipient
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.positiveAmount
+import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.recipientIsNotSystemAccount
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientCommissionBalanceToStayAboveED
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.sufficientTransferableBalanceToPayOriginFee
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.validAddress
@@ -44,6 +45,7 @@ class RealCrossChainTransactor(
 
     override val validationSystem: AssetTransfersValidationSystem = ValidationSystem {
         positiveAmount()
+        recipientIsNotSystemAccount()
 
         validAddress()
         notPhishingRecipient(phishingValidationFactory)


### PR DESCRIPTION
#85ztqpjp0

Tested on
Fund (crowdloan), sovereign accounts (child, parent) for Moonbeam: https://polkadot.subscan.io/parachain/2004
Sovereign (sibling) account of Parallel on Moonbeam: `0x7369626cDC070000000000000000000000000000`
Nomination pool accounts: https://polkadot.subscan.io/nomination_pool/1

Cross-chain works too

![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/1a21103c-ff9a-4589-8a10-79cfc0a8c07a)
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/801f8cd1-ac0c-4e9d-a967-3326d1c6f0ed)

