### PR TITLE
Require stash instead of controller

### DIFF
--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/StakeActionsValidationModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/StakeActionsValidationModule.kt
@@ -134,10 +134,10 @@ class StakeActionsValidationsModule {
     @Named(SYSTEM_MANAGE_STAKING_REBAG)
     @Provides
     fun provideRebagValidationSystem(
-        @Named(BALANCE_REQUIRED_CONTROLLER)
-        controllerRequiredValidation: MainStakingAccountRequiredValidation
+        @Named(BALANCE_REQUIRED_STASH)
+        stashRequiredValidation: MainStakingAccountRequiredValidation
     ): StakeActionsValidationSystem = ValidationSystem {
-        validate(controllerRequiredValidation)
+        validate(stashRequiredValidation)
     }
 
     @FeatureScope


### PR DESCRIPTION
While `rebag` call is permissionless, we submit it from stash, so we should require stash and not controller