### PR TITLE
Fix caip2 moonbeam matching

### DIFF
--- a/caip/src/main/java/io/novafoundation/nova/caip/caip2/matchers/Eip155Matcher.kt
+++ b/caip/src/main/java/io/novafoundation/nova/caip/caip2/matchers/Eip155Matcher.kt
@@ -1,12 +1,12 @@
 package io.novafoundation.nova.caip.caip2.matchers
 
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.caip.caip2.identifier.Caip2Identifier
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 
 class Eip155Matcher(private val chain: Chain) : Caip2Matcher {
 
     override fun match(caip2Identifier: Caip2Identifier): Boolean {
         return caip2Identifier is Caip2Identifier.Eip155 &&
-            caip2Identifier.namespaceWitId == chain.id
+            caip2Identifier.chainId == chain.addressPrefix.toBigInteger()
     }
 }

--- a/caip/src/test/java/io/novafoundation/nova/caip/Caip19MatcherTest.kt
+++ b/caip/src/test/java/io/novafoundation/nova/caip/Caip19MatcherTest.kt
@@ -27,6 +27,7 @@ class Caip19MatcherTest {
 
     private val substrateChainId = "0x0"
     private val ethereumChainId = "eip155:1"
+    private val eip155ChainId = 1
 
     @Mock
     private lateinit var chain: Chain
@@ -54,7 +55,16 @@ class Caip19MatcherTest {
 
     @Test
     fun `eip155 erc20 should match`() = runBlocking {
-        mockChain(chainId = ethereumChainId, isEthereumBased = true)
+        mockChain(chainId = ethereumChainId, isEthereumBased = true, addressPrefix = eip155ChainId)
+        mockAsset(type = Chain.Asset.Type.EvmErc20("0x0"))
+        val identifier = getIdentifier("$ethereumChainId/erc20:0x0")
+        val matcher = caip19MatcherFactory.getCaip19Matcher(chain, chainAsset)
+        assertTrue(matcher.match(identifier))
+    }
+
+    @Test
+    fun `substrate-chainId ethereum-based erc20 should match`() = runBlocking {
+        mockChain(chainId = substrateChainId, isEthereumBased = true, addressPrefix = eip155ChainId)
         mockAsset(type = Chain.Asset.Type.EvmErc20("0x0"))
         val identifier = getIdentifier("$ethereumChainId/erc20:0x0")
         val matcher = caip19MatcherFactory.getCaip19Matcher(chain, chainAsset)
@@ -91,9 +101,13 @@ class Caip19MatcherTest {
         return parser.parseCaip19(raw).requireValue()
     }
 
-    private fun mockChain(chainId: String, isEthereumBased: Boolean) {
+    private fun mockChain(chainId: String, isEthereumBased: Boolean, addressPrefix: Int? = null) {
         `when`(chain.id).thenReturn(chainId)
         `when`(chain.isEthereumBased).thenReturn(isEthereumBased)
+
+        addressPrefix?.let {
+            `when`(chain.addressPrefix).thenReturn(addressPrefix)
+        }
     }
 
     private fun mockAsset(type: Chain.Asset.Type) {


### PR DESCRIPTION
Current implementation of EIP155 matcher relied on the fact that all EVM-compatible chains will have id in  EIP155 form. However for Moonbeam and Moonriver we use genesis hash as a chain id, which resulted in false-negative matchings

We fix it by comparing eip chainId (which is address prefix for evm chains in our configs)