### PR TITLE
Show event id for pool rewards instead of tx hash

### DIFF
--- a/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
@@ -50,8 +50,8 @@ import io.novafoundation.nova.core_db.migrations.AddContributions_23_24
 import io.novafoundation.nova.core_db.migrations.AddCurrencies_18_19
 import io.novafoundation.nova.core_db.migrations.AddDAppAuthorizations_1_2
 import io.novafoundation.nova.core_db.migrations.AddEnabledColumnToChainAssets_30_31
+import io.novafoundation.nova.core_db.migrations.AddEventIdToOperation_47_48
 import io.novafoundation.nova.core_db.migrations.AddExternalBalances_45_46
-import io.novafoundation.nova.core_db.migrations.AddExternalBalances_46_47
 import io.novafoundation.nova.core_db.migrations.AddExtrinsicContentField_37_38
 import io.novafoundation.nova.core_db.migrations.AddFavouriteDApps_9_10
 import io.novafoundation.nova.core_db.migrations.AddGovernanceDapps_25_26
@@ -62,6 +62,7 @@ import io.novafoundation.nova.core_db.migrations.AddLocks_22_23
 import io.novafoundation.nova.core_db.migrations.AddMetaAccountType_14_15
 import io.novafoundation.nova.core_db.migrations.AddNfts_5_6
 import io.novafoundation.nova.core_db.migrations.AddNodeSelectionStrategyField_38_39
+import io.novafoundation.nova.core_db.migrations.AddPoolIdToOperations_46_47
 import io.novafoundation.nova.core_db.migrations.AddRewardAccountToStakingDashboard_43_44
 import io.novafoundation.nova.core_db.migrations.AddRuntimeFlagToChains_36_37
 import io.novafoundation.nova.core_db.migrations.AddSitePhishing_6_7
@@ -121,7 +122,7 @@ import io.novafoundation.nova.core_db.model.chain.ChainRuntimeInfoLocal
 import io.novafoundation.nova.core_db.model.chain.MetaAccountLocal
 
 @Database(
-    version = 47,
+    version = 48,
     entities = [
         AccountLocal::class,
         NodeLocal::class,
@@ -202,7 +203,7 @@ abstract class AppDatabase : RoomDatabase() {
                     .addMigrations(AddWalletConnectSessions_39_40, TransferFiatAmount_40_41)
                     .addMigrations(AddStakingDashboardItems_41_42, StakingRewardPeriods_42_43)
                     .addMigrations(AddRewardAccountToStakingDashboard_43_44, AddStakingTypeToTotalRewards_44_45, AddExternalBalances_45_46)
-                    .addMigrations(AddExternalBalances_46_47)
+                    .addMigrations(AddPoolIdToOperations_46_47, AddEventIdToOperation_47_48)
                     .build()
             }
             return instance!!

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/46_47_AddPoolIdToOperations.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/46_47_AddPoolIdToOperations.kt
@@ -1,0 +1,11 @@
+package io.novafoundation.nova.core_db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val AddPoolIdToOperations_46_47 = object : Migration(46, 47) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE operations ADD COLUMN poolId INTEGER")
+    }
+}

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/47_48_AddEventIdToOperation.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/47_48_AddEventIdToOperation.kt
@@ -3,9 +3,11 @@ package io.novafoundation.nova.core_db.migrations
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-val AddExternalBalances_46_47 = object : Migration(46, 47) {
+val AddEventIdToOperation_47_48 = object : Migration(47, 48) {
 
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE operations ADD COLUMN poolId INTEGER")
+        database.execSQL("ALTER TABLE operations ADD COLUMN eventId TEXT")
+
+        database.execSQL("DELETE FROM operations")
     }
 }

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/OperationLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/OperationLocal.kt
@@ -28,6 +28,7 @@ data class OperationLocal(
     val era: Int? = null,
     val validator: String? = null,
     val poolId: Int? = null,
+    val eventId: String? = null,
 ) {
     enum class Type {
         EXTRINSIC, TRANSFER, REWARD, POOL_REWARD

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/mappers/OperationMappers.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/mappers/OperationMappers.kt
@@ -115,7 +115,8 @@ fun mapOperationToOperationLocalDb(
             isReward = rewardOrNull()?.isReward,
             era = rewardOrNull()?.directKindOrNull()?.era,
             validator = rewardOrNull()?.directKindOrNull()?.validator,
-            poolId = rewardOrNull()?.poolKindOrNull()?.poolId
+            poolId = rewardOrNull()?.poolKindOrNull()?.poolId,
+            eventId = rewardOrNull()?.eventId
         )
     }
 }
@@ -151,7 +152,8 @@ fun mapOperationLocalToOperation(
                 kind = RewardKind.Direct(
                     era = era!!,
                     validator = validator
-                )
+                ),
+                eventId = eventId!!
             )
             OperationLocal.Type.POOL_REWARD -> Type.Reward(
                 amount = amount!!,
@@ -159,7 +161,8 @@ fun mapOperationLocalToOperation(
                 isReward = isReward!!,
                 kind = RewardKind.Pool(
                     poolId = poolId!!
-                )
+                ),
+                eventId = eventId!!
             )
         }
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/model/OperationParcelizeModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/model/OperationParcelizeModel.kt
@@ -31,7 +31,7 @@ sealed class OperationParcelizeModel : Parcelable {
         val amount: AmountParcelModel,
         val type: String,
         val poolId: Int,
-        val extrinsicHash: String?,
+        val eventId: String,
     ) : OperationParcelizeModel()
 
     @Parcelize

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/reward/pool/PoolRewardDetailFragment.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/reward/pool/PoolRewardDetailFragment.kt
@@ -18,11 +18,11 @@ import io.novafoundation.nova.feature_assets.presentation.model.showOperationSta
 import io.novafoundation.nova.feature_assets.presentation.model.toAmountModel
 import io.novafoundation.nova.feature_staking_api.presentation.nominationPools.display.showPool
 import kotlinx.android.synthetic.main.fragment_pool_reward_details.poolRewardDetailAmount
+import kotlinx.android.synthetic.main.fragment_pool_reward_details.poolRewardDetailEventId
 import kotlinx.android.synthetic.main.fragment_pool_reward_details.poolRewardDetailNetwork
 import kotlinx.android.synthetic.main.fragment_pool_reward_details.poolRewardDetailPool
 import kotlinx.android.synthetic.main.fragment_pool_reward_details.poolRewardDetailStatus
 import kotlinx.android.synthetic.main.fragment_pool_reward_details.poolRewardDetailToolbar
-import kotlinx.android.synthetic.main.fragment_pool_reward_details.poolRewardDetailTransactionId
 import kotlinx.android.synthetic.main.fragment_pool_reward_details.poolRewardDetailType
 
 class PoolRewardDetailFragment : BaseFragment<PoolRewardDetailViewModel>() {
@@ -44,8 +44,8 @@ class PoolRewardDetailFragment : BaseFragment<PoolRewardDetailViewModel>() {
     override fun initViews() {
         poolRewardDetailToolbar.setHomeButtonListener { viewModel.backClicked() }
 
-        poolRewardDetailTransactionId.setOnClickListener {
-            viewModel.transactionIdClicked()
+        poolRewardDetailEventId.setOnClickListener {
+            viewModel.eventIdClicked()
         }
 
         poolRewardDetailPool.setOnClickListener {
@@ -71,7 +71,7 @@ class PoolRewardDetailFragment : BaseFragment<PoolRewardDetailViewModel>() {
         setupExternalActions(viewModel)
 
         with(viewModel.operation) {
-            poolRewardDetailTransactionId.showValueOrHide(extrinsicHash)
+            poolRewardDetailEventId.showValueOrHide(eventId)
             poolRewardDetailToolbar.setTitle(time.formatDateTime())
             poolRewardDetailAmount.setAmount(amount.toAmountModel())
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/reward/pool/PoolRewardDetailViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/detail/reward/pool/PoolRewardDetailViewModel.kt
@@ -41,10 +41,8 @@ class PoolRewardDetailViewModel(
         router.back()
     }
 
-    fun transactionIdClicked() {
-        operation.extrinsicHash?.let { hash ->
-            shoExternalActions(ExternalActions.Type.Extrinsic(hash))
-        }
+    fun eventIdClicked() {
+        shoExternalActions(ExternalActions.Type.Event(operation.eventId))
     }
 
     fun poolClicked() = launch {

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/mixin/OperationMappers.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/mixin/OperationMappers.kt
@@ -310,7 +310,7 @@ suspend fun mapOperationToParcel(
                 when (val rewardKind = operationType.kind) {
                     is RewardKind.Direct -> OperationParcelizeModel.Reward(
                         chainId = chainAsset.chainId,
-                        eventId = id,
+                        eventId = operationType.eventId,
                         address = address,
                         time = time,
                         amount = amount,
@@ -327,7 +327,7 @@ suspend fun mapOperationToParcel(
                         amount = amount,
                         type = resourceManager.getString(typeRes),
                         poolId = rewardKind.poolId,
-                        extrinsicHash = extrinsicHash
+                        eventId = operationType.eventId
                     )
                 }
             }

--- a/feature-assets/src/main/res/layout/fragment_pool_reward_details.xml
+++ b/feature-assets/src/main/res/layout/fragment_pool_reward_details.xml
@@ -89,12 +89,12 @@
                 android:layout_marginBottom="24dp">
 
                 <io.novafoundation.nova.common.view.TableCellView
-                    android:id="@+id/poolRewardDetailTransactionId"
+                    android:id="@+id/poolRewardDetailEventId"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:primaryValueIcon="@drawable/ic_info_cicrle_filled_16"
                     app:primaryValueIconTint="@color/icon_secondary"
-                    app:title="@string/common_transaction_id" />
+                    app:title="@string/common_event" />
 
                 <io.novafoundation.nova.common.view.TableCellView
                     android:id="@+id/poolRewardDetailType"

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/Operation.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/Operation.kt
@@ -36,6 +36,7 @@ data class Operation(
             val amount: BigInteger,
             val fiatAmount: BigDecimal?,
             val isReward: Boolean,
+            val eventId: String,
             val kind: RewardKind
         ) : Type() {
 

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/SubstrateAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/SubstrateAssetHistory.kt
@@ -147,7 +147,8 @@ abstract class SubstrateAssetHistory(
                     kind = Operation.Type.Reward.RewardKind.Direct(
                         era = era,
                         validator = validator.nullIfEmpty(),
-                    )
+                    ),
+                    eventId = eventId(node.blockNumber, node.reward.eventIdx)
                 )
             }
 
@@ -158,7 +159,8 @@ abstract class SubstrateAssetHistory(
                     isReward = isReward,
                     kind = Operation.Type.Reward.RewardKind.Pool(
                         poolId = poolId
-                    )
+                    ),
+                    eventId = eventId(node.blockNumber, node.poolReward.eventIdx)
                 )
             }
 
@@ -206,5 +208,9 @@ abstract class SubstrateAssetHistory(
             chainAsset = chainAsset,
             extrinsicHash = node.extrinsicHash
         )
+    }
+
+    private fun eventId(blockNumber: Long, eventIdx: Int): String {
+        return "${blockNumber}-${eventIdx}"
     }
 }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/SubstrateAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/SubstrateAssetHistory.kt
@@ -211,6 +211,6 @@ abstract class SubstrateAssetHistory(
     }
 
     private fun eventId(blockNumber: Long, eventIdx: Int): String {
-        return "${blockNumber}-${eventIdx}"
+        return "$blockNumber-$eventIdx"
     }
 }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/model/request/SubqueryHistoryRequest.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/model/request/SubqueryHistoryRequest.kt
@@ -58,6 +58,7 @@ class SubqueryHistoryRequest(
                     id
                     timestamp
                     extrinsicHash
+                    blockNumber
                     address
                     ${rewardsResponseSections(asset)}
                     extrinsic

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/model/response/SubqueryHistoryElementResponse.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/model/response/SubqueryHistoryElementResponse.kt
@@ -17,6 +17,7 @@ class SubqueryHistoryElementResponse(val query: Query) {
                 val extrinsicHash: String?,
                 val address: String,
                 val reward: Reward?,
+                val blockNumber: Long,
                 val poolReward: PoolReward?,
                 val transfer: Transfer?,
                 val extrinsic: Extrinsic?,
@@ -25,12 +26,14 @@ class SubqueryHistoryElementResponse(val query: Query) {
                 class Reward(
                     val era: Int,
                     val amount: BigInteger,
+                    val eventIdx: Int,
                     val isReward: Boolean,
                     val validator: String?,
                 )
 
                 class PoolReward(
                     val amount: BigInteger,
+                    val eventIdx: Int,
                     val poolId: Int,
                     val isReward: Boolean,
                 )


### PR DESCRIPTION
#85zty28w1
#862kcfq9z

PR also removes assumption that reward id is equal to event id and relies on blockNumber + eventIdx instead

![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/6b768652-5eb6-468d-ac58-63a8cfdd31fe)
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/fc3806c6-9afa-46d9-83c8-cae4a8c89924)
