### PR TITLE
Fixed open pin code twice

### DIFF
--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/Navigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/Navigator.kt
@@ -336,7 +336,13 @@ class Navigator(
     override fun nonCancellableVerify() {
         val currentDestination = navController?.currentDestination
 
+        // Don't open on splashScreen
         if (currentDestination?.id == R.id.splashFragment) {
+            return
+        }
+
+        // Don't open if pin already opened
+        if (currentDestination?.id == R.id.pincodeFragment) {
             return
         }
 

--- a/common/src/main/java/io/novafoundation/nova/common/di/modules/CommonModule.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/di/modules/CommonModule.kt
@@ -9,6 +9,7 @@ import coil.ImageLoader
 import coil.decode.SvgDecoder
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.common.BuildConfig
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.CachingAddressIconGenerator
 import io.novafoundation.nova.common.address.StatelessAddressIconGenerator
@@ -64,6 +65,7 @@ import jp.co.soramitsu.fearless_utils.encrypt.Signer
 import jp.co.soramitsu.fearless_utils.icon.IconGenerator
 import java.security.SecureRandom
 import java.util.Random
+import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 
 const val SHARED_PREFERENCES_FILE = "fearless_prefs"
@@ -115,7 +117,12 @@ class CommonModule {
         preferences: Preferences,
         automaticInteractionGate: AutomaticInteractionGate
     ): BackgroundAccessObserver {
-        return BackgroundAccessObserver(preferences, automaticInteractionGate)
+        val accessTime = if (BuildConfig.DEBUG) {
+            TimeUnit.SECONDS.toMillis(15L)
+        } else {
+            BackgroundAccessObserver.DEFAULT_ACCESS_TIME
+        }
+        return BackgroundAccessObserver(preferences, automaticInteractionGate, accessTime)
     }
 
     @Provides


### PR DESCRIPTION
Test case:
Precondition: enabled "don't keep activities"
- open app on main screen
- hide app to let system kill it
- open app (the pin verification must open)
- hide app to let system kill the app again
- open app

Result: Second pin verification fragment is shown. To use the app we must input pin code twice on both screens