### PR TITLE
Fix - algorithm ignores partial inactive stakes

### DIFF
--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/StakingInteractorExt.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/StakingInteractorExt.kt
@@ -106,12 +106,10 @@ fun minimumStake(
 private class ActiveStakingEntry {
 
     private var totalStaked: Balance = Balance.ZERO
-    private var numberOfValidators: Short = 0
     private var allStakeInactive: Boolean = true
 
     fun addStake(stake: Balance, isStakeActive: Boolean) {
         totalStaked += stake
-        numberOfValidators++
         allStakeInactive = allStakeInactive && !isStakeActive
     }
 


### PR DESCRIPTION
Regression was caused by introduction of ` .take(maxNominatorsInValidator)` which only counts nominator stakes that will be rewarded per each validator. The issue is cuased by the cornercase when staking is split between two parts and biggest one is inactive leaving smallest one being considered at nominator's total stake