### PR TITLE
[Temp] Remove max nominators limit in min stake

### DIFF
--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/StakingInteractorExt.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/StakingInteractorExt.kt
@@ -73,7 +73,6 @@ fun minimumStake(
     val stakeByNominator = exposures
         .fold(mutableMapOf<AccountIdKey, BigInteger>()) { acc, exposure ->
             exposure.others
-                .take(maxNominatorsInValidator)
                 .forEach { individualExposure ->
                     val key = individualExposure.who.intoKey()
                     val currentExposure = acc.getOrDefault(key, BigInteger.ZERO)


### PR DESCRIPTION
A hotfix version that rollbacks min stake calculation to the previous version

Supposed to be superseded by #1158 which needs to be verified more throughly

![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/09162bd5-5c7e-4d64-8a43-dc36ab7c1a09)
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/07aeab14-2eaf-418c-abeb-f3895c784f3f)
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/79f3bc6b-0e81-456e-8a51-a6a8a93b09e2)