### PR TITLE
Swap/max button

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -346,6 +346,9 @@ inline fun <T, R : Any> Iterable<T>.mapNotNullToSet(mapper: (T) -> R?): Set<R> =
 
 fun <T> List<T>.indexOfFirstOrNull(predicate: (T) -> Boolean) = indexOfFirst(predicate).takeIf { it >= 0 }
 
+
+
+
 @Suppress("IfThenToElvis")
 fun ByteArray?.optionalContentEquals(other: ByteArray?): Boolean {
     return if (this == null) {

--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -346,9 +346,6 @@ inline fun <T, R : Any> Iterable<T>.mapNotNullToSet(mapper: (T) -> R?): Set<R> =
 
 fun <T> List<T>.indexOfFirstOrNull(predicate: (T) -> Boolean) = indexOfFirst(predicate).takeIf { it >= 0 }
 
-
-
-
 @Suppress("IfThenToElvis")
 fun ByteArray?.optionalContentEquals(other: ByteArray?): Boolean {
     return if (this == null) {

--- a/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/model/SwapQuote.kt
+++ b/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/model/SwapQuote.kt
@@ -44,6 +44,9 @@ class SwapFee(
     val minimumBalanceBuyIn: MinimumBalanceBuyIn,
 ) : GenericFee
 
+val SwapFee.totalDeductedPlanks: Balance
+    get() = networkFee.amount + minimumBalanceBuyIn.commissionAssetToSpendOnBuyIn
+
 sealed class MinimumBalanceBuyIn {
 
     class NeedsToBuyMinimumBalance(

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsFragment.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsFragment.kt
@@ -4,13 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isGone
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.applyStatusBarInsets
 import io.novafoundation.nova.common.utils.postToUiThread
 import io.novafoundation.nova.common.utils.setSelectionEnd
-import io.novafoundation.nova.common.utils.setTextOrHide
 import io.novafoundation.nova.common.utils.setVisible
 import io.novafoundation.nova.common.view.setState
 import io.novafoundation.nova.common.view.showLoadingValue
@@ -26,7 +24,6 @@ import kotlinx.android.synthetic.main.fragment_main_swap_settings.swapMainSettin
 import kotlinx.android.synthetic.main.fragment_main_swap_settings.swapMainSettingsDetailsRate
 import kotlinx.android.synthetic.main.fragment_main_swap_settings.swapMainSettingsFlip
 import kotlinx.android.synthetic.main.fragment_main_swap_settings.swapMainSettingsMaxAmount
-import kotlinx.android.synthetic.main.fragment_main_swap_settings.swapMainSettingsMaxAmountButton
 import kotlinx.android.synthetic.main.fragment_main_swap_settings.swapMainSettingsMinBalanceAlert
 import kotlinx.android.synthetic.main.fragment_main_swap_settings.swapMainSettingsPayInput
 import kotlinx.android.synthetic.main.fragment_main_swap_settings.swapMainSettingsReceiveInput
@@ -46,7 +43,6 @@ class SwapMainSettingsFragment : BaseFragment<SwapMainSettingsViewModel>() {
         swapMainSettingsToolbar.applyStatusBarInsets()
         swapMainSettingsToolbar.setHomeButtonListener { viewModel.backClicked() }
 
-        swapMainSettingsMaxAmountButton.setOnClickListener { viewModel.maxTokens() }
         swapMainSettingsPayInput.setOnClickListener { viewModel.selectPayToken() }
         swapMainSettingsReceiveInput.setOnClickListener { viewModel.selectReceiveToken() }
         swapMainSettingsFlip.setOnClickListener {
@@ -68,14 +64,9 @@ class SwapMainSettingsFragment : BaseFragment<SwapMainSettingsViewModel>() {
     }
 
     override fun subscribe(viewModel: SwapMainSettingsViewModel) {
-        setupSwapAmountInput(viewModel.amountInInput, swapMainSettingsPayInput)
-        setupSwapAmountInput(viewModel.amountOutInput, swapMainSettingsReceiveInput)
+        setupSwapAmountInput(viewModel.amountInInput, swapMainSettingsPayInput, swapMainSettingsMaxAmount)
+        setupSwapAmountInput(viewModel.amountOutInput, swapMainSettingsReceiveInput, maxAvailableView = null)
         setupFeeLoading(viewModel.feeMixin, swapMainSettingsDetailsNetworkFee)
-
-        viewModel.amountInInput.maxAvailable.observe {
-            swapMainSettingsMaxAmountButton.isGone = it.isNullOrEmpty()
-            swapMainSettingsMaxAmount.setTextOrHide(it)
-        }
 
         viewModel.rateDetails.observe { swapMainSettingsDetailsRate.showLoadingValue(it) }
         viewModel.showDetails.observe { swapMainSettingsDetails.setVisible(it) }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
@@ -26,6 +26,7 @@ import io.novafoundation.nova.feature_swap_api.domain.model.SwapQuoteArgs
 import io.novafoundation.nova.feature_swap_api.domain.model.quotedBalance
 import io.novafoundation.nova.feature_swap_api.domain.model.swapRate
 import io.novafoundation.nova.feature_swap_api.domain.model.toExecuteArgs
+import io.novafoundation.nova.feature_swap_api.domain.model.totalDeductedPlanks
 import io.novafoundation.nova.feature_swap_impl.R
 import io.novafoundation.nova.feature_swap_impl.domain.interactor.SwapInteractor
 import io.novafoundation.nova.feature_swap_impl.presentation.SwapRouter
@@ -43,10 +44,13 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixinBase.InputState
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixinBase.InputState.InputKind
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.MaxActionProviderDsl.deductFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.MaxActionProviderDsl.providingMaxOf
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFeeLoaderMixin
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.loadedFeeFlow
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.loadedFeeOrNullFlow
 import io.novafoundation.nova.runtime.ext.commissionAsset
 import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
@@ -116,25 +120,26 @@ class SwapMainSettingsViewModel(
         .flatMapLatest { assetUseCase.assetFlow(it.commissionAsset) }
         .shareInBackground()
 
-    val amountInInput = swapAmountInputMixinFactory.create(
-        coroutineScope = viewModelScope,
-        assetFlow = assetInFlow.nullOnStart(),
-        maxAvailable = { it.transferableInPlanks },
-        emptyAssetTitle = R.string.swap_field_asset_from_title
-    )
-
-    val amountOutInput = swapAmountInputMixinFactory.create(
-        coroutineScope = viewModelScope,
-        assetFlow = assetOutFlow.nullOnStart(),
-        maxAvailable = { null },
-        emptyAssetTitle = R.string.swap_field_asset_to_title
-    )
-
     val feeMixin = feeLoaderMixinFactory.createGeneric<SwapFee>(
         tokenFlow = feeAssetFlow.map { it?.token },
         configuration = GenericFeeLoaderMixin.Configuration(
             initialStatusValue = FeeStatus.NoFee
         )
+    )
+
+    val amountInInput = swapAmountInputMixinFactory.create(
+        coroutineScope = viewModelScope,
+        tokenFlow = assetInFlow.token().nullOnStart(),
+        emptyAssetTitle = R.string.swap_field_asset_from_title,
+        maxActionProvider = assetInFlow
+            .providingMaxOf(Asset::transferableInPlanks)
+            .deductFee(feeMixin, SwapFee::totalDeductedPlanks)
+    )
+
+    val amountOutInput = swapAmountInputMixinFactory.create(
+        coroutineScope = viewModelScope,
+        tokenFlow = assetOutFlow.token().nullOnStart(),
+        emptyAssetTitle = R.string.swap_field_asset_to_title
     )
 
     val rateDetails: Flow<ExtendedLoadingState<String>> = quotingState.map {
@@ -152,7 +157,7 @@ class SwapMainSettingsViewModel(
 
     val swapDirectionFlipped: MutableLiveData<Event<SwapDirection>> = MutableLiveData()
 
-    val minimumBalanceBuyAlert = feeMixin.loadedFeeFlow()
+    val minimumBalanceBuyAlert = feeMixin.loadedFeeOrNullFlow()
         .map(::prepareMinimumBalanceBuyInAlertIfNeeded)
         .shareInBackground()
 
@@ -170,10 +175,6 @@ class SwapMainSettingsViewModel(
         setupQuoting()
 
         feeMixin.setupFees()
-    }
-
-    // TODO sync with iOS team
-    fun maxTokens() {
     }
 
     fun selectPayToken() {
@@ -236,7 +237,13 @@ class SwapMainSettingsViewModel(
     @OptIn(FlowPreview::class)
     private fun GenericFeeLoaderMixin.Presentation<SwapFee>.setupFees() {
         quotingState
-            .onEach { if (it is QuotingState.Loading) invalidateFee() }
+            .onEach {
+                when(it) {
+                    is QuotingState.Loading -> invalidateFee()
+                    is QuotingState.NotAvailable -> setFee(null)
+                    else -> {}
+                }
+            }
             .filterIsInstance<QuotingState.Loaded>()
             .debounce(300.milliseconds)
             .onEach { quoteState ->
@@ -380,12 +387,12 @@ class SwapMainSettingsViewModel(
     }
 
     private fun SwapAmountInputMixin.clearInput() {
-        inputState.value = InputState(value = "", initiatedByUser = false)
+        inputState.value = InputState(value = "", initiatedByUser = false, inputKind = InputKind.REGULAR)
     }
 
     private fun SwapAmountInputMixin.updateInput(chainAsset: Chain.Asset, planks: Balance) {
         val amount = chainAsset.amountFromPlanks(planks)
-        inputState.value = InputState(amountInputFormatter.format(amount), initiatedByUser = false)
+        inputState.value = InputState(amountInputFormatter.format(amount), initiatedByUser = false, InputKind.REGULAR)
     }
 
     private fun Flow<SwapSettings>.assetFlowOf(extractor: (SwapSettings) -> Chain.Asset?): Flow<Asset?> {
@@ -422,4 +429,6 @@ class SwapMainSettingsViewModel(
             ),
         )
     )
+
+    private fun Flow<Asset?>.token(): Flow<Token?> = map { it?.token }
 }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
@@ -50,10 +50,9 @@ import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChoose
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFeeLoaderMixin
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.loadedFeeFlow
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.loadedFeeOrNullFlow
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
 import io.novafoundation.nova.feature_wallet_api.presentation.model.fullChainAssetId
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.loadedFeeOrNullFlow
 import io.novafoundation.nova.runtime.ext.commissionAsset
 import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
@@ -238,7 +238,7 @@ class SwapMainSettingsViewModel(
     private fun GenericFeeLoaderMixin.Presentation<SwapFee>.setupFees() {
         quotingState
             .onEach {
-                when(it) {
+                when (it) {
                     is QuotingState.Loading -> invalidateFee()
                     is QuotingState.NotAvailable -> setFee(null)
                     else -> {}

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixin.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixin.kt
@@ -6,10 +6,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface SwapAmountInputMixin : AmountChooserMixinBase {
 
-    val fiatAmount: Flow<String>
-
-    val maxAvailable: Flow<String?>
-
     val assetModel: Flow<SwapInputAssetModel>
 
     interface Presentation : SwapAmountInputMixin, AmountChooserMixinBase.Presentation

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixinFactory.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixinFactory.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-
 class SwapAmountInputMixinFactory(
     private val chainRegistry: ChainRegistry,
     private val resourceManager: ResourceManager
@@ -48,7 +47,8 @@ private class RealSwapAmountInputMixin(
     coroutineScope = coroutineScope,
     tokenFlow = tokenFlow,
     maxActionProvider = maxActionProvider
-), SwapAmountInputMixin.Presentation {
+),
+    SwapAmountInputMixin.Presentation {
 
     override val assetModel: Flow<SwapInputAssetModel> = tokenFlow.map {
         val chainAsset = it?.configuration

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixinFactory.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixinFactory.kt
@@ -3,22 +3,17 @@ package io.novafoundation.nova.feature_swap_impl.presentation.main.input
 import androidx.annotation.StringRes
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.images.Icon
-import io.novafoundation.nova.feature_currency_api.presentation.formatters.formatAsCurrency
 import io.novafoundation.nova.feature_swap_impl.R
 import io.novafoundation.nova.feature_swap_impl.presentation.main.input.SwapAmountInputMixin.SwapInputAssetModel
-import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
-import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
+import io.novafoundation.nova.feature_wallet_api.domain.model.Token
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.BaseAmountChooserProvider
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.MaxActionProvider
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 
-typealias MaxAvailableExtractor = (Asset) -> Balance?
 
 class SwapAmountInputMixinFactory(
     private val chainRegistry: ChainRegistry,
@@ -27,44 +22,36 @@ class SwapAmountInputMixinFactory(
 
     fun create(
         coroutineScope: CoroutineScope,
-        assetFlow: Flow<Asset?>,
-        maxAvailable: MaxAvailableExtractor,
-        @StringRes emptyAssetTitle: Int
+        tokenFlow: Flow<Token?>,
+        @StringRes emptyAssetTitle: Int,
+        maxActionProvider: MaxActionProvider? = null,
     ): SwapAmountInputMixin.Presentation {
         return RealSwapAmountInputMixin(
             coroutineScope = coroutineScope,
-            assetFlow = assetFlow,
-            maxAvailableExtractor = maxAvailable,
+            tokenFlow = tokenFlow,
             emptyAssetTitle = emptyAssetTitle,
             chainRegistry = chainRegistry,
-            resourceManager = resourceManager
+            resourceManager = resourceManager,
+            maxActionProvider = maxActionProvider,
         )
     }
 }
 
 private class RealSwapAmountInputMixin(
     coroutineScope: CoroutineScope,
-    assetFlow: Flow<Asset?>,
-    private val maxAvailableExtractor: MaxAvailableExtractor,
+    tokenFlow: Flow<Token?>,
     @StringRes private val emptyAssetTitle: Int,
     private val chainRegistry: ChainRegistry,
-    private val resourceManager: ResourceManager
-) : BaseAmountChooserProvider(coroutineScope), SwapAmountInputMixin.Presentation {
+    private val resourceManager: ResourceManager,
+    maxActionProvider: MaxActionProvider?,
+) : BaseAmountChooserProvider(
+    coroutineScope = coroutineScope,
+    tokenFlow = tokenFlow,
+    maxActionProvider = maxActionProvider
+), SwapAmountInputMixin.Presentation {
 
-    override val fiatAmount: Flow<String> = combine(assetFlow.filterNotNull(), amount) { asset, amount ->
-        asset.token.amountToFiat(amount).formatAsCurrency(asset.token.currency)
-    }
-        .shareInBackground()
-
-    override val maxAvailable: Flow<String?> = assetFlow.map { asset ->
-        if (asset == null) return@map null
-        val maxAvailableBalance = maxAvailableExtractor.invoke(asset)
-
-        maxAvailableBalance?.formatPlanks(asset.token.configuration)
-    }.shareInBackground()
-
-    override val assetModel: Flow<SwapInputAssetModel> = assetFlow.map {
-        val chainAsset = it?.token?.configuration
+    override val assetModel: Flow<SwapInputAssetModel> = tokenFlow.map {
+        val chainAsset = it?.configuration
 
         if (chainAsset != null) {
             formatInputAsset(chainAsset)

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputUi.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputUi.kt
@@ -2,14 +2,15 @@ package io.novafoundation.nova.feature_swap_impl.presentation.main.input
 
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.feature_swap_impl.presentation.views.SwapAmountInputView
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.MaxAvailableView
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.setupAmountChooserBase
 
 fun BaseFragment<*>.setupSwapAmountInput(
     mixin: SwapAmountInputMixin,
     amountView: SwapAmountInputView,
+    maxAvailableView: MaxAvailableView?
 ) {
-    setupAmountChooserBase(mixin, amountView.amountInput)
+    setupAmountChooserBase(mixin, amountView, maxAvailableView)
 
     mixin.assetModel.observe(amountView::setModel)
-    mixin.fiatAmount.observe(amountView::setFiatAmount)
 }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/state/RealSwapSettingsState.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/state/RealSwapSettingsState.kt
@@ -23,9 +23,9 @@ class RealSwapSettingsState(
         val chain = chainRegistry.getChain(asset.chainId)
 
         val new = if (current.feeAsset == null || current.feeAsset!!.chainId != chain.id) {
-            current.copy(assetIn = asset, feeAsset = chain.commissionAsset)
+            current.copy(assetIn = asset, feeAsset = chain.commissionAsset, amount = null)
         } else {
-            current.copy(assetIn = asset)
+            current.copy(assetIn = asset, amount = null)
         }
 
         selectedOption.value = new

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/state/RealSwapSettingsState.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/state/RealSwapSettingsState.kt
@@ -23,9 +23,9 @@ class RealSwapSettingsState(
         val chain = chainRegistry.getChain(asset.chainId)
 
         val new = if (current.feeAsset == null || current.feeAsset!!.chainId != chain.id) {
-            current.copy(assetIn = asset, feeAsset = chain.commissionAsset, amount = null)
+            current.copy(assetIn = asset, feeAsset = chain.commissionAsset)
         } else {
-            current.copy(assetIn = asset, amount = null)
+            current.copy(assetIn = asset)
         }
 
         selectedOption.value = new

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/views/SwapAmountInputView.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/views/SwapAmountInputView.kt
@@ -17,6 +17,7 @@ import io.novafoundation.nova.common.view.shape.getInputBackgroundError
 import io.novafoundation.nova.feature_account_api.presenatation.chain.loadTokenIcon
 import io.novafoundation.nova.feature_swap_impl.R
 import io.novafoundation.nova.feature_swap_impl.presentation.main.input.SwapAmountInputMixin.SwapInputAssetModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountInputView
 import kotlinx.android.synthetic.main.view_swap_amount_input.view.swapAmountInputFiat
 import kotlinx.android.synthetic.main.view_swap_amount_input.view.swapAmountInputField
 import kotlinx.android.synthetic.main.view_swap_amount_input.view.swapAmountInputImage
@@ -29,11 +30,10 @@ class SwapAmountInputView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : ConstraintLayout(context, attrs, defStyleAttr),
-    WithContextExtensions by WithContextExtensions(
-        context
-    ) {
+    WithContextExtensions by WithContextExtensions(context),
+    AmountInputView {
 
-    val amountInput: EditText
+    override val amountInput: EditText
         get() = swapAmountInputField
 
     private val imageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
@@ -54,8 +54,8 @@ class SwapAmountInputView @JvmOverloads constructor(
         amountInput.isVisible = model.showInput
     }
 
-    fun setFiatAmount(priceAmount: String?) {
-        swapAmountInputFiat.setTextOrHide(priceAmount)
+    override fun setFiatAmount(fiat: String?) {
+        swapAmountInputFiat.setTextOrHide(fiat)
     }
 
     private fun setTitle(title: String) {

--- a/feature-swap-impl/src/main/res/layout/fragment_main_swap_settings.xml
+++ b/feature-swap-impl/src/main/res/layout/fragment_main_swap_settings.xml
@@ -28,29 +28,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/swapMainSettingsToolbar" />
 
-    <TextView
-        android:id="@+id/swapMainSettingsMaxAmountButton"
-        style="@style/TextAppearance.NovaFoundation.Regular.Footnote"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:padding="4dp"
-        android:text="@string/fragment_swap_main_settings_max_button"
-        android:textColor="@color/button_text_accent"
-        app:layout_constraintBottom_toBottomOf="@+id/swapMainSettingsMaxAmount"
-        app:layout_constraintEnd_toStartOf="@+id/swapMainSettingsMaxAmount"
-        app:layout_constraintTop_toTopOf="@+id/swapMainSettingsMaxAmount" />
 
-    <TextView
+    <io.novafoundation.nova.feature_wallet_api.presentation.view.amount.MaxAmountView
         android:id="@+id/swapMainSettingsMaxAmount"
-        style="@style/TextAppearance.NovaFoundation.Regular.Footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
         android:layout_marginTop="16dp"
-        android:textColor="@color/text_primary"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/swapMainSettingsToolbar"
-        tools:text="4 DOT" />
+        app:layout_constraintTop_toBottomOf="@id/swapMainSettingsToolbar" />
 
     <io.novafoundation.nova.feature_swap_impl.presentation.views.SwapAmountInputView
         android:id="@+id/swapMainSettingsPayInput"

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/mappers/Fee.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/mappers/Fee.kt
@@ -20,8 +20,9 @@ fun <F : GenericFee> mapFeeToFeeModel(
 ) = GenericFeeModel(
     decimalFee = GenericDecimalFee(
         genericFee = fee,
-        networkFeeDecimalAmount = token.amountFromPlanks(fee.networkFee.amount)
+        networkFeeDecimalAmount = token.amountFromPlanks(fee.networkFee.amount),
     ),
+    chainAsset = token.configuration,
     display = mapAmountToAmountModel(
         amountInPlanks = fee.networkFee.amount,
         token = token,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserMixin.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserMixin.kt
@@ -20,7 +20,13 @@ interface AmountChooserMixinBase : CoroutineScope {
 
     val inputState: MutableStateFlow<InputState<String>>
 
-    @Deprecated("Use amountInput instead")
+    @Deprecated(
+        message = "Use `inputState` instead",
+        replaceWith = ReplaceWith(
+            expression = "inputState.map { it.value }",
+            imports = ["kotlinx.coroutines.flow.map"]
+        )
+    )
     val amountInput: StateFlow<String>
 
     val maxAction: MaxAction

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserMixin.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserMixin.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChoos
 import androidx.annotation.StringRes
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixinBase.InputState
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixinBase.InputState.InputKind
 import io.novafoundation.nova.feature_wallet_api.presentation.model.ChooseAmountModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -11,12 +12,18 @@ import kotlinx.coroutines.flow.StateFlow
 import java.math.BigDecimal
 import java.math.BigInteger
 
+typealias MaxClick = () -> Unit
+
 interface AmountChooserMixinBase : CoroutineScope {
+
+    val fiatAmount: Flow<String>
 
     val inputState: MutableStateFlow<InputState<String>>
 
     @Deprecated("Use amountInput instead")
     val amountInput: StateFlow<String>
+
+    val maxAction: MaxAction
 
     interface Presentation : AmountChooserMixinBase {
 
@@ -28,12 +35,19 @@ interface AmountChooserMixinBase : CoroutineScope {
         val backPressuredAmount: Flow<BigDecimal>
     }
 
-    interface Factory {
+    class InputState<T>(val value: T, val initiatedByUser: Boolean, val inputKind: InputKind) {
 
-        fun create(scope: CoroutineScope)
+        enum class InputKind {
+            REGULAR, MAX_ACTION
+        }
     }
 
-    class InputState<T>(val value: T, val initiatedByUser: Boolean)
+    interface MaxAction {
+
+        val display: Flow<String?>
+
+        val maxClick: Flow<MaxClick?>
+    }
 }
 
 interface AmountChooserMixin : AmountChooserMixinBase {
@@ -41,8 +55,6 @@ interface AmountChooserMixin : AmountChooserMixinBase {
     val usedAssetFlow: Flow<Asset>
 
     val assetModel: Flow<ChooseAmountModel>
-
-    val fiatAmount: Flow<String>
 
     interface Presentation : AmountChooserMixin, AmountChooserMixinBase.Presentation
 
@@ -65,9 +77,9 @@ interface AmountChooserMixin : AmountChooserMixinBase {
 }
 
 fun AmountChooserMixin.Presentation.setAmount(amount: BigDecimal) {
-    inputState.value = InputState(value = amount.toPlainString(), initiatedByUser = false)
+    inputState.value = InputState(value = amount.toPlainString(), initiatedByUser = false, inputKind = InputKind.REGULAR)
 }
 
 fun AmountChooserMixin.Presentation.setAmountInput(amountInput: String) {
-    inputState.value = InputState(value = amountInput, initiatedByUser = false)
+    inputState.value = InputState(value = amountInput, initiatedByUser = false, inputKind = InputKind.REGULAR)
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserProvider.kt
@@ -62,7 +62,8 @@ class AmountChooserProvider(
     coroutineScope = coroutineScope,
     tokenFlow = usedAssetFlow.map { it.token },
     maxActionProvider = maxActionProvider,
-), AmountChooserMixin.Presentation {
+),
+    AmountChooserMixin.Presentation {
 
     override val assetModel = usedAssetFlow.map { asset ->
         ChooseAmountModel(asset, resourceManager, balanceLabel)

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserProvider.kt
@@ -2,16 +2,15 @@ package io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChoos
 
 import androidx.annotation.StringRes
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.inBackground
-import io.novafoundation.nova.feature_currency_api.presentation.formatters.formatAsCurrency
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.MaxActionProvider
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.SimpleMaxActionProvider
 import io.novafoundation.nova.feature_wallet_api.presentation.model.ChooseAmountModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
 import java.math.BigDecimal
 import java.math.BigInteger
 
@@ -28,9 +27,13 @@ class AmountChooserProviderFactory(
         return AmountChooserProvider(
             coroutineScope = scope,
             usedAssetFlow = assetFlow,
-            availableBalanceFlow = availableBalanceFlow,
             balanceLabel = balanceLabel,
-            resourceManager = resourceManager
+            resourceManager = resourceManager,
+            maxActionProvider = SimpleMaxActionProvider(
+                maxAvailableForDisplay = availableBalanceFlow,
+                // TODO amount chooser max button
+                maxAvailableForAction = flowOf(null)
+            )
         )
     }
 
@@ -53,22 +56,16 @@ class AmountChooserProvider(
     coroutineScope: CoroutineScope,
     override val usedAssetFlow: Flow<Asset>,
     private val resourceManager: ResourceManager,
-    private val availableBalanceFlow: Flow<BigInteger>,
-    @StringRes private val balanceLabel: Int?
-) : AmountChooserMixin.Presentation,
-    BaseAmountChooserProvider(coroutineScope) {
+    @StringRes private val balanceLabel: Int?,
+    maxActionProvider: MaxActionProvider
+) : BaseAmountChooserProvider(
+    coroutineScope = coroutineScope,
+    tokenFlow = usedAssetFlow.map { it.token },
+    maxActionProvider = maxActionProvider,
+), AmountChooserMixin.Presentation {
 
-    override val assetModel = combine(
-        availableBalanceFlow.onStart<BigInteger?> { emit(null) },
-        usedAssetFlow
-    ) { balance, asset ->
-        ChooseAmountModel(asset, resourceManager, balance, balanceLabel)
+    override val assetModel = usedAssetFlow.map { asset ->
+        ChooseAmountModel(asset, resourceManager, balanceLabel)
     }
         .shareInBackground()
-
-    override val fiatAmount: Flow<String> = usedAssetFlow.combine(amount) { asset, amount ->
-        asset.token.amountToFiat(amount).formatAsCurrency(asset.token.currency)
-    }
-        .inBackground()
-        .share()
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserUi.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserUi.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser
 
+import android.view.View.OnClickListener
 import android.widget.EditText
 import androidx.lifecycle.lifecycleScope
 import io.novafoundation.nova.common.base.BaseFragment
@@ -10,23 +11,68 @@ import io.novafoundation.nova.feature_wallet_api.presentation.view.amount.setCho
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 
+interface AmountInputView {
+
+    val amountInput: EditText
+
+    fun setFiatAmount(fiat: String?)
+}
+
+interface MaxAvailableView {
+
+    fun setMaxAmountDisplay(maxAmountDisplay: String?)
+
+    fun setMaxActionAvailability(availability: MaxActionAvailability)
+}
+
+sealed class MaxActionAvailability {
+
+    class Available(val onMaxClicked: OnClickListener) : MaxActionAvailability()
+
+    object NotAvailable : MaxActionAvailability()
+}
+
 fun BaseFragment<*>.setupAmountChooser(
     mixin: AmountChooserMixin,
     amountView: ChooseAmountView,
 ) {
-    setupAmountChooserBase(mixin, amountView.amountInput)
+    setupAmountChooserBase(mixin, amountView)
 
     mixin.assetModel.observe(amountView::setChooseAmountModel)
-    mixin.fiatAmount.observe(amountView::setFiatAmount)
+}
+
+fun <T> BaseFragment<*>.setupAmountChooserBase(
+    mixin: AmountChooserMixinBase,
+    view: T,
+) where T : AmountInputView, T : MaxAvailableView {
+    setupAmountChooserBase(mixin, view, view)
 }
 
 fun BaseFragment<*>.setupAmountChooserBase(
     mixin: AmountChooserMixinBase,
-    inputField: EditText
+    amountInputView: AmountInputView,
+    maxAvailableView: MaxAvailableView?
 ) {
-    inputField.bindToAmountInput(mixin.inputState, lifecycleScope)
+    amountInputView.amountInput.bindToAmountInput(mixin.inputState, lifecycleScope)
+    mixin.fiatAmount.observe(amountInputView::setFiatAmount)
+
+    if (maxAvailableView == null) return
+
+    mixin.maxAction.display.observe(maxAvailableView::setMaxAmountDisplay)
+    mixin.maxAction.maxClick.observe { maxClick ->
+        val maxActionAvailability = if (maxClick != null) {
+            MaxActionAvailability.Available {
+                amountInputView.amountInput.requestFocus()
+
+                maxClick()
+            }
+        } else {
+            MaxActionAvailability.NotAvailable
+        }
+        maxAvailableView.setMaxActionAvailability(maxActionAvailability)
+    }
 }
 
 private fun EditText.bindToAmountInput(flow: MutableSharedFlow<InputState<String>>, scope: CoroutineScope) {
-    bindTo(flow, scope, toT = { InputState(it, initiatedByUser = true) }, fromT = { it.value })
+    bindTo(flow, scope, toT = { InputState(it, initiatedByUser = true, InputState.InputKind.REGULAR) }, fromT = { it.value })
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/BaseAmountChooserProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/BaseAmountChooserProvider.kt
@@ -162,7 +162,7 @@ open class BaseAmountChooserProvider(
 
         private fun MaxActionProvider?.maxAvailableForAction(): Flow<Balance?> = this?.maxAvailableForAction?.balance() ?: flowOf(null)
 
-        private fun MaxActionProvider?.maxAvailableForDisplay(): Flow<Balance?> = this?.maxAvailableForDisplay?: flowOf(null)
+        private fun MaxActionProvider?.maxAvailableForDisplay(): Flow<Balance?> = this?.maxAvailableForDisplay ?: flowOf(null)
 
         private fun Flow<MaxAvailableForAction?>.balance(): Flow<Balance?> = map { it?.balance }
 

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/BaseAmountChooserProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/BaseAmountChooserProvider.kt
@@ -51,7 +51,13 @@ open class BaseAmountChooserProvider(
 
     final override val inputState = MutableStateFlow(defaultState())
 
-    @Deprecated("Use amountInput instead")
+    @Deprecated(
+        message = "Use `inputState` instead",
+        replaceWith = ReplaceWith(
+            expression = "inputState.map { it.value }",
+            imports = ["kotlinx.coroutines.flow.map"]
+        )
+    )
     final override val amountInput = inputState.map { it.value }
         .stateIn(this, SharingStarted.Eagerly, initialValue = "")
 

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/BaseAmountChooserProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/BaseAmountChooserProvider.kt
@@ -1,28 +1,57 @@
 package io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser
 
 import io.novafoundation.nova.common.utils.WithCoroutineScopeExtensions
+import io.novafoundation.nova.common.utils.firstNotNull
+import io.novafoundation.nova.common.utils.inBackground
 import io.novafoundation.nova.common.utils.orZero
+import io.novafoundation.nova.feature_currency_api.presentation.formatters.formatAsCurrency
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.domain.model.Token
+import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixinBase.InputState
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixinBase.InputState.InputKind
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.MaxActionProvider
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.MaxActionProvider.MaxAvailableForAction
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import kotlin.time.Duration.Companion.milliseconds
 
 private const val DEBOUNCE_DURATION_MILLIS = 500
 
+@OptIn(FlowPreview::class)
+@Suppress("LeakingThis")
 open class BaseAmountChooserProvider(
     coroutineScope: CoroutineScope,
+    tokenFlow: Flow<Token?>,
+    private val maxActionProvider: MaxActionProvider?
 ) : AmountChooserMixinBase.Presentation,
     CoroutineScope by coroutineScope,
     WithCoroutineScopeExtensions by WithCoroutineScopeExtensions(coroutineScope) {
 
+    private val chainAssetFlow = tokenFlow.map { it?.configuration }
+        .distinctUntilChanged()
+
     final override val inputState = MutableStateFlow(defaultState())
 
+    @Deprecated("Use amountInput instead")
     final override val amountInput = inputState.map { it.value }
         .stateIn(this, SharingStarted.Eagerly, initialValue = "")
 
@@ -31,18 +60,115 @@ open class BaseAmountChooserProvider(
             inputState.map { input -> input.parseBigDecimalOrNull() }
         }.share()
 
-    override val amount: Flow<BigDecimal> = amountState
+    private val _amount: Flow<BigDecimal> = amountState
         .map { it.value.orZero() }
         .share()
 
+    @Deprecated("Use amountState instead")
+    override val amount: Flow<BigDecimal> = _amount
+
+    override val fiatAmount: Flow<String> = combine(tokenFlow.filterNotNull(), _amount) { token, amount ->
+        token.amountToFiat(amount).formatAsCurrency(token.currency)
+    }
+        .shareInBackground()
+
     override val backPressuredAmount: Flow<BigDecimal>
-        get() = amount.debounce(DEBOUNCE_DURATION_MILLIS.milliseconds)
+        get() = _amount.debounce(DEBOUNCE_DURATION_MILLIS.milliseconds)
+
+    override val maxAction: AmountChooserMixinBase.MaxAction = RealMaxAction()
 
     private fun String.parseBigDecimalOrNull() = replace(",", "").toBigDecimalOrNull()
 
-    private fun defaultState(): InputState<String> = InputState(value = "", initiatedByUser = true)
+    private fun defaultState(): InputState<String> = InputState(value = "", initiatedByUser = true, inputKind = InputKind.REGULAR)
 
     private fun <T, R> InputState<T>.map(valueTransform: (T) -> R): InputState<R> {
-        return InputState(valueTransform(value), initiatedByUser)
+        return InputState(valueTransform(value), initiatedByUser, inputKind)
+    }
+
+    private inner class RealMaxAction : AmountChooserMixinBase.MaxAction {
+
+        private var activeDelayedClick: Job? = null
+
+        private val maxAvailableForActionAmount = combine(chainAssetFlow, maxActionProvider.maxAvailableForAction()) { chainAsset, maxAvailableForAction ->
+            if (chainAsset == null || maxAvailableForAction == null) {
+                null
+            } else {
+                chainAsset.amountFromPlanks(maxAvailableForAction)
+            }
+        }.shareInBackground()
+
+        override val display: Flow<String?> = combine(chainAssetFlow, maxActionProvider.maxAvailableForDisplay()) { chainAsset, maxAvailableForDisplay ->
+            if (chainAsset == null || maxAvailableForDisplay == null) {
+                null
+            } else {
+                maxAvailableForDisplay.formatPlanks(chainAsset)
+            }
+        }.inBackground()
+
+        override val maxClick: Flow<MaxClick?> = maxAvailableForActionAmount.map { maxAvailableForAction ->
+            if (maxAvailableForAction != null) createImmediateMaxClicked(maxAvailableForAction) else createDelayedMaxClicked()
+        }.inBackground()
+
+        init {
+            setupAutoUpdates()
+
+            cancelDelayedInputOnInputChange()
+        }
+
+        private fun createImmediateMaxClicked(amount: BigDecimal): MaxClick {
+            val potentialState = maxAmountInputState(amount)
+
+            return {
+                cancelActiveDelayedClick()
+
+                inputState.value = potentialState
+            }
+        }
+
+        private fun createDelayedMaxClicked(): MaxClick {
+            return {
+                cancelActiveDelayedClick()
+
+                activeDelayedClick = launch {
+                    val amount = maxAvailableForActionAmount.firstNotNull()
+                    val potentialState = maxAmountInputState(amount)
+                    inputState.value = potentialState
+                }
+            }
+        }
+
+        private fun setupAutoUpdates() {
+            maxAvailableForActionAmount
+                .filterNotNull()
+                .filter { amount ->
+                    val currentState = amountState.first()
+                    currentState.inputKind == InputKind.MAX_ACTION && amount != currentState.value
+                }
+                .onEach { newAmount ->
+                    inputState.value = maxAmountInputState(newAmount)
+                }
+                .launchIn(this@BaseAmountChooserProvider)
+        }
+
+        private fun cancelDelayedInputOnInputChange() {
+            amountState.onEach {
+                if (it.inputKind != InputKind.MAX_ACTION) cancelActiveDelayedClick()
+            }.launchIn(this@BaseAmountChooserProvider)
+        }
+
+        private fun maxAmountInputState(amount: BigDecimal): InputState<String> {
+            return InputState(amount.toPlainString(), initiatedByUser = true, inputKind = InputKind.MAX_ACTION)
+        }
+
+        private fun MaxActionProvider?.maxAvailableForAction(): Flow<Balance?> = this?.maxAvailableForAction?.balance() ?: flowOf(null)
+
+        private fun MaxActionProvider?.maxAvailableForDisplay(): Flow<Balance?> = this?.maxAvailableForDisplay?: flowOf(null)
+
+        private fun Flow<MaxAvailableForAction?>.balance(): Flow<Balance?> = map { it?.balance }
+
+        private fun cancelActiveDelayedClick() {
+            activeDelayedClick?.cancel()
+            activeDelayedClick = null
+        }
     }
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/maxAction/MaxActionProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/maxAction/MaxActionProvider.kt
@@ -1,0 +1,113 @@
+package io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction
+
+import androidx.lifecycle.asFlow
+import io.novafoundation.nova.common.utils.atLeastZero
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.MaxActionProvider.MaxAvailableForAction
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFeeLoaderMixin
+import io.novafoundation.nova.runtime.ext.fullId
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import java.math.BigInteger
+
+interface MaxActionProvider {
+
+    class MaxAvailableForAction(val balance: Balance, val chainAsset: Chain.Asset)
+
+    val maxAvailableForDisplay: Flow<Balance?>
+
+    val maxAvailableForAction: Flow<MaxAvailableForAction?>
+}
+
+
+class SimpleMaxActionProvider(
+    override val maxAvailableForDisplay: Flow<Balance>,
+    override val maxAvailableForAction: Flow<MaxAvailableForAction?>
+): MaxActionProvider
+
+
+
+class AssetMaxActionProvider(
+    private val assetFlow: Flow<Asset?>,
+    private val assetField: (Asset) -> Balance,
+    private val allowMaxAction: Boolean
+): MaxActionProvider {
+
+    override val maxAvailableForDisplay: Flow<Balance?> = assetFlow.map{ it?.let(assetField) }
+
+    override val maxAvailableForAction: Flow<MaxAvailableForAction?> = assetFlow.map{ asset ->
+        if (allowMaxAction && asset != null) {
+            val extractedBalance = assetField(asset)
+
+            MaxAvailableForAction(extractedBalance, asset.token.configuration)
+        } else {
+            null
+        }
+    }
+}
+
+class FeeAwareMaxActionProvider<F: GenericFee>(
+    feeInputMixin: GenericFeeLoaderMixin<F>,
+    private val extractTotalFee: (F) -> Balance,
+    inner: MaxActionProvider,
+) : MaxActionProvider {
+
+    // Fee is not deducted for display
+    override val maxAvailableForDisplay: Flow<Balance?> = inner.maxAvailableForDisplay
+
+    override val maxAvailableForAction: Flow<MaxAvailableForAction?> = combine(
+        inner.maxAvailableForAction,
+        feeInputMixin.feeLiveData.asFlow()
+    ) { maxAvailable, newFeeStatus ->
+        if (maxAvailable == null) return@combine null
+
+        when(newFeeStatus) {
+            // do not block in case there is no fee or fee is not yet present
+            FeeStatus.Error, FeeStatus.NoFee -> maxAvailable
+
+            is FeeStatus.Loaded -> {
+                val feeAsset = newFeeStatus.feeModel.chainAsset
+                val amountAsset = maxAvailable.chainAsset
+
+                if (feeAsset.fullId == amountAsset.fullId) {
+                    val genericFee = newFeeStatus.feeModel.decimalFee.genericFee
+                    val extractedFee = extractTotalFee(genericFee)
+
+                    maxAvailable - extractedFee
+                } else {
+                    maxAvailable
+                }
+            }
+
+            FeeStatus.Loading -> null
+        }
+
+    }
+
+    infix operator fun MaxAvailableForAction?.minus(other: BigInteger?): MaxAvailableForAction? {
+        if (this == null  || other == null) return null
+
+        val difference = balance - other
+
+        return MaxAvailableForAction(difference.atLeastZero(), chainAsset)
+    }
+}
+
+object MaxActionProviderDsl {
+
+    fun Flow<Asset?>.providingMaxOf(field: (Asset) -> Balance, allowMaxAction: Boolean = true): MaxActionProvider {
+        return AssetMaxActionProvider(this, field, allowMaxAction)
+    }
+
+    fun <F: GenericFee> MaxActionProvider.deductFee(
+        feeLoaderMixin: GenericFeeLoaderMixin<F>,
+        extractTotalFee: (F) -> Balance
+    ): MaxActionProvider {
+        return FeeAwareMaxActionProvider(feeLoaderMixin, extractTotalFee, inner = this)
+    }
+}

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/maxAction/MaxActionProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/maxAction/MaxActionProvider.kt
@@ -24,23 +24,20 @@ interface MaxActionProvider {
     val maxAvailableForAction: Flow<MaxAvailableForAction?>
 }
 
-
 class SimpleMaxActionProvider(
     override val maxAvailableForDisplay: Flow<Balance>,
     override val maxAvailableForAction: Flow<MaxAvailableForAction?>
-): MaxActionProvider
-
-
+) : MaxActionProvider
 
 class AssetMaxActionProvider(
     private val assetFlow: Flow<Asset?>,
     private val assetField: (Asset) -> Balance,
     private val allowMaxAction: Boolean
-): MaxActionProvider {
+) : MaxActionProvider {
 
-    override val maxAvailableForDisplay: Flow<Balance?> = assetFlow.map{ it?.let(assetField) }
+    override val maxAvailableForDisplay: Flow<Balance?> = assetFlow.map { it?.let(assetField) }
 
-    override val maxAvailableForAction: Flow<MaxAvailableForAction?> = assetFlow.map{ asset ->
+    override val maxAvailableForAction: Flow<MaxAvailableForAction?> = assetFlow.map { asset ->
         if (allowMaxAction && asset != null) {
             val extractedBalance = assetField(asset)
 
@@ -51,7 +48,7 @@ class AssetMaxActionProvider(
     }
 }
 
-class FeeAwareMaxActionProvider<F: GenericFee>(
+class FeeAwareMaxActionProvider<F : GenericFee>(
     feeInputMixin: GenericFeeLoaderMixin<F>,
     private val extractTotalFee: (F) -> Balance,
     inner: MaxActionProvider,
@@ -66,7 +63,7 @@ class FeeAwareMaxActionProvider<F: GenericFee>(
     ) { maxAvailable, newFeeStatus ->
         if (maxAvailable == null) return@combine null
 
-        when(newFeeStatus) {
+        when (newFeeStatus) {
             // do not block in case there is no fee or fee is not yet present
             FeeStatus.Error, FeeStatus.NoFee -> maxAvailable
 
@@ -86,11 +83,10 @@ class FeeAwareMaxActionProvider<F: GenericFee>(
 
             FeeStatus.Loading -> null
         }
-
     }
 
     infix operator fun MaxAvailableForAction?.minus(other: BigInteger?): MaxAvailableForAction? {
-        if (this == null  || other == null) return null
+        if (this == null || other == null) return null
 
         val difference = balance - other
 
@@ -104,7 +100,7 @@ object MaxActionProviderDsl {
         return AssetMaxActionProvider(this, field, allowMaxAction)
     }
 
-    fun <F: GenericFee> MaxActionProvider.deductFee(
+    fun <F : GenericFee> MaxActionProvider.deductFee(
         feeLoaderMixin: GenericFeeLoaderMixin<F>,
         extractTotalFee: (F) -> Balance
     ): MaxActionProvider {

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/FeeLoaderMixin.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/FeeLoaderMixin.kt
@@ -143,7 +143,7 @@ suspend fun <F : GenericFee> GenericFeeLoaderMixin<F>.awaitOptionalDecimalFee():
         }
     }.first()
 
-fun <F : GenericFee> GenericFeeLoaderMixin<F>.loadedFeeFlow(): Flow<F?> {
+fun <F : GenericFee> GenericFeeLoaderMixin<F>.loadedFeeOrNullFlow(): Flow<F?> {
     return feeLiveData.asFlow().map {
         it.castOrNull<FeeStatus.Loaded<F>>()?.feeModel?.decimalFee?.genericFee
     }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/model/ChooseAmountModel.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/model/ChooseAmountModel.kt
@@ -5,12 +5,10 @@ import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.ensureSuffix
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import java.math.BigInteger
 
 class ChooseAmountModel(
     val input: ChooseAmountInputModel,
     val balanceLabel: String?,
-    val balance: String?
 )
 
 class ChooseAmountInputModel(
@@ -21,12 +19,10 @@ class ChooseAmountInputModel(
 internal fun ChooseAmountModel(
     asset: Asset,
     resourceManager: ResourceManager,
-    availableBalance: BigInteger?,
     @StringRes balanceLabelRes: Int?,
 ): ChooseAmountModel = ChooseAmountModel(
     input = ChooseAmountInputModel(asset.token.configuration),
     balanceLabel = balanceLabelRes?.let(resourceManager::getString)?.ensureSuffix(":"),
-    balance = availableBalance?.let { mapAmountToAmountModel(it, asset).token }
 )
 
 internal fun ChooseAmountInputModel(chainAsset: Chain.Asset): ChooseAmountInputModel = ChooseAmountInputModel(

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/model/FeeModel.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/model/FeeModel.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_wallet_api.presentation.model
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.SimpleFee
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigDecimal
 
 typealias FeeModel = GenericFeeModel<SimpleFee>
@@ -11,6 +12,7 @@ typealias DecimalFee = GenericDecimalFee<SimpleFee>
 class GenericFeeModel<F : GenericFee>(
     val decimalFee: GenericDecimalFee<F>,
     val display: AmountModel,
+    val chainAsset: Chain.Asset
 )
 
 class GenericDecimalFee<F : GenericFee>(

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/view/amount/ChooseAmountView.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/view/amount/ChooseAmountView.kt
@@ -8,6 +8,9 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import io.novafoundation.nova.common.utils.setTextOrHide
 import io.novafoundation.nova.common.utils.useAttributes
 import io.novafoundation.nova.feature_wallet_api.R
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountInputView
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.MaxActionAvailability
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.MaxAvailableView
 import io.novafoundation.nova.feature_wallet_api.presentation.model.ChooseAmountModel
 import kotlinx.android.synthetic.main.view_choose_amount.view.chooseAmountBalance
 import kotlinx.android.synthetic.main.view_choose_amount.view.chooseAmountBalanceLabel
@@ -18,9 +21,9 @@ class ChooseAmountView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0,
-) : ConstraintLayout(context, attrs, defStyle) {
+) : ConstraintLayout(context, attrs, defStyle), MaxAvailableView, AmountInputView {
 
-    val amountInput: EditText
+    override val amountInput: EditText
         get() = chooseAmountInput.amountInput
 
     init {
@@ -31,10 +34,6 @@ class ChooseAmountView @JvmOverloads constructor(
 
     fun setBalanceLabel(label: String?) {
         chooseAmountBalanceLabel.setTextOrHide(label)
-    }
-
-    fun setBalance(balance: String?) {
-        chooseAmountBalance.setTextOrHide(balance)
     }
 
     fun loadAssetImage(imageUrl: String) {
@@ -49,8 +48,16 @@ class ChooseAmountView @JvmOverloads constructor(
         chooseAmountInput.setAssetName(name)
     }
 
-    fun setFiatAmount(priceAmount: String?) {
-        chooseAmountInput.setFiatAmount(priceAmount)
+    override fun setFiatAmount(fiat: String?) {
+        chooseAmountInput.setFiatAmount(fiat)
+    }
+
+    override fun setMaxAmountDisplay(maxAmountDisplay: String?) {
+        chooseAmountBalance.setTextOrHide(maxAmountDisplay)
+    }
+
+    override fun setMaxActionAvailability(availability: MaxActionAvailability) {
+        // TODO amount chooser max button
     }
 
     private fun applyAttrs(attrs: AttributeSet) = context.useAttributes(attrs, R.styleable.ChooseAmountView) {
@@ -61,8 +68,6 @@ class ChooseAmountView @JvmOverloads constructor(
 
 fun ChooseAmountView.setChooseAmountModel(chooseAmountModel: ChooseAmountModel) {
     setBalanceLabel(chooseAmountModel.balanceLabel)
-
-    setBalance(chooseAmountModel.balance)
 
     chooseAmountInput.setChooseAmountInputModel(chooseAmountModel.input)
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/view/amount/MaxAmountView.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/view/amount/MaxAmountView.kt
@@ -1,0 +1,45 @@
+package io.novafoundation.nova.feature_wallet_api.presentation.view.amount
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.View
+import android.widget.LinearLayout
+import io.novafoundation.nova.common.utils.letOrHide
+import io.novafoundation.nova.common.utils.setTextColorRes
+import io.novafoundation.nova.feature_wallet_api.R
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.MaxActionAvailability
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.MaxAvailableView
+import kotlinx.android.synthetic.main.view_max_amount.view.viewMaxAmountAction
+import kotlinx.android.synthetic.main.view_max_amount.view.viewMaxAmountValue
+
+class MaxAmountView  @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : LinearLayout(context, attrs, defStyle), MaxAvailableView {
+
+    init {
+        View.inflate(context, R.layout.view_max_amount, this)
+
+        orientation = HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+    }
+
+    override fun setMaxAmountDisplay(maxAmountDisplay: String?) = letOrHide(maxAmountDisplay) { display ->
+        viewMaxAmountValue.text = display
+    }
+
+    override fun setMaxActionAvailability(availability: MaxActionAvailability) {
+        when(availability) {
+            is MaxActionAvailability.Available -> {
+                setOnClickListener(availability.onMaxClicked)
+                viewMaxAmountAction.setTextColorRes(R.color.button_text_accent)
+            }
+            MaxActionAvailability.NotAvailable -> {
+                setOnClickListener(null)
+                viewMaxAmountAction.setTextColorRes(R.color.text_primary)
+            }
+        }
+    }
+}

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/view/amount/MaxAmountView.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/view/amount/MaxAmountView.kt
@@ -13,7 +13,7 @@ import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChoose
 import kotlinx.android.synthetic.main.view_max_amount.view.viewMaxAmountAction
 import kotlinx.android.synthetic.main.view_max_amount.view.viewMaxAmountValue
 
-class MaxAmountView  @JvmOverloads constructor(
+class MaxAmountView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0,
@@ -31,7 +31,7 @@ class MaxAmountView  @JvmOverloads constructor(
     }
 
     override fun setMaxActionAvailability(availability: MaxActionAvailability) {
-        when(availability) {
+        when (availability) {
             is MaxActionAvailability.Available -> {
                 setOnClickListener(availability.onMaxClicked)
                 viewMaxAmountAction.setTextColorRes(R.color.button_text_accent)

--- a/feature-wallet-api/src/main/res/layout/view_max_amount.xml
+++ b/feature-wallet-api/src/main/res/layout/view_max_amount.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    tools:gravity="center_vertical"
+    tools:orientation="horizontal"
+    tools:parentTag="android.widget.LinearLayout">
+
+    <TextView
+        android:id="@+id/viewMaxAmountAction"
+        style="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
+        android:text="@string/fragment_swap_main_settings_max_button"
+        android:textColor="@color/button_text_accent" />
+
+    <TextView
+        android:id="@+id/viewMaxAmountValue"
+        style="@style/TextAppearance.NovaFoundation.Regular.Footnote.Primary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/text_secondary"
+        tools:text="105.79 USDT" />
+
+</merge>


### PR DESCRIPTION
Basic idea:

* `MaxActionProvider` is  generic enough to handle any use-case with max available balance flow since its exposes just `Flow<Balance>`
* `MaxActionProvider` implementations are stackable. There are currently two implementations - one for just using field from `Asset`, another one deducts fee based on `GenericFeeLoaderMixin<F>`
* `BaseAmountChooserProvider` depends on `MaxActionProvider` and implements tracking for max available balances changes and updates its internal state with `InputKind.MAX_ACTION`
* Note that neither `BaseAmountChooserProvider` nor `MaxActionProvider` are responsible for updateing fee, they just update `inputState`. It is up for the screen (logic in viewModel) to define when exactly they want to recalculate fee. They might rely on `InputKind` to discinguish between regular and max button inputs

![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/9ad65a33-bde8-4f2a-a479-f5092f292614)
