### PR TITLE
Swap/pending swaps

### DIFF
--- a/app/src/androidTest/java/io/novafoundation/nova/SwapServiceIntegrationTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/SwapServiceIntegrationTest.kt
@@ -83,7 +83,7 @@ class SwapServiceIntegrationTest : BaseIntegrationTest() {
             assetIn = wnd,
             assetOut = siri,
             swapLimit = SwapLimit.SpecifiedIn(
-                amountIn = siri.planksFromAmount(0.000001.toBigDecimal()),
+                expectedAmountIn = siri.planksFromAmount(0.000001.toBigDecimal()),
                 amountOutMin = Balance.ZERO
             ),
             customFeeAsset = null,
@@ -105,7 +105,7 @@ class SwapServiceIntegrationTest : BaseIntegrationTest() {
             assetIn = siri,
             assetOut = wnd,
             swapLimit = SwapLimit.SpecifiedIn(
-                amountIn = siri.planksFromAmount(0.000001.toBigDecimal()),
+                expectedAmountIn = siri.planksFromAmount(0.000001.toBigDecimal()),
                 amountOutMin = Balance.ZERO
             ),
             customFeeAsset = siri,

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/operation/OperationLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/operation/OperationLocal.kt
@@ -50,5 +50,41 @@ class OperationLocal(
                 )
             )
         }
+
+        @Suppress("UnnecessaryVariable")
+        fun manualSwap(
+            hash: String,
+            originAddress: String,
+            assetId: AssetAndChainId,
+            fee: SwapTypeLocal.AssetWithAmount,
+            amountIn: SwapTypeLocal.AssetWithAmount,
+            amountOut: SwapTypeLocal.AssetWithAmount,
+            status: OperationBaseLocal.Status,
+            source: OperationBaseLocal.Source
+        ): OperationLocal {
+            val id = hash // we're ok here even if remote data source uses other ids since we clear operations by transactionHash in OperationDao
+
+            return OperationLocal(
+                base = OperationBaseLocal(
+                    id = id,
+                    address = originAddress,
+                    assetId = assetId,
+                    time = System.currentTimeMillis(),
+                    status = status,
+                    source = source,
+                    hash = hash
+                ),
+                type = SwapTypeLocal(
+                    foreignKey = OperationForeignKey(
+                        address = originAddress,
+                        operationId = id,
+                        assetId = assetId
+                    ),
+                    fee = fee,
+                    assetIn = amountIn,
+                    assetOut = amountOut
+                )
+            )
+        }
     }
 }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/extrinsic/ExtrinsicService.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/extrinsic/ExtrinsicService.kt
@@ -19,16 +19,27 @@ typealias FormMultiExtrinsic = suspend CallBuilder.() -> Unit
 
 typealias ExtrinsicHash = String
 
+class ExtrinsicSubmission(val hash: String, val origin: AccountId)
+
 interface ExtrinsicService {
 
     suspend fun submitMultiExtrinsicWithSelectedWalletAwaitingInclusion(
         chain: Chain,
         formExtrinsic: FormMultiExtrinsicWithOrigin,
     ): RetriableMultiResult<ExtrinsicStatus.InBlock>
+
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("Use submitExtrinsicWithSelectedWalletV2 instead")
     suspend fun submitExtrinsicWithSelectedWallet(
         chain: Chain,
         formExtrinsic: FormExtrinsicWithOrigin,
-    ): Result<ExtrinsicHash>
+    ): Result<ExtrinsicHash> = submitExtrinsicWithSelectedWalletV2(chain, formExtrinsic)
+        .map { it.hash }
+
+    suspend fun submitExtrinsicWithSelectedWalletV2(
+        chain: Chain,
+        formExtrinsic: FormExtrinsicWithOrigin,
+    ): Result<ExtrinsicSubmission>
 
     suspend fun submitAndWatchExtrinsicWithSelectedWallet(
         chain: Chain,

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/repository/TransactionHistoryRepository.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/repository/TransactionHistoryRepository.kt
@@ -77,8 +77,10 @@ class RealTransactionHistoryRepository(
         val historySource = historySourceFor(chainAsset)
         val accountAddress = chain.addressOf(accountId)
 
-        val dataPage = historySource.getFilteredOperations(pageSize, PageOffset.Loadable.FirstPage, filters, accountId, chain, chainAsset, currency)
-        historySource.additionalFirstPageSync(chain, chainAsset, accountId, dataPage)
+        val dataPageResult = runCatching { historySource.getFilteredOperations(pageSize, PageOffset.Loadable.FirstPage, filters, accountId, chain, chainAsset, currency) }
+        historySource.additionalFirstPageSync(chain, chainAsset, accountId, dataPageResult)
+
+        val dataPage = dataPageResult.getOrThrow()
 
         val localOperations = dataPage.map { mapOperationToOperationLocalDb(it, OperationBaseLocal.Source.REMOTE) }
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/repository/TransactionHistoryRepository.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/data/repository/TransactionHistoryRepository.kt
@@ -77,7 +77,17 @@ class RealTransactionHistoryRepository(
         val historySource = historySourceFor(chainAsset)
         val accountAddress = chain.addressOf(accountId)
 
-        val dataPageResult = runCatching { historySource.getFilteredOperations(pageSize, PageOffset.Loadable.FirstPage, filters, accountId, chain, chainAsset, currency) }
+        val dataPageResult = runCatching {
+            historySource.getFilteredOperations(
+                pageSize,
+                PageOffset.Loadable.FirstPage,
+                filters,
+                accountId,
+                chain,
+                chainAsset,
+                currency
+            )
+        }
         historySource.additionalFirstPageSync(chain, chainAsset, accountId, dataPageResult)
 
         val dataPage = dataPageResult.getOrThrow()

--- a/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/swap/SwapService.kt
+++ b/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/swap/SwapService.kt
@@ -1,6 +1,6 @@
 package io.novafoundation.nova.feature_swap_api.domain.swap
 
-import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicHash
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapExecuteArgs
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapFee
@@ -24,7 +24,7 @@ interface SwapService {
 
     suspend fun estimateFee(args: SwapExecuteArgs): SwapFee
 
-    suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicHash>
+    suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicSubmission>
 
     suspend fun slippageConfig(chainId: ChainId): SlippageConfig?
 }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/AssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/AssetExchange.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.feature_swap_impl.data.assetExchange
 
 import io.novafoundation.nova.common.utils.MultiMap
-import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicHash
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_swap_api.domain.model.MinimumBalanceBuyIn
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
@@ -35,7 +35,7 @@ interface AssetExchange {
 
     suspend fun estimateFee(args: SwapExecuteArgs): AssetExchangeFee
 
-    suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicHash>
+    suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicSubmission>
 
     suspend fun slippageConfig(): SlippageConfig
 }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
@@ -7,8 +7,8 @@ import io.novafoundation.nova.common.utils.Percent
 import io.novafoundation.nova.common.utils.assetConversion
 import io.novafoundation.nova.common.utils.mutableMultiMapOf
 import io.novafoundation.nova.common.utils.put
-import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicHash
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_account_api.data.model.InlineFee
 import io.novafoundation.nova.feature_swap_api.domain.model.MinimumBalanceBuyIn
@@ -128,8 +128,8 @@ private class AssetConversionExchange(
         return convertNativeFeeToPayingTokenFee(nativeAssetFee, args)
     }
 
-    override suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicHash> {
-        return extrinsicService.submitExtrinsicWithSelectedWallet(chain) { origin ->
+    override suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicSubmission> {
+        return extrinsicService.submitExtrinsicWithSelectedWalletV2(chain) { origin ->
             executeSwap(args, origin)
         }
     }
@@ -232,7 +232,7 @@ private class AssetConversionExchange(
                 callName = "swap_exact_tokens_for_tokens",
                 arguments = mapOf(
                     "path" to path,
-                    "amount_in" to swapLimit.amountIn,
+                    "amount_in" to swapLimit.expectedAmountIn,
                     "amount_out_min" to swapLimit.amountOutMin,
                     "send_to" to origin,
                     "keep_alive" to keepAlive
@@ -244,7 +244,7 @@ private class AssetConversionExchange(
                 callName = "swap_tokens_for_exact_tokens",
                 arguments = mapOf(
                     "path" to path,
-                    "amount_out" to swapLimit.amountOut,
+                    "amount_out" to swapLimit.expectedAmountOut,
                     "amount_in_max" to swapLimit.amountInMax,
                     "send_to" to origin,
                     "keep_alive" to keepAlive

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/repository/SwapTransactionHistoryRepository.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/repository/SwapTransactionHistoryRepository.kt
@@ -27,7 +27,7 @@ interface SwapTransactionHistoryRepository {
 class RealSwapTransactionHistoryRepository(
     private val operationDao: OperationDao,
     private val chainRegistry: ChainRegistry,
-): SwapTransactionHistoryRepository {
+) : SwapTransactionHistoryRepository {
 
     override suspend fun insertPendingSwap(
         chainAsset: Chain.Asset,

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/repository/SwapTransactionHistoryRepository.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/repository/SwapTransactionHistoryRepository.kt
@@ -1,0 +1,62 @@
+package io.novafoundation.nova.feature_swap_impl.data.repository
+
+import io.novafoundation.nova.core_db.dao.OperationDao
+import io.novafoundation.nova.core_db.model.operation.OperationBaseLocal
+import io.novafoundation.nova.core_db.model.operation.OperationLocal
+import io.novafoundation.nova.core_db.model.operation.SwapTypeLocal.AssetWithAmount
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapExecuteArgs
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapFee
+import io.novafoundation.nova.feature_swap_api.domain.model.feeAsset
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.runtime.ext.addressOf
+import io.novafoundation.nova.runtime.ext.localId
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+
+interface SwapTransactionHistoryRepository {
+
+    suspend fun insertPendingSwap(
+        chainAsset: Chain.Asset,
+        swapArgs: SwapExecuteArgs,
+        fee: SwapFee,
+        txSubmission: ExtrinsicSubmission
+    )
+}
+
+class RealSwapTransactionHistoryRepository(
+    private val operationDao: OperationDao,
+    private val chainRegistry: ChainRegistry,
+): SwapTransactionHistoryRepository {
+
+    override suspend fun insertPendingSwap(
+        chainAsset: Chain.Asset,
+        swapArgs: SwapExecuteArgs,
+        fee: SwapFee,
+        txSubmission: ExtrinsicSubmission
+    ) {
+        val chain = chainRegistry.getChain(chainAsset.chainId)
+
+        val localOperation = with(swapArgs) {
+            OperationLocal.manualSwap(
+                hash = txSubmission.hash,
+                originAddress = chain.addressOf(txSubmission.origin),
+                assetId = chainAsset.localId,
+                fee = feeAsset.withAmountLocal(fee.networkFee.amount),
+                amountIn = assetIn.withAmountLocal(swapLimit.expectedAmountIn),
+                amountOut = assetOut.withAmountLocal(swapLimit.expectedAmountOut),
+                status = OperationBaseLocal.Status.PENDING,
+                source = OperationBaseLocal.Source.APP
+            )
+        }
+
+        operationDao.insert(localOperation)
+    }
+
+    private fun Chain.Asset.withAmountLocal(amount: Balance): AssetWithAmount {
+        return AssetWithAmount(
+            assetId = localId,
+            amount = amount
+        )
+    }
+}

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureDependencies.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureDependencies.kt
@@ -12,6 +12,7 @@ import io.novafoundation.nova.common.validation.ValidationExecutor
 import io.novafoundation.nova.common.view.bottomSheet.description.DescriptionBottomSheetLauncher
 import io.novafoundation.nova.common.view.input.chooser.ListChooserMixin
 import io.novafoundation.nova.core.storage.StorageCache
+import io.novafoundation.nova.core_db.dao.OperationDao
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_account_api.data.repository.OnChainIdentityRepository
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
@@ -110,4 +111,6 @@ interface SwapFeatureDependencies {
     val buyMixinUi: BuyMixinUi
 
     val crossChainTransfersUseCase: CrossChainTransfersUseCase
+
+    val operationDao: OperationDao
 }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
@@ -12,7 +12,7 @@ import io.novafoundation.nova.common.utils.flatMap
 import io.novafoundation.nova.common.utils.flowOf
 import io.novafoundation.nova.common.utils.isZero
 import io.novafoundation.nova.common.utils.toPercent
-import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicHash
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapDirection
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapExecuteArgs
@@ -100,7 +100,7 @@ internal class RealSwapService(
         return SwapFee(networkFee = assetExchangeFee.networkFee, minimumBalanceBuyIn = assetExchangeFee.minimumBalanceBuyIn)
     }
 
-    override suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicHash> {
+    override suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicSubmission> {
         val computationScope = CoroutineScope(coroutineContext)
 
         return runCatching { exchanges(computationScope).getValue(args.assetIn.chainId) }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/SwapConfirmationViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/SwapConfirmationViewModel.kt
@@ -233,7 +233,9 @@ class SwapConfirmationViewModel(
             val payload = getValidationPayload() ?: return@launch
 
             validationExecutor.requireValid(
-                validationSystem = validationSystem, payload = payload, progressConsumer = _validationProgress.progressConsumer(),
+                validationSystem = validationSystem,
+                payload = payload,
+                progressConsumer = _validationProgress.progressConsumer(),
                 validationFailureTransformerCustom = ::formatValidationFailure,
                 block = ::executeSwap
             )

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/history/AssetHistory.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/history/AssetHistory.kt
@@ -25,7 +25,7 @@ interface AssetHistory {
         chain: Chain,
         chainAsset: Chain.Asset,
         accountId: AccountId,
-        page: DataPage<Operation>
+        page: Result<DataPage<Operation>>
     )
 
     suspend fun getOperations(

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/EvmAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/EvmAssetHistory.kt
@@ -32,7 +32,7 @@ abstract class EvmAssetHistory(
         chain: Chain,
         chainAsset: Chain.Asset,
         accountId: AccountId,
-        page: DataPage<Operation>
+        page: Result<DataPage<Operation>>
     ) {
         // nothing to do
     }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/SubstrateAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/SubstrateAssetHistory.kt
@@ -51,9 +51,7 @@ abstract class SubstrateAssetHistory(
                     cursorStorage.saveCursor(chain.id, chainAsset.id, accountId, cursor = null)
                 }
             }
-
     }
-
 
     override suspend fun getOperations(
         pageSize: Int,

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/SubstrateAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/SubstrateAssetHistory.kt
@@ -36,11 +36,24 @@ abstract class SubstrateAssetHistory(
         chain: Chain,
         chainAsset: Chain.Asset,
         accountId: AccountId,
-        page: DataPage<Operation>
+        pageResult: Result<DataPage<Operation>>
     ) {
-        val newCursor = page.nextOffset.asCursorOrNull()?.value
-        cursorStorage.saveCursor(chain.id, chainAsset.id, accountId, newCursor)
+        pageResult
+            .onSuccess { page ->
+                val newCursor = page.nextOffset.asCursorOrNull()?.value
+                cursorStorage.saveCursor(chain.id, chainAsset.id, accountId, newCursor)
+            }
+            .onFailure {
+                // Empty cursor means we haven't yet synced any data for this asset
+                // However we still want to store null cursor on failure to show items
+                // that came not from the remote (e.g. local pending operations)
+                if (!cursorStorage.hasCursor(chain.id, chainAsset.id, accountId)) {
+                    cursorStorage.saveCursor(chain.id, chainAsset.id, accountId, cursor = null)
+                }
+            }
+
     }
+
 
     override suspend fun getOperations(
         pageSize: Int,

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/UnsupportedAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/UnsupportedAssetHistory.kt
@@ -26,7 +26,7 @@ class UnsupportedAssetHistory : AssetHistory {
         return emptySet()
     }
 
-    override suspend fun additionalFirstPageSync(chain: Chain, chainAsset: Chain.Asset, accountId: AccountId, page: DataPage<Operation>) {
+    override suspend fun additionalFirstPageSync(chain: Chain, chainAsset: Chain.Asset, accountId: AccountId, page: Result<DataPage<Operation>>) {
         // do nothing
     }
 

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/storage/TransferCursorStorage.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/storage/TransferCursorStorage.kt
@@ -28,6 +28,13 @@ class TransferCursorStorage(
 
         preferences.putString(cursorKey(chainId, chainAssetId, accountId), toSave)
     }
+    fun hasCursor(
+        chainId: ChainId,
+        chainAssetId: Int,
+        accountId: AccountId,
+    ): Boolean {
+        return preferences.contains(cursorKey(chainId, chainAssetId, accountId))
+    }
 
     suspend fun awaitCursor(
         chainId: ChainId,

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.common.utils.emptyEthereumAccountId
 import io.novafoundation.nova.common.utils.findIsInstanceOrNull
 import io.novafoundation.nova.common.utils.formatNamed
 import io.novafoundation.nova.common.utils.substrateAccountId
+import io.novafoundation.nova.core_db.model.AssetAndChainId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.ALEPH_ZERO
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
@@ -350,3 +351,6 @@ fun Chain.findAssetByOrmlCurrencyId(runtime: RuntimeSnapshot, currencyId: Any?):
         currencyIdScale == asset.type.currencyIdScale
     }
 }
+
+val Chain.Asset.localId: AssetAndChainId
+    get() = AssetAndChainId(chainId, id)


### PR DESCRIPTION
I've also adjusted logic with subsrate cursors to save null cursor (aka full data) if page failed to sync to avoid cache page being blocked by absence cursor in case first page failed to sync on cold launch
This allows pending operations to be displayed even if first page cant be synced (currently reproduced on Kusama Asset Hub) 