### PR TITLE
Fix - false positive VoteType si mapping for Interlay

### DIFF
--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeFactory.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeFactory.kt
@@ -150,5 +150,5 @@ class RuntimeFactory(
 
     private fun fromJson(types: String): TypeDefinitionsTree = gson.fromJson(types, TypeDefinitionsTree::class.java)
 
-    private fun allSiTypeMappings() = SiTypeMapping.default() + SiVoteTypeMapping
+    private fun allSiTypeMappings() = SiTypeMapping.default() + SiVoteTypeMapping()
 }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/types/custom/vote/SiVoteTypeMapping.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/types/custom/vote/SiVoteTypeMapping.kt
@@ -1,26 +1,12 @@
 package io.novafoundation.nova.runtime.multiNetwork.runtime.types.custom.vote
 
-import jp.co.soramitsu.fearless_utils.runtime.definitions.registry.TypePresetBuilder
-import jp.co.soramitsu.fearless_utils.runtime.definitions.types.Type
-import jp.co.soramitsu.fearless_utils.runtime.definitions.v14.typeMapping.SiTypeMapping
-import jp.co.soramitsu.fearless_utils.runtime.metadata.v14.PortableType
-import jp.co.soramitsu.fearless_utils.runtime.metadata.v14.path
-import jp.co.soramitsu.fearless_utils.runtime.metadata.v14.type
-import jp.co.soramitsu.fearless_utils.scale.EncodableStruct
+import jp.co.soramitsu.fearless_utils.runtime.definitions.v14.typeMapping.ReplaceTypesSiTypeMapping
 
-object SiVoteTypeMapping : SiTypeMapping {
+fun SiVoteTypeMapping(): ReplaceTypesSiTypeMapping {
+    val voteType = VoteType("NovaWallet.ConvictionVote")
 
-    override fun map(
-        originalDefinition: EncodableStruct<PortableType>,
-        suggestedTypeName: String,
-        typesBuilder: TypePresetBuilder
-    ): Type<*>? {
-        val path = originalDefinition.type.path
-
-        return if (path.isNotEmpty() && path.last() == "Vote") {
-            VoteType(suggestedTypeName)
-        } else {
-            null
-        }
-    }
+    return ReplaceTypesSiTypeMapping(
+        "pallet_democracy.vote.Vote" to voteType,
+        "pallet_conviction_voting.vote.Vote" to voteType
+    )
 }


### PR DESCRIPTION
Interlay uses forked version of  `democracy` pallet that has custom `Vote` type that doesnt have convitction: https://github.com/interlay/interbtc/blob/94066c995907506454522e49b02180bc35692b52/crates/democracy/src/types.rs#L15
Current implement of VoteSiTypeMapping triggers on this type due to its path (not empty + last segment is "Vote")
While we dont support Interlay governance, users can use it from Dapp browser. In such case this issue prevents correct decoding of extrinsic and thus fee loading fails
Fix uses full path matching for known Vote types

#86932gf41