### PR TITLE
Fix/considering self sufficient validation

### DIFF
--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -1309,7 +1309,7 @@
     <string name="wallet_send_existential_warning_title">Перевод удалит аккаунт</string>
     <string name="wallet_send_existential_warnining_transfer_dust">Ваша учетная запись будет удалена из блокчейна после перевода, потому что общий баланс становится ниже минимального. Остаток также будет переведен получателю.</string>
     <string name="wallet_send_from_network">Из сети</string>
-    <string name="wallet_send_insufficient_balance_commission">У вас недостаточно %, чтобы оплатить комиссию и остаться выше минимального баланса</string>
+    <string name="wallet_send_insufficient_balance_commission">У вас недостаточно %s, чтобы оплатить комиссию и остаться выше минимального баланса</string>
     <string name="wallet_send_myself">Себе</string>
     <string name="wallet_send_on_chain">Внутри сети</string>
     <string name="wallet_send_phishing_warning_text">Следующий адрес: %s как известно, используется для фишинга, поэтому мы не рекомендуем отправлять токены на этот адрес. Вы все равно хотите продолжить?</string>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -613,6 +613,7 @@
     <string name="onboarding_restore_wallet">У меня уже есть кошелёк</string>
     <string name="onboarding_terms_and_conditions_1_v2_2_0">Продолжая вы соглашаетесь с нашими\nУсловиями использования и Политикой конфиденциальности</string>
     <string name="onboarding_terms_and_conditions_2">Условиями использования</string>
+    <string name="operations_swap_title">Обмен</string>
     <string name="parachain_staking_alerts_bond_more_message">Один из ваших коллаторов не генерирует награды</string>
     <string name="parachain_staking_alerts_change_collator_message">Один из ваших коллаторов не выбран в текущем раунде</string>
     <string name="parachain_staking_alerts_redeem_message">Ваш период разблокировки %s истек. Не забудьте забрать разблокированные токены</string>
@@ -1180,6 +1181,7 @@
     <string name="swap_rate_title">Курс</string>
     <string name="swap_rate_was_updated_failure_message">Старый курс: %1$s ≈ %2$s.\nНовый курс: %1$s ≈ %3$s</string>
     <string name="swap_rate_was_updated_failure_title">Обменный курс изменился</string>
+    <string name="swap_repeat_operation">Повторить операцию</string>
     <string name="swap_settings_title">Настройки обмена</string>
     <string name="swap_slippage">Проскальзывание</string>
     <string name="swap_slippage_description">Проскальзывание - распространенное явление в децентрализованной торговле, когда конечная цена сделки по обмену может незначительно отличаться от ожидаемой в связи с изменением рыночных условий.</string>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -1309,7 +1309,7 @@
     <string name="wallet_send_existential_warning_title">Перевод удалит аккаунт</string>
     <string name="wallet_send_existential_warnining_transfer_dust">Ваша учетная запись будет удалена из блокчейна после перевода, потому что общий баланс становится ниже минимального. Остаток также будет переведен получателю.</string>
     <string name="wallet_send_from_network">Из сети</string>
-    <string name="wallet_send_insufficient_balance_commission">У вас недостаточно %s для оплаты комиссии</string>
+    <string name="wallet_send_insufficient_balance_commission">У вас недостаточно %, чтобы оплатить комиссию и остаться выше минимального баланса</string>
     <string name="wallet_send_myself">Себе</string>
     <string name="wallet_send_on_chain">Внутри сети</string>
     <string name="wallet_send_phishing_warning_text">Следующий адрес: %s как известно, используется для фишинга, поэтому мы не рекомендуем отправлять токены на этот адрес. Вы все равно хотите продолжить?</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="TypographyEllipsis">
 
+    <!--<string name="wallet_send_insufficient_balance_commission">You don\'t have enough %s to pay fees</string>-->
+    <string name="wallet_send_insufficient_balance_commission">You don\'t have enough %s to pay fee and remain above minimal balance</string>
+
     <string name="operations_swap_title">Swap</string>
-    
+
     <string name="swap_repeat_operation">Repeat the operation</string>
 
     <string name="wallet_filters_swaps">Swaps</string>
@@ -1146,8 +1149,6 @@
     <string name="wallet_send_existential_warnining_transfer_dust">Your account will be removed from blockchain after transfer cause it makes total balance lower than minimal. Remaining balance will be transferred to recipient as well.</string>
     <string name="wallet_send_dead_recipient_commission_asset_title">Recipient is not able to accept transfer</string>
     <string name="wallet_send_dead_recipient_commission_asset_message">Your transfer will fail since the destination account does not have enough %s to accept other token transfers</string>
-
-    <string name="wallet_send_insufficient_balance_commission">You don\'t have enough %s to pay fees</string>
 
     <string name="common_close">Close</string>
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="TypographyEllipsis">
 
+    <string name="operations_swap_title">Swap</string>
+    
     <string name="swap_repeat_operation">Repeat the operation</string>
 
     <string name="wallet_filters_swaps">Swaps</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="TypographyEllipsis">
 
-    <!--<string name="wallet_send_insufficient_balance_commission">You don\'t have enough %s to pay fees</string>-->
     <string name="wallet_send_insufficient_balance_commission">You don\'t have enough %s to pay fee and remain above minimal balance</string>
 
     <string name="operations_swap_title">Swap</string>

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/mixin/OperationMappers.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/transaction/history/mixin/OperationMappers.kt
@@ -286,7 +286,7 @@ fun mapOperationToOperationModel(
                     amount = chainAsset.formatPlanksSigned(amount, negative = !isIncome),
                     amountColorRes = incomeTextColor(isIncome, operation.status),
                     amountDetails = mapToFiatWithTime(token, operationType.fiatAmount, formattedTime, resourceManager),
-                    header = resourceManager.getString(R.string.wallet_asset_swap),
+                    header = resourceManager.getString(R.string.operations_swap_title),
                     statusAppearance = statusAppearance,
                     subHeader = operationType.formatSubHeader(resourceManager),
                     subHeaderEllipsize = TextUtils.TruncateAt.END,

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/interactor/SwapInteractor.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/interactor/SwapInteractor.kt
@@ -31,10 +31,10 @@ import io.novafoundation.nova.feature_swap_impl.domain.validation.sufficientBala
 import io.novafoundation.nova.feature_swap_impl.domain.validation.sufficientBalanceConsideringNonSufficientAssetsValidation
 import io.novafoundation.nova.feature_swap_impl.domain.validation.sufficientBalanceInFeeAsset
 import io.novafoundation.nova.feature_swap_impl.domain.validation.sufficientBalanceInUsedAsset
-import io.novafoundation.nova.feature_swap_impl.domain.validation.sufficientBalanceToPayFeeConsideringED
 import io.novafoundation.nova.feature_swap_impl.domain.validation.swapFeeSufficientBalance
 import io.novafoundation.nova.feature_swap_impl.domain.validation.swapSmallRemainingBalance
 import io.novafoundation.nova.feature_swap_impl.domain.validation.utils.SharedQuoteValidationRetriever
+import io.novafoundation.nova.feature_swap_impl.domain.validation.validations.sufficientNativeBalanceToPayFeeConsideringED
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.AssetSourceRegistry
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.CrossChainTransfersUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletRepository
@@ -141,7 +141,7 @@ class SwapInteractor(
 
             sufficientBalanceInFeeAsset()
 
-            sufficientBalanceToPayFeeConsideringED(assetSourceRegistry)
+            sufficientNativeBalanceToPayFeeConsideringED(assetSourceRegistry, chainRegistry)
 
             availableSlippage(swapService)
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/interactor/SwapInteractor.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/interactor/SwapInteractor.kt
@@ -139,6 +139,8 @@ class SwapInteractor(
 
             positiveAmountOut()
 
+            sufficientBalanceInFeeAsset()
+
             sufficientBalanceToPayFeeConsideringED(assetSourceRegistry)
 
             availableSlippage(swapService)
@@ -150,8 +152,6 @@ class SwapInteractor(
             sufficientBalanceInUsedAsset()
 
             swapFeeSufficientBalance()
-
-            sufficientBalanceInFeeAsset()
 
             sufficientBalanceConsideringNonSufficientAssetsValidation(assetSourceRegistry)
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SufficientBalanceConsideringNonSufficientAssetsValidation.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SufficientBalanceConsideringNonSufficientAssetsValidation.kt
@@ -20,7 +20,7 @@ class SufficientBalanceConsideringNonSufficientAssetsValidation(
         val isSelfSufficientAssetOut = assetSourceRegistry.isSelfSufficientAsset(assetOut.token.configuration)
 
         if (!isSelfSufficientAssetOut && assetIn.token.configuration.isCommissionAsset) {
-            val existentialDeposit = assetSourceRegistry.existentialDepositInPlanks(value.detailedAssetIn.chain, assetOut.token.configuration)
+            val existentialDeposit = assetSourceRegistry.existentialDepositInPlanks(value.detailedAssetIn.chain, assetIn.token.configuration)
             val fee = value.swapFee.networkFee.amount
 
             return validOrError(assetIn.totalInPlanks - existentialDeposit >= amount + fee) {

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidationFailure.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidationFailure.kt
@@ -27,7 +27,7 @@ sealed class SwapValidationFailure {
 
     sealed class NotEnoughFunds : SwapValidationFailure() {
 
-        class ToStayAboveED(override val asset: Chain.Asset) : NotEnoughFunds(), InsufficientBalanceToStayAboveEDError
+        class ToPayFeeAndStayAboveED(override val asset: Chain.Asset) : NotEnoughFunds(), InsufficientBalanceToStayAboveEDError
 
         object InUsedAsset : NotEnoughFunds()
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidationFailure.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidationFailure.kt
@@ -32,11 +32,7 @@ sealed class SwapValidationFailure {
 
         object InUsedAsset : NotEnoughFunds()
 
-        class InCommissionAsset(
-            override val chainAsset: Chain.Asset,
-            override val maxUsable: BigDecimal,
-            override val fee: BigDecimal
-        ) : NotEnoughFunds(), NotEnoughToPayFeesError
+        object ToPayFee : NotEnoughFunds()
     }
 
     class AmountOutIsTooLowToStayAboveED(

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidationFailure.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidationFailure.kt
@@ -5,7 +5,6 @@ import io.novafoundation.nova.feature_swap_api.domain.model.SwapFee
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.validation.FeeChangeDetectedFailure
 import io.novafoundation.nova.feature_wallet_api.domain.validation.InsufficientBalanceToStayAboveEDError
-import io.novafoundation.nova.feature_wallet_api.domain.validation.NotEnoughToPayFeesError
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigDecimal
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidations.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidations.kt
@@ -13,11 +13,9 @@ import io.novafoundation.nova.feature_swap_impl.domain.validation.validations.Sw
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.AssetSourceRegistry
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.domain.validation.checkForFeeChanges
-import io.novafoundation.nova.feature_wallet_api.domain.validation.enoughBalanceToStayAboveEDValidation
 import io.novafoundation.nova.feature_wallet_api.domain.validation.positiveAmount
 import io.novafoundation.nova.feature_wallet_api.domain.validation.sufficientBalance
 import io.novafoundation.nova.feature_wallet_api.domain.validation.sufficientBalanceConsideringConsumersValidation
-import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import java.math.BigDecimal
 
 typealias SwapValidationSystem = ValidationSystem<SwapValidationPayload, SwapValidationFailure>

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidations.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidations.kt
@@ -87,16 +87,6 @@ fun SwapValidationSystemBuilder.sufficientAssetOutBalanceToStayAboveED(
     assetSourceRegistry: AssetSourceRegistry
 ) = sufficientAmountOutToStayAboveEDValidation(assetSourceRegistry)
 
-fun SwapValidationSystemBuilder.sufficientBalanceToPayFeeConsideringED(
-    assetSourceRegistry: AssetSourceRegistry
-) = enoughBalanceToStayAboveEDValidation(
-    assetSourceRegistry,
-    fee = { it.feeAsset.token.amountFromPlanks(it.swapFee.networkFee.amount) },
-    balance = { it.feeAsset.free },
-    chainWithAsset = { ChainWithAsset(it.detailedAssetIn.chain, it.feeAsset.token.configuration) },
-    error = { payload, _ -> SwapValidationFailure.NotEnoughFunds.ToStayAboveED(payload.feeAsset.token.configuration) }
-)
-
 fun SwapValidationSystemBuilder.checkForFeeChanges(
     swapService: SwapService
 ) = checkForFeeChanges(

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidations.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidations.kt
@@ -71,13 +71,7 @@ fun SwapValidationSystemBuilder.sufficientBalanceInFeeAsset() = sufficientBalanc
     available = { it.feeAsset.transferable },
     amount = { BigDecimal.ZERO },
     fee = { it.feeAsset.token.amountFromPlanks(it.swapFee.networkFee.amount) },
-    error = { payload, availableToPayFees ->
-        SwapValidationFailure.NotEnoughFunds.InCommissionAsset(
-            chainAsset = payload.feeAsset.token.configuration,
-            fee = payload.feeAsset.token.amountFromPlanks(payload.swapFee.networkFee.amount),
-            maxUsable = availableToPayFees
-        )
-    }
+    error = { _, _ -> SwapValidationFailure.NotEnoughFunds.ToPayFee }
 )
 
 fun SwapValidationSystemBuilder.sufficientBalanceInUsedAsset() = sufficientBalance(

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/EnoughNativeAssetBalanceToPayFeeConsideringEDValidation.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/EnoughNativeAssetBalanceToPayFeeConsideringEDValidation.kt
@@ -1,0 +1,46 @@
+package io.novafoundation.nova.feature_swap_impl.domain.validation.validations
+
+import io.novafoundation.nova.common.validation.ValidationStatus
+import io.novafoundation.nova.common.validation.valid
+import io.novafoundation.nova.common.validation.validOrError
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidation
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NotEnoughFunds
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationPayload
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationSystemBuilder
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.AssetSourceRegistry
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.existentialDepositInPlanks
+import io.novafoundation.nova.runtime.ext.isCommissionAsset
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+
+class EnoughNativeAssetBalanceToPayFeeConsideringEDValidation(
+    private val assetSourceRegistry: AssetSourceRegistry,
+    private val chainRegistry: ChainRegistry
+) : SwapValidation {
+
+    override suspend fun validate(value: SwapValidationPayload): ValidationStatus<SwapValidationFailure> {
+        val feeChainAsset = value.feeAsset.token.configuration
+
+        if (feeChainAsset.isCommissionAsset) {
+            val chain = chainRegistry.getChain(feeChainAsset.chainId)
+            val existentialDeposit = assetSourceRegistry.existentialDepositInPlanks(chain, feeChainAsset)
+            return validOrError(value.feeAsset.freeInPlanks - value.swapFee.networkFee.amount >= existentialDeposit) {
+                NotEnoughFunds.ToPayFeeAndStayAboveED(value.feeAsset.token.configuration)
+            }
+        }
+
+        return valid()
+    }
+}
+
+fun SwapValidationSystemBuilder.sufficientNativeBalanceToPayFeeConsideringED(
+    assetSourceRegistry: AssetSourceRegistry,
+    chainRegistry: ChainRegistry
+) {
+    validate(
+        EnoughNativeAssetBalanceToPayFeeConsideringEDValidation(
+            assetSourceRegistry = assetSourceRegistry,
+            chainRegistry = chainRegistry
+        )
+    )
+}

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
@@ -41,7 +41,7 @@ fun CoroutineScope.mapSwapValidationFailureToUI(
     amountOutSwapMinAction: (Chain.Asset, Balance) -> Unit
 ): TransformedFailure? {
     return when (val reason = status.reason) {
-        is NotEnoughFunds.ToStayAboveED -> handleInsufficientBalanceCommission(reason, resourceManager).asDefault()
+        is NotEnoughFunds.ToPayFeeAndStayAboveED -> handleInsufficientBalanceCommission(reason, resourceManager).asDefault()
 
         NotEnoughFunds.InUsedAsset -> resourceManager.amountIsTooBig().asDefault()
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
@@ -23,6 +23,7 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Ba
 import io.novafoundation.nova.feature_wallet_api.domain.validation.amountIsTooBig
 import io.novafoundation.nova.feature_wallet_api.domain.validation.handleFeeSpikeDetected
 import io.novafoundation.nova.feature_wallet_api.domain.validation.handleNotEnoughFeeError
+import io.novafoundation.nova.feature_wallet_api.domain.validation.notSufficientBalanceToPayFeeErrorMessage
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.validation.handleInsufficientBalanceCommission
@@ -45,7 +46,7 @@ fun CoroutineScope.mapSwapValidationFailureToUI(
 
         NotEnoughFunds.InUsedAsset -> resourceManager.amountIsTooBig().asDefault()
 
-        is NotEnoughFunds.InCommissionAsset -> handleNotEnoughFeeError(reason, resourceManager).asDefault()
+        NotEnoughFunds.ToPayFee -> resourceManager.notSufficientBalanceToPayFeeErrorMessage().asDefault()
 
         InvalidSlippage -> TitleAndMessage(
             resourceManager.getString(R.string.swap_invalid_slippage_failure_title),

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
@@ -22,7 +22,6 @@ import io.novafoundation.nova.feature_wallet_api.R
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.validation.amountIsTooBig
 import io.novafoundation.nova.feature_wallet_api.domain.validation.handleFeeSpikeDetected
-import io.novafoundation.nova.feature_wallet_api.domain.validation.handleNotEnoughFeeError
 import io.novafoundation.nova.feature_wallet_api.domain.validation.notSufficientBalanceToPayFeeErrorMessage
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixinFactory.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixinFactory.kt
@@ -58,8 +58,7 @@ private class RealSwapAmountInputMixin(
     maxActionProvider = maxActionProvider,
     fiatFormatter = fiatFormatter,
     fieldValidator = fieldValidator
-),
-    SwapAmountInputMixin.Presentation {
+), SwapAmountInputMixin.Presentation {
 
     override val assetModel: Flow<SwapInputAssetModel> = tokenFlow.map {
         val chainAsset = it?.configuration

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixinFactory.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/input/SwapAmountInputMixinFactory.kt
@@ -58,7 +58,8 @@ private class RealSwapAmountInputMixin(
     maxActionProvider = maxActionProvider,
     fiatFormatter = fiatFormatter,
     fieldValidator = fieldValidator
-), SwapAmountInputMixin.Presentation {
+),
+    SwapAmountInputMixin.Presentation {
 
     override val assetModel: Flow<SwapInputAssetModel> = tokenFlow.map {
         val chainAsset = it?.configuration


### PR DESCRIPTION
#869347jdh
- Fixed swap localization for operations
- Fixed validation which should consider minimal balance if we send tokens to non sufficient asset
- Fixed validation text that for feeAsset.transferable > fee + ed
- Fixed validation text that for feeAsset.transferable > fee 
Old text: You can use up to %s since you need to pay\n%s for network fee.
New one: Sorry, you don\'t have enough funds to pay the network fee.