### PR TITLE
Fix/nft sync

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/di/modules/NetworkModule.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/di/modules/NetworkModule.kt
@@ -35,6 +35,8 @@ private const val HTTP_CACHE = "http_cache"
 private const val CACHE_SIZE = 50L * 1024L * 1024L // 50 MiB
 private const val TIMEOUT_SECONDS = 20L
 
+private const val SOCKET_CONNECTION_TIMEOUT = 5_000
+
 @Module
 class NetworkModule {
 
@@ -103,7 +105,9 @@ class NetworkModule {
 
     @Provides
     @ApplicationScope
-    fun provideSocketFactory() = WebSocketFactory()
+    fun provideSocketFactory() = WebSocketFactory().apply {
+        connectionTimeout = SOCKET_CONNECTION_TIMEOUT
+    }
 
     @Provides
     fun provideReconnector() = Reconnector()

--- a/common/src/main/java/io/novafoundation/nova/common/presentation/LoadingState.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/presentation/LoadingState.kt
@@ -55,4 +55,7 @@ val <T> LoadingState<T>.dataOrNull: T?
         else -> null
     }
 
+val LoadingState<*>.isLoading: Boolean
+    get() = this is LoadingState.Loading
+
 suspend inline fun <reified T> Flow<LoadingState<T>>.firstLoaded(): T = first { it.dataOrNull != null }.dataOrNull as T

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/domain/assets/list/AssetsListInteractor.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/domain/assets/list/AssetsListInteractor.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_assets.domain.assets.list
 import io.novafoundation.nova.common.data.repository.BannerVisibilityRepository
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_nft_api.data.model.Nft
+import io.novafoundation.nova.feature_nft_api.data.model.isFullySynced
 import io.novafoundation.nova.feature_nft_api.data.repository.NftRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
@@ -25,7 +26,7 @@ class AssetsListInteractor(
             .map { nfts ->
                 NftPreviews(
                     totalNftsCount = nfts.size,
-                    nftPreviews = nfts.take(PREVIEW_COUNT)
+                    nftPreviews = nfts.sortedBy { it.isFullySynced }.take(PREVIEW_COUNT)
                 )
             }
     }

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/BalanceListViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/BalanceListViewModel.kt
@@ -191,6 +191,7 @@ class BalanceListViewModel(
 
         walletInteractor.nftSyncTrigger()
             .onEach { trigger -> walletInteractor.syncChainNfts(selectedMetaAccount.first(), trigger.chain) }
+            .launchIn(viewModelScope)
     }
 
     fun fullSync() {

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/GoToNftsView.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/view/GoToNftsView.kt
@@ -6,14 +6,15 @@ import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import coil.ImageLoader
 import coil.load
-import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.presentation.LoadingState
 import io.novafoundation.nova.common.presentation.dataOrNull
+import io.novafoundation.nova.common.presentation.isLoading
 import io.novafoundation.nova.common.utils.WithContextExtensions
 import io.novafoundation.nova.common.utils.makeGone
 import io.novafoundation.nova.common.utils.makeVisible
 import io.novafoundation.nova.common.utils.setVisible
+import io.novafoundation.nova.feature_assets.R
 import io.novafoundation.nova.feature_assets.di.AssetsFeatureApi
 import io.novafoundation.nova.feature_assets.di.AssetsFeatureComponent
 import io.novafoundation.nova.feature_assets.presentation.balance.list.model.NftPreviewUi
@@ -21,11 +22,11 @@ import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftCounter
 import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftPreview1
 import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftPreview2
 import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftPreview3
-import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftsShimmer
-import javax.inject.Inject
 import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftPreviewHolder1
 import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftPreviewHolder2
 import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftPreviewHolder3
+import kotlinx.android.synthetic.main.view_go_to_nfts.view.goToNftsShimmer
+import javax.inject.Inject
 
 class GoToNftsView @JvmOverloads constructor(
     context: Context,
@@ -62,7 +63,8 @@ class GoToNftsView @JvmOverloads constructor(
     }
 
     fun setPreviews(previews: List<NftPreviewUi>?) {
-        val shouldShowLoading = previews == null || previews.any { it is LoadingState.Loading }
+        setVisible(previews != null && previews.isNotEmpty())
+        val shouldShowLoading = previews == null || previews.all { it is LoadingState.Loading }
 
         if (shouldShowLoading) {
             previewHolders.forEach(View::makeGone)
@@ -70,12 +72,10 @@ class GoToNftsView @JvmOverloads constructor(
         } else {
             goToNftsShimmer.makeGone()
 
-            setVisible(previews!!.isNotEmpty())
-
             previewHolders.forEachIndexed { index, view ->
-                val previewContent = previews.getOrNull(index)
+                val previewContent = previews!!.getOrNull(index)
 
-                if (previewContent == null) { // no such element
+                if (previewContent == null || previewContent.isLoading) {
                     view.makeGone()
                 } else {
                     view.makeVisible()

--- a/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/data/repository/NftRepositoryImpl.kt
+++ b/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/data/repository/NftRepositoryImpl.kt
@@ -25,8 +25,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -65,8 +63,7 @@ class NftRepositoryImpl(
     override fun initialNftSyncTrigger(): Flow<NftSyncTrigger> {
         return chainRegistry.currentChains
             .map { chains -> chains.filter { nftProvidersRegistry.nftSupported(it) } }
-            .transformLatestDiffed { emitAll(flowOf(NftSyncTrigger(it))) }
-            .flowOn(Dispatchers.Default)
+            .transformLatestDiffed { emit(NftSyncTrigger(it)) }
     }
 
     override suspend fun initialNftSync(

--- a/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/data/source/providers/uniques/UniquesNftProvider.kt
+++ b/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/data/source/providers/uniques/UniquesNftProvider.kt
@@ -17,7 +17,6 @@ import io.novafoundation.nova.feature_nft_impl.data.mappers.nftIssuance
 import io.novafoundation.nova.feature_nft_impl.data.network.distributed.FileStorageAdapter.adoptFileStorageLinkToHttps
 import io.novafoundation.nova.feature_nft_impl.data.source.NftProvider
 import io.novafoundation.nova.feature_nft_impl.data.source.providers.uniques.network.IpfsApi
-import io.novafoundation.nova.runtime.ext.isFullSync
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
@@ -40,7 +39,6 @@ class UniquesNftProvider(
     override val requireFullChainSync: Boolean = true
 
     override suspend fun initialNftsSync(chain: Chain, metaAccount: MetaAccount, forceOverwrite: Boolean) {
-        if (chain.connectionState.isFullSync) return
         val accountId = metaAccount.accountIdIn(chain) ?: return
 
         val newNfts = remoteStorage.query(chain.id) {

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/ChainRegistry.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/ChainRegistry.kt
@@ -137,7 +137,7 @@ class ChainRegistry(
         }
     }
 
-    private suspend fun awaitConnectionStateIsAtLeast(chainId: ChainId, state: ConnectionState): Unit {
+    private suspend fun awaitConnectionStateIsAtLeast(chainId: ChainId, state: ConnectionState) {
         chainsById
             .mapNotNull { chainsById -> chainsById[chainId] }
             .first { it.connectionState.level >= state.level }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/connection/ChainConnection.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/connection/ChainConnection.kt
@@ -146,7 +146,7 @@ class ChainConnection internal constructor(
         }
     }
 
-    private fun State.needsAutobalance() = this is State.WaitingForReconnect && attempt > 3
+    private fun State.needsAutobalance() = this is State.WaitingForReconnect && attempt > 1
     override fun onRpcResponseReceived(rpcResponse: RpcResponse): ResponseDelivery {
         val error = rpcResponse.error
 

--- a/runtime/src/test/java/io/novafoundation/nova/runtime/multiNetwork/chain/ChainSyncServiceTest.kt
+++ b/runtime/src/test/java/io/novafoundation/nova/runtime/multiNetwork/chain/ChainSyncServiceTest.kt
@@ -311,7 +311,7 @@ class ChainSyncServiceTest {
     private fun removesTransferApiByUrl(url: String) = removesElement<ChainExternalApiLocal> { it.url == url }
 
     private fun createLocalCopy(remote: ChainRemote): JoinedChainInfo {
-        val domain = mapRemoteChainToLocal(remote, gson)
+        val domain = mapRemoteChainToLocal(remote, oldChain = null, gson)
         val assets = remote.assets.map { mapRemoteAssetToLocal(remote, it, gson, true) }
         val nodes = mapRemoteNodesToLocal(remote)
         val explorers = mapRemoteExplorersToLocal(remote)


### PR DESCRIPTION
* Introduce ws connection of 5 seconds - currently it will hang almost indefenetely causing long wait for reconnect attempt
* Reduce required number of attempts for node swtch from 4 to 2
* Show loaded nft previews even if not all of preview candidates were loaded
* Fix concurrent emission error in `transformLatestDiffer`
* Fix - nft sync trigger doesnt trigger

#8693angnp