### PR TITLE
Proxy/fee validation

### DIFF
--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/extrinsic/ExtrinsicService.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/extrinsic/ExtrinsicService.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.Tran
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicStatus
 import io.novafoundation.nova.runtime.extrinsic.multi.CallBuilder
+import io.novafoundation.nova.runtime.extrinsic.signer.FeeSigner
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import jp.co.soramitsu.fearless_utils.runtime.extrinsic.ExtrinsicBuilder
@@ -70,11 +71,17 @@ interface ExtrinsicService {
         formExtrinsic: suspend ExtrinsicBuilder.() -> Unit,
     ): Fee
 
+    suspend fun zeroFee(chain: Chain, origin: TransactionOrigin): Fee
+
     suspend fun estimateMultiFee(
         chain: Chain,
         origin: TransactionOrigin,
         formExtrinsic: FormMultiExtrinsic,
     ): Fee
 
-    suspend fun estimateFee(chain: Chain, extrinsic: String): Fee
+    suspend fun estimateFee(
+        chain: Chain,
+        extrinsic: String,
+        usedSigner: FeeSigner
+    ): Fee
 }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/model/Fee.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/model/Fee.kt
@@ -28,7 +28,6 @@ class SubstrateFee(
     override val submissionOrigin: SubmissionOrigin
 ) : Fee
 
-
 val Fee.requestedAccountPaysFees: Boolean
     get() = submissionOrigin.requestedOrigin.contentEquals(submissionOrigin.actualOrigin)
 

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/model/Fee.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/model/Fee.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_account_api.data.model
 
+import io.novafoundation.nova.feature_account_api.data.extrinsic.SubmissionOrigin
 import java.math.BigInteger
 
 interface Fee {
@@ -7,13 +8,33 @@ interface Fee {
     companion object
 
     val amount: BigInteger
+
+    /**
+     * Information about origin that is supposed to send the transaction fee was calculated against
+     */
+    val submissionOrigin: SubmissionOrigin
 }
 
-data class EvmFee(val gasLimit: BigInteger, val gasPrice: BigInteger) : Fee {
+data class EvmFee(
+    val gasLimit: BigInteger,
+    val gasPrice: BigInteger,
+    override val submissionOrigin: SubmissionOrigin
+) : Fee {
     override val amount = gasLimit * gasPrice
 }
 
-@JvmInline
-value class InlineFee(override val amount: BigInteger) : Fee
+class SubstrateFee(
+    override val amount: BigInteger,
+    override val submissionOrigin: SubmissionOrigin
+) : Fee
 
-fun Fee.Companion.zero(): Fee = InlineFee(BigInteger.ZERO)
+
+val Fee.requestedAccountPaysFees: Boolean
+    get() = submissionOrigin.requestedOrigin.contentEquals(submissionOrigin.actualOrigin)
+
+val Fee.amountByRequestedAccount: BigInteger
+    get() = if (requestedAccountPaysFees) {
+        amount
+    } else {
+        BigInteger.ZERO
+    }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/signer/SignerProvider.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/signer/SignerProvider.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_account_api.data.signer
 
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.runtime.extrinsic.signer.FeeSigner
 import io.novafoundation.nova.runtime.extrinsic.signer.NovaSigner
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 
@@ -8,5 +9,5 @@ interface SignerProvider {
 
     fun signerFor(metaAccount: MetaAccount): NovaSigner
 
-    fun feeSigner(metaAccount: MetaAccount, chain: Chain): NovaSigner
+    fun feeSigner(metaAccount: MetaAccount, chain: Chain): FeeSigner
 }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
@@ -185,10 +185,6 @@ private fun MultiChainEncryption.Companion.substrateFrom(cryptoType: CryptoType)
 
 fun MetaAccount.chainAccountFor(chainId: ChainId) = chainAccounts.getValue(chainId)
 
-fun LightMetaAccount.Type.isPolkadotVaultLike(): Boolean {
-    return asPolkadotVaultVariantOrNull() != null
-}
-
 fun LightMetaAccount.Type.asPolkadotVaultVariantOrNull(): PolkadotVaultVariant? {
     return when (this) {
         LightMetaAccount.Type.PARITY_SIGNER -> PolkadotVaultVariant.PARITY_SIGNER
@@ -200,5 +196,17 @@ fun LightMetaAccount.Type.asPolkadotVaultVariantOrNull(): PolkadotVaultVariant? 
 fun LightMetaAccount.Type.asPolkadotVaultVariantOrThrow(): PolkadotVaultVariant {
     return requireNotNull(asPolkadotVaultVariantOrNull()) {
         "Not a Polkadot Vault compatible account type"
+    }
+}
+
+fun LightMetaAccount.Type.requestedAccountPaysFees(): Boolean {
+    return when(this) {
+        LightMetaAccount.Type.SECRETS,
+        LightMetaAccount.Type.WATCH_ONLY,
+        LightMetaAccount.Type.PARITY_SIGNER,
+        LightMetaAccount.Type.LEDGER,
+        LightMetaAccount.Type.POLKADOT_VAULT -> true
+
+        LightMetaAccount.Type.PROXIED -> false
     }
 }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
@@ -200,7 +200,7 @@ fun LightMetaAccount.Type.asPolkadotVaultVariantOrThrow(): PolkadotVaultVariant 
 }
 
 fun LightMetaAccount.Type.requestedAccountPaysFees(): Boolean {
-    return when(this) {
+    return when (this) {
         LightMetaAccount.Type.SECRETS,
         LightMetaAccount.Type.WATCH_ONLY,
         LightMetaAccount.Type.PARITY_SIGNER,

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/ethereum/transaction/RealEvmTransactionService.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/ethereum/transaction/RealEvmTransactionService.kt
@@ -60,7 +60,7 @@ internal class RealEvmTransactionService(
         val gasPrice = gasPriceProviderFactory.createKnown(chainId).getGasPrice()
         val gasLimit = web3Api.gasLimitOrDefault(txForFee, fallbackGasLimit)
 
-        return EvmFee(gasLimit, gasPrice)
+        return EvmFee(gasLimit, gasPrice, SubmissionOrigin.singleOrigin(submittingMetaAccount.requireAccountIdIn(chain)))
     }
 
     override suspend fun transact(
@@ -83,7 +83,7 @@ internal class RealEvmTransactionService(
             val gasPrice = gasPriceProviderFactory.createKnown(chainId).getGasPrice()
             val gasLimit = web3Api.gasLimitOrDefault(txForFee, fallbackGasLimit)
 
-            EvmFee(gasLimit, gasPrice)
+            EvmFee(gasLimit, gasPrice, SubmissionOrigin.singleOrigin(submittingAccountId))
         }
 
         val nonce = web3Api.getNonce(submittingAddress)

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/proxy/RealProxySyncService.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/proxy/RealProxySyncService.kt
@@ -40,12 +40,20 @@ class RealProxySyncService(
         val metaAccounts = getMetaAccounts()
         if (metaAccounts.isEmpty()) return
 
+        Log.d("RX", "Started syncing proxies")
+
         runCatching {
             val supportedProxyChains = getSupportedProxyChains()
+            Log.d("RX", "Proxy chains: ${supportedProxyChains.joinToString { it.name }}")
+
             val chainsToAccountIds = supportedProxyChains.associateWith { chain -> chain.getAvailableAccountIds(metaAccounts) }
 
             val proxiedsWithProxies = chainsToAccountIds.flatMap { (chain, accountIds) ->
-                proxyRepository.getAllProxiesForMetaAccounts(chain.id, accountIds)
+                Log.d("RX", "Started syncing proxies for ${chain.name}")
+
+                proxyRepository.getAllProxiesForMetaAccounts(chain.id, accountIds).also {
+                    Log.d("RX", "Done syncing for ${chain.name}")
+                }
             }
 
             val oldProxies = accountDao.getAllProxyAccounts()
@@ -100,7 +108,7 @@ class RealProxySyncService(
             .map { it.proxiedMetaId }
     }
 
-    private suspend fun getProxiedsToRemove(
+    private suspend fun getPedsToRemove(
         oldProxies: List<ProxyAccountLocal>,
         proxiedsMetaAccounts: List<MetaAccountLocal>
     ): List<Long> {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/proxy/RealProxySyncService.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/proxy/RealProxySyncService.kt
@@ -40,20 +40,13 @@ class RealProxySyncService(
         val metaAccounts = getMetaAccounts()
         if (metaAccounts.isEmpty()) return
 
-        Log.d("RX", "Started syncing proxies")
-
         runCatching {
             val supportedProxyChains = getSupportedProxyChains()
-            Log.d("RX", "Proxy chains: ${supportedProxyChains.joinToString { it.name }}")
 
             val chainsToAccountIds = supportedProxyChains.associateWith { chain -> chain.getAvailableAccountIds(metaAccounts) }
 
             val proxiedsWithProxies = chainsToAccountIds.flatMap { (chain, accountIds) ->
-                Log.d("RX", "Started syncing proxies for ${chain.name}")
-
-                proxyRepository.getAllProxiesForMetaAccounts(chain.id, accountIds).also {
-                    Log.d("RX", "Done syncing for ${chain.name}")
-                }
+                proxyRepository.getAllProxiesForMetaAccounts(chain.id, accountIds)
             }
 
             val oldProxies = accountDao.getAllProxyAccounts()

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/RealSignerProvider.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/RealSignerProvider.kt
@@ -9,7 +9,7 @@ import io.novafoundation.nova.feature_account_impl.data.signer.proxy.ProxiedFeeS
 import io.novafoundation.nova.feature_account_impl.data.signer.proxy.ProxiedSignerFactory
 import io.novafoundation.nova.feature_account_impl.data.signer.secrets.SecretsSignerFactory
 import io.novafoundation.nova.feature_account_impl.data.signer.watchOnly.WatchOnlySignerFactory
-import io.novafoundation.nova.runtime.extrinsic.signer.DefaultFeeSigner
+import io.novafoundation.nova.runtime.extrinsic.signer.FeeSigner
 import io.novafoundation.nova.runtime.extrinsic.signer.NovaSigner
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 
@@ -33,13 +33,13 @@ internal class RealSignerProvider(
         }
     }
 
-    override fun feeSigner(metaAccount: MetaAccount, chain: Chain): NovaSigner {
+    override fun feeSigner(metaAccount: MetaAccount, chain: Chain): FeeSigner {
         return when (metaAccount.type) {
             LightMetaAccount.Type.SECRETS,
             LightMetaAccount.Type.WATCH_ONLY,
             LightMetaAccount.Type.PARITY_SIGNER,
             LightMetaAccount.Type.POLKADOT_VAULT,
-            LightMetaAccount.Type.LEDGER -> DefaultFeeSigner(chain)
+            LightMetaAccount.Type.LEDGER -> DefaultFeeSigner(metaAccount, chain)
 
             LightMetaAccount.Type.PROXIED -> proxiedFeeSignerFactory.create(metaAccount, chain, this)
         }

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/domain/send/SendInteractor.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/domain/send/SendInteractor.kt
@@ -1,8 +1,11 @@
 package io.novafoundation.nova.feature_assets.domain.send
 
 import io.novafoundation.nova.common.utils.orZero
+import io.novafoundation.nova.feature_account_api.data.extrinsic.SubmissionOrigin
 import io.novafoundation.nova.feature_account_api.data.model.Fee
-import io.novafoundation.nova.feature_account_api.data.model.InlineFee
+import io.novafoundation.nova.feature_account_api.data.model.SubstrateFee
+import io.novafoundation.nova.feature_account_api.data.model.amountByRequestedAccount
+import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.AssetSourceRegistry
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransfer
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.WeightedAssetTransfer
@@ -14,13 +17,12 @@ import io.novafoundation.nova.feature_wallet_api.domain.implementations.transfer
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletRepository
 import io.novafoundation.nova.feature_wallet_api.domain.model.CrossChainTransfersConfiguration
 import io.novafoundation.nova.feature_wallet_api.domain.model.RecipientSearchResult
-import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.repository.ParachainInfoRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.math.BigDecimal
 
 class SendInteractor(
     private val walletRepository: WalletRepository,
@@ -78,25 +80,29 @@ class SendInteractor(
             crossChainFee.reserve.orZero() + crossChainFee.destination.orZero()
         }
 
-        InlineFee(feePlanks)
+        val submissionOriginId = transfer.sender.requireAccountIdIn(transfer.originChain)
+        val submissionOrigin = SubmissionOrigin.singleOrigin(submissionOriginId) // cross-chain fee is always paid by requested account id
+
+        SubstrateFee(feePlanks, submissionOrigin)
     } else {
         null
     }
 
     suspend fun performTransfer(
         transfer: WeightedAssetTransfer,
-        originFee: BigDecimal,
-        crossChainFee: BigDecimal?,
+        originFee: DecimalFee,
+        crossChainFee: DecimalFee?,
     ): Result<*> = withContext(Dispatchers.Default) {
         if (transfer.isCrossChain) {
-            val crossChainFeePlanks = transfer.originChainAsset.planksFromAmount(crossChainFee!!)
+            val crossChainFeePlanks = crossChainFee!!.networkFee.amountByRequestedAccount
             val config = crossChainTransfersRepository.getConfiguration().configurationFor(transfer)!!
 
             crossChainTransactor.performTransfer(config, transfer, crossChainFeePlanks)
         } else {
             getAssetTransfers(transfer).performTransfer(transfer)
                 .onSuccess { submission ->
-                    walletRepository.insertPendingTransfer(submission.hash, transfer, originFee)
+                    // Insert used fee regardless of who paid it
+                    walletRepository.insertPendingTransfer(submission.hash, transfer, originFee.networkFeeDecimalAmount)
                 }
         }
     }

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/TransferDraft.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/TransferDraft.kt
@@ -10,7 +10,7 @@ import java.math.BigDecimal
 class TransferDraft(
     val amount: BigDecimal,
     val originFee: FeeParcelModel,
-    val crossChainFee: BigDecimal?,
+    val crossChainFee: FeeParcelModel?,
     val origin: AssetPayload,
     val destination: AssetPayload,
     val recipientAddress: String,

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/amount/SelectSendViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/amount/SelectSendViewModel.kt
@@ -190,8 +190,8 @@ class SelectSendViewModel(
                 assetTransfer = transfer,
                 fee = originFee,
             ),
-            crossChainFee = crossChainFee?.networkFeeDecimalAmount,
-            originFee = originFee.networkFeeDecimalAmount,
+            crossChainFee = crossChainFee,
+            originFee = originFee,
             originCommissionAsset = commissionAssetFlow.first(),
             originUsedAsset = originAssetFlow.first()
         )
@@ -334,7 +334,7 @@ class SelectSendViewModel(
                 chainAssetId = validPayload.transfer.destinationChainAsset.id
             ),
             recipientAddress = validPayload.transfer.recipient,
-            crossChainFee = validPayload.crossChainFee,
+            crossChainFee = validPayload.crossChainFee?.let(::mapFeeToParcel),
             openAssetDetailsOnCompletion = payload is SendPayload.SpecifiedOrigin
         )
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmSendViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmSendViewModel.kt
@@ -186,8 +186,8 @@ class ConfirmSendViewModel(
     }
 
     private fun setInitialState() = launch {
-        originFeeMixin.setFee(originFee.networkFee)
-        crossChainFeeMixin.setFee(crossChainFee?.networkFee)
+        originFeeMixin.setFee(originFee.genericFee)
+        crossChainFeeMixin.setFee(crossChainFee?.genericFee)
     }
 
     private suspend fun createAddressModel(

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/di/validations/ContributeValidationsModule.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/di/validations/ContributeValidationsModule.kt
@@ -28,7 +28,7 @@ class ContributeValidationsModule {
         feeExtractor = { it.fee },
         availableBalanceProducer = { it.asset.transferable },
         extraAmountExtractor = { it.contributionAmount },
-        errorProducer = { _, _ -> ContributeValidationFailure.CannotPayFees }
+        errorProducer = { ContributeValidationFailure.CannotPayFees }
     )
 
     @Provides

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/di/validations/MoonbeamTermsValidationsModule.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/di/validations/MoonbeamTermsValidationsModule.kt
@@ -19,7 +19,7 @@ class MoonbeamTermsValidationsModule {
     fun provideFeesValidation(): MoonbeamTermsValidation = MoonbeamTermsFeeValidation(
         feeExtractor = { it.fee },
         availableBalanceProducer = { it.asset.transferable },
-        errorProducer = { _, _ -> MoonbeamTermsValidationFailure.CANNOT_PAY_FEES }
+        errorProducer = { MoonbeamTermsValidationFailure.CANNOT_PAY_FEES }
     )
 
     @Provides

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/contribute/validations/ContributeValidationPayload.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/contribute/validations/ContributeValidationPayload.kt
@@ -4,13 +4,14 @@ import android.os.Parcelable
 import io.novafoundation.nova.feature_crowdloan_impl.domain.main.Crowdloan
 import io.novafoundation.nova.feature_crowdloan_impl.presentation.contribute.custom.BonusPayload
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 class ContributeValidationPayload(
     val crowdloan: Crowdloan,
     val customizationPayload: Parcelable?,
     val asset: Asset,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val bonusPayload: BonusPayload?,
     val contributionAmount: BigDecimal,
 )

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/contribute/validations/custom/moonbeam/MoonbeamTermsPayload.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/domain/contribute/validations/custom/moonbeam/MoonbeamTermsPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_crowdloan_impl.domain.contribute.validations.custom.moonbeam
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class MoonbeamTermsPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset
 )

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/confirm/ConfirmContributeViewModel.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/confirm/ConfirmContributeViewModel.kt
@@ -33,6 +33,7 @@ import io.novafoundation.nova.feature_wallet_api.data.mappers.mapAssetToAssetMod
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.runtime.state.SingleAssetSharedState
 import io.novafoundation.nova.runtime.state.chain
 import kotlinx.coroutines.flow.Flow
@@ -58,6 +59,8 @@ class ConfirmContributeViewModel(
     Validatable by validationExecutor,
     ExternalActions by externalActions {
 
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
     private val chain by lazyAsync { assetSharedState.chain() }
 
     override val openBrowserEvent = MutableLiveData<Event<String>>()
@@ -82,7 +85,7 @@ class ConfirmContributeViewModel(
     val selectedAmount = payload.amount.toString()
 
     val feeFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(payload.fee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.genericFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }
@@ -161,7 +164,7 @@ class ConfirmContributeViewModel(
     private fun maybeGoToNext() = launch {
         val validationPayload = ContributeValidationPayload(
             crowdloan = crowdloanFlow.first(),
-            fee = payload.fee,
+            fee = decimalFee,
             asset = assetFlow.first(),
             customizationPayload = payload.customizationPayload,
             bonusPayload = payload.bonusPayload,

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/confirm/parcel/ConfirmContributePayload.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/confirm/parcel/ConfirmContributePayload.kt
@@ -4,13 +4,14 @@ import android.os.Parcelable
 import io.novafoundation.nova.common.data.network.runtime.binding.ParaId
 import io.novafoundation.nova.feature_crowdloan_impl.presentation.contribute.custom.BonusPayload
 import io.novafoundation.nova.feature_crowdloan_impl.presentation.contribute.select.parcel.ParachainMetadataParcelModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
 
 @Parcelize
 class ConfirmContributePayload(
     val paraId: ParaId,
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
     val amount: BigDecimal,
     val bonusPayload: BonusPayload?,
     val customizationPayload: Parcelable?,

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/custom/moonbeam/terms/MoonbeamCrowdloanTermsViewModel.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/custom/moonbeam/terms/MoonbeamCrowdloanTermsViewModel.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import java.math.BigDecimal
 
 sealed class SubmitActionState {
     object Loading : SubmitActionState()

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/custom/moonbeam/terms/MoonbeamCrowdloanTermsViewModel.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/custom/moonbeam/terms/MoonbeamCrowdloanTermsViewModel.kt
@@ -20,6 +20,8 @@ import io.novafoundation.nova.feature_crowdloan_impl.presentation.contribute.sel
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.getCurrentAsset
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -93,13 +95,15 @@ class MoonbeamCrowdloanTermsViewModel(
         openBrowserEvent.value = Event(interactor.getTermsLink())
     }
 
-    fun submitClicked() = requireFee { fee ->
+    fun submitClicked() = launch {
         submittingInProgressFlow.value = true
+
+        val fee = feeLoaderMixin.awaitDecimalFee()
 
         submitAfterValidation(fee)
     }
 
-    private fun submitAfterValidation(fee: BigDecimal) = launch {
+    private fun submitAfterValidation(fee: DecimalFee) = launch {
         val validationPayload = MoonbeamTermsPayload(
             fee = fee,
             asset = assetUseCase.getCurrentAsset()
@@ -132,9 +136,4 @@ class MoonbeamCrowdloanTermsViewModel(
             onRetryCancelled = ::backClicked
         )
     }
-
-    private fun requireFee(block: (BigDecimal) -> Unit) = feeLoaderMixin.requireFee(
-        block,
-        onError = { title, message -> showError(title, message) }
-    )
 }

--- a/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/domain/sign/polkadot/PolkadotExternalSignInteractor.kt
+++ b/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/domain/sign/polkadot/PolkadotExternalSignInteractor.kt
@@ -28,6 +28,8 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.Token
 import io.novafoundation.nova.runtime.ext.accountIdOf
 import io.novafoundation.nova.runtime.ext.utilityAsset
 import io.novafoundation.nova.runtime.extrinsic.CustomSignedExtensions
+import io.novafoundation.nova.runtime.extrinsic.signer.FeeSigner
+import io.novafoundation.nova.runtime.extrinsic.signer.NovaSigner
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.getChainOrNull
@@ -145,7 +147,8 @@ class PolkadotExternalSignInteractor(
 
         val chain = signPayload.chainOrNull() ?: return@withContext null
 
-        val extrinsicBuilder = signPayload.toExtrinsicBuilderWithoutCall(forFee = true)
+        val signer = signPayload.feeSigner()
+        val extrinsicBuilder = signPayload.toExtrinsicBuilderWithoutCall(signer)
         val runtime = chainRegistry.getRuntime(chain.id)
 
         val extrinsic = when (val callRepresentation = signPayload.callRepresentation(runtime)) {
@@ -153,7 +156,7 @@ class PolkadotExternalSignInteractor(
             is CallRepresentation.Bytes -> extrinsicBuilder.build(rawCallBytes = callRepresentation.bytes)
         }
 
-        extrinsicService.estimateFee(chain, extrinsic)
+        extrinsicService.estimateFee(chain, extrinsic, signer)
     }
 
     private fun readableBytesContent(signBytesPayload: PolkadotSignPayload.Raw): String {
@@ -183,7 +186,8 @@ class PolkadotExternalSignInteractor(
 
     private suspend fun signExtrinsic(extrinsicPayload: PolkadotSignPayload.Json): String {
         val runtime = chainRegistry.getRuntime(extrinsicPayload.chain().id)
-        val extrinsicBuilder = extrinsicPayload.toExtrinsicBuilderWithoutCall(forFee = false)
+        val signer = resolveWalletSigner()
+        val extrinsicBuilder = extrinsicPayload.toExtrinsicBuilderWithoutCall(signer)
 
         return when (val callRepresentation = extrinsicPayload.callRepresentation(runtime)) {
             is CallRepresentation.Instance -> extrinsicBuilder.call(callRepresentation.call).buildSignature()
@@ -191,20 +195,18 @@ class PolkadotExternalSignInteractor(
         }
     }
 
-    private suspend fun PolkadotSignPayload.Json.toExtrinsicBuilderWithoutCall(
-        forFee: Boolean
-    ): ExtrinsicBuilder {
+    private suspend fun PolkadotSignPayload.Json.feeSigner(): FeeSigner {
+        val chain = chain()
+
+        return signerProvider.feeSigner(resolveMetaAccount(), chain)
+    }
+
+    private suspend fun PolkadotSignPayload.Json.toExtrinsicBuilderWithoutCall(signer: NovaSigner): ExtrinsicBuilder {
         val chain = chain()
         val runtime = chainRegistry.getRuntime(genesisHash)
         val parsedExtrinsic = parseDAppExtrinsic(runtime, this)
 
         val accountId = chain.accountIdOf(address)
-
-        val signer = if (forFee) {
-            signerProvider.feeSigner(resolveMetaAccount(), chain)
-        } else {
-            resolveWalletSigner()
-        }
 
         return with(parsedExtrinsic) {
             ExtrinsicBuilder(

--- a/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/presentation/signExtrinsic/ExternaSignViewModel.kt
+++ b/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/presentation/signExtrinsic/ExternaSignViewModel.kt
@@ -112,7 +112,7 @@ class ExternaSignViewModel(
             autoFixPayload = ::autoFixPayload,
             progressConsumer = _performingOperationInProgress.progressConsumer()
         ) {
-            performOperation(it.decimalFee?.fee)
+            performOperation(it.decimalFee?.networkFee)
         }
     }
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationPayload.kt
@@ -1,11 +1,12 @@
 package io.novafoundation.nova.feature_governance_impl.domain.delegation.delegation.create.chooseAmount.validation
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import java.math.BigDecimal
 
 class ChooseDelegationAmountValidationPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset,
     val amount: BigDecimal,
     val delegate: AccountId

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationSystem.kt
@@ -20,11 +20,11 @@ fun ValidationSystem.Companion.chooseDelegationAmount(
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             ChooseDelegationAmountValidationFailure.NotEnoughToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/removeVotes/validations/RemoveVotesValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/removeVotes/validations/RemoveVotesValidationPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_governance_impl.domain.delegation.delegation.removeVotes.validations
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class RemoveVotesValidationPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset,
 )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/removeVotes/validations/RemoveVotesValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/removeVotes/validations/RemoveVotesValidationSystem.kt
@@ -9,11 +9,11 @@ fun ValidationSystem.Companion.removeVotesValidationSystem(): RemoteVotesValidat
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             RemoveVotesValidationFailure.NotEnoughToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/revoke/validations/RevokeDelegationValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/revoke/validations/RevokeDelegationValidationPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_governance_impl.domain.delegation.delegation.revoke.validations
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class RevokeDelegationValidationPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset,
 )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/revoke/validations/RevokeDelegationValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/revoke/validations/RevokeDelegationValidationSystem.kt
@@ -9,11 +9,11 @@ fun ValidationSystem.Companion.revokeDelegationValidationSystem(): RevokeDelegat
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             RevokeDelegationValidationFailure.NotEnoughToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/unlock/GovernanceUnlockInteractor.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/unlock/GovernanceUnlockInteractor.kt
@@ -7,7 +7,6 @@ import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.Tran
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_account_api.data.extrinsic.awaitInBlock
 import io.novafoundation.nova.feature_account_api.data.model.Fee
-import io.novafoundation.nova.feature_account_api.data.model.zero
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_account_api.domain.model.accountIdIn
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.OnChainReferendum
@@ -81,10 +80,10 @@ class RealGovernanceUnlockInteractor(
 ) : GovernanceUnlockInteractor {
 
     override suspend fun calculateFee(claimable: UnlockChunk.Claimable?): Fee {
-        if (claimable == null) return Fee.zero()
-
         val governanceSelectedOption = selectedAssetState.selectedOption()
         val chain = governanceSelectedOption.assetWithChain.chain
+
+        if (claimable == null) return extrinsicService.zeroFee(chain, TransactionOrigin.SelectedWallet)
 
         val metaAccount = accountRepository.getSelectedMetaAccount()
         val origin = metaAccount.accountIdIn(chain)!!

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/unlock/validations/UnlockReferendumValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/unlock/validations/UnlockReferendumValidationPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_governance_impl.domain.referendum.unlock.validations
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class UnlockReferendumValidationPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset,
 )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/unlock/validations/VoteReferendumValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/unlock/validations/VoteReferendumValidationSystem.kt
@@ -9,11 +9,11 @@ fun ValidationSystem.Companion.unlockReferendumValidationSystem(): UnlockReferen
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             UnlockGovernanceValidationFailure.NotEnoughToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/VoteReferendumValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/VoteReferendumValidationPayload.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_governance_impl.domain.referendum.vote.va
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.OnChainReferendum
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.Voting
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 class VoteReferendumValidationPayload(
@@ -10,5 +11,5 @@ class VoteReferendumValidationPayload(
     val asset: Asset,
     val trackVoting: Voting?,
     val voteAmount: BigDecimal,
-    val fee: BigDecimal
+    val fee: DecimalFee
 )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/VoteReferendumValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/VoteReferendumValidationSystem.kt
@@ -26,11 +26,11 @@ fun ValidationSystem.Companion.voteReferendumValidationSystem(
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             VoteReferendumValidationFailure.NotEnoughToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/chooseAmount/NewDelegationChooseAmountViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/chooseAmount/NewDelegationChooseAmountViewModel.kt
@@ -34,6 +34,7 @@ import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.WithFeeL
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.connectWith
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -157,10 +158,10 @@ class NewDelegationChooseAmountViewModel(
 
     private fun openConfirmIfValid() = launch {
         validationInProgressFlow.value = true
-        val fee = originFeeMixin.awaitDecimalFee().networkFeeDecimalAmount
+
         val payload = ChooseDelegationAmountValidationPayload(
             asset = selectedAsset.first(),
-            fee = fee,
+            fee = originFeeMixin.awaitDecimalFee(),
             amount = amountChooserMixin.amount.first(),
             delegate = payload.delegate
         )
@@ -183,7 +184,7 @@ class NewDelegationChooseAmountViewModel(
             trackIdsRaw = payload.trackIdsRaw,
             amount = validationPayload.amount,
             conviction = selectedConvictionFlow.first(),
-            fee = validationPayload.fee,
+            fee = mapFeeToParcel(validationPayload.fee),
             isEditMode = payload.isEditMode
         )
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/confirm/NewDelegationConfirmPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/confirm/NewDelegationConfirmPayload.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_governance_impl.presentation.delegation.d
 import android.os.Parcelable
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.TrackId
 import io.novafoundation.nova.feature_governance_api.domain.referendum.voters.GenericVoter
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import io.novafoundation.nova.runtime.multiNetwork.runtime.types.custom.vote.Conviction
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import kotlinx.android.parcel.Parcelize
@@ -15,7 +16,7 @@ class NewDelegationConfirmPayload(
     @Suppress("CanBeParameter") val trackIdsRaw: List<BigInteger>,
     val amount: BigDecimal,
     val conviction: Conviction,
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
     val isEditMode: Boolean,
 ) : Parcelable {
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/confirm/NewDelegationConfirmViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/confirm/NewDelegationConfirmViewModel.kt
@@ -189,7 +189,7 @@ class NewDelegationConfirmViewModel(
     }
 
     private fun setFee() = launch {
-        originFeeMixin.setFee(decimalFee.networkFee)
+        originFeeMixin.setFee(decimalFee.genericFee)
     }
 
     private fun performDelegate(amountPlanks: Balance) = launch {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/confirm/NewDelegationConfirmViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/confirm/NewDelegationConfirmViewModel.kt
@@ -43,6 +43,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.WithFeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.chain
 import io.novafoundation.nova.runtime.state.chainAsset
@@ -138,6 +139,8 @@ class NewDelegationConfirmViewModel(
     private val _showTracksEvent = MutableLiveData<Event<List<TrackModel>>>()
     val showTracksEvent: LiveData<Event<List<TrackModel>>> = _showTracksEvent
 
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
     init {
         setFee()
     }
@@ -166,7 +169,7 @@ class NewDelegationConfirmViewModel(
         val amountPlanks = asset.token.planksFromAmount(payload.amount)
         val validationPayload = ChooseDelegationAmountValidationPayload(
             asset = asset,
-            fee = payload.fee,
+            fee = decimalFee,
             amount = payload.amount,
             delegate = payload.delegate
         )
@@ -186,7 +189,7 @@ class NewDelegationConfirmViewModel(
     }
 
     private fun setFee() = launch {
-        originFeeMixin.setFee(payload.fee)
+        originFeeMixin.setFee(decimalFee.networkFee)
     }
 
     private fun performDelegate(amountPlanks: Balance) = launch {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/revoke/confirm/RevokeDelegationConfirmViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/revoke/confirm/RevokeDelegationConfirmViewModel.kt
@@ -35,6 +35,7 @@ import io.novafoundation.nova.feature_governance_impl.presentation.track.TrackFo
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.WithFeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
 import io.novafoundation.nova.runtime.state.chain
 import io.novafoundation.nova.runtime.state.chainAsset
@@ -146,10 +147,12 @@ class RevokeDelegationConfirmViewModel(
     }
 
     fun confirmClicked() = launch {
-        val asset = assetFlow.first()
-        val fee = originFeeMixin.awaitFee()
+        _showNextProgress.value = true
 
-        val validationPayload = RevokeDelegationValidationPayload(fee, asset)
+        val validationPayload = RevokeDelegationValidationPayload(
+            fee = originFeeMixin.awaitDecimalFee(),
+            asset = assetFlow.first()
+        )
 
         validationExecutor.requireValid(
             validationSystem = validationSystem,

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmReferendumVoteViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmReferendumVoteViewModel.kt
@@ -32,6 +32,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.WithFeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.multiNetwork.runtime.types.custom.vote.Vote
 import io.novafoundation.nova.runtime.state.chain
@@ -120,6 +121,8 @@ class ConfirmReferendumVoteViewModel(
     }
         .shareInBackground()
 
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
     init {
         setFee()
     }
@@ -139,7 +142,7 @@ class ConfirmReferendumVoteViewModel(
             asset = assetFlow.first(),
             trackVoting = voteAssistant.trackVoting,
             voteAmount = payload.vote.amount,
-            fee = payload.fee
+            fee = decimalFee
         )
 
         validationExecutor.requireValid(
@@ -157,7 +160,7 @@ class ConfirmReferendumVoteViewModel(
     }
 
     private fun setFee() = launch {
-        originFeeMixin.setFee(payload.fee)
+        originFeeMixin.setFee(decimalFee.networkFee)
     }
 
     private fun performVote() = launch {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmReferendumVoteViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmReferendumVoteViewModel.kt
@@ -160,7 +160,7 @@ class ConfirmReferendumVoteViewModel(
     }
 
     private fun setFee() = launch {
-        originFeeMixin.setFee(decimalFee.networkFee)
+        originFeeMixin.setFee(decimalFee.genericFee)
     }
 
     private fun performVote() = launch {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmVoteReferendumPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmVoteReferendumPayload.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_governance_impl.presentation.referenda.vo
 
 import android.os.Parcelable
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.ReferendumId
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import io.novafoundation.nova.runtime.multiNetwork.runtime.types.custom.vote.Conviction
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
@@ -10,7 +11,7 @@ import java.math.BigInteger
 @Parcelize
 class ConfirmVoteReferendumPayload(
     val _referendumId: BigInteger,
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
     val vote: AccountVoteParcelModel
 ) : Parcelable
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/setup/SetupVoteReferendumViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/setup/SetupVoteReferendumViewModel.kt
@@ -33,8 +33,10 @@ import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChoose
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.setAmountInput
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.WithFeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.connectWith
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -156,7 +158,6 @@ class SetupVoteReferendumViewModel(
 
     private fun openConfirmIfValid(voteType: VoteType) = launch {
         validatingVoteType.value = voteType
-        val fee = originFeeMixin.awaitFee()
         val voteAssistant = voteAssistantFlow.first()
 
         val payload = VoteReferendumValidationPayload(
@@ -164,7 +165,7 @@ class SetupVoteReferendumViewModel(
             asset = selectedAsset.first(),
             trackVoting = voteAssistant.trackVoting,
             voteAmount = amountChooserMixin.amount.first(),
-            fee = fee
+            fee = originFeeMixin.awaitDecimalFee()
         )
 
         validationExecutor.requireValid(
@@ -184,7 +185,7 @@ class SetupVoteReferendumViewModel(
 
         val confirmPayload = ConfirmVoteReferendumPayload(
             _referendumId = payload._referendumId,
-            fee = validationPayload.fee,
+            fee = mapFeeToParcel(validationPayload.fee),
             vote = AccountVoteParcelModel(
                 amount = validationPayload.voteAmount,
                 conviction = conviction,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/MakePayoutValidationsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/MakePayoutValidationsModule.kt
@@ -22,14 +22,14 @@ class MakePayoutValidationsModule {
         return EnoughAmountToTransferValidation(
             feeExtractor = { it.fee },
             availableBalanceProducer = { it.asset.transferable },
-            errorProducer = { _, _ -> PayoutValidationFailure.CannotPayFee }
+            errorProducer = { PayoutValidationFailure.CannotPayFee }
         )
     }
 
     @FeatureScope
     @Provides
     fun provideProfitableValidation() = ProfitablePayoutValidation(
-        fee = { fee },
+        fee = { it.fee },
         amount = { totalReward },
         error = { PayoutValidationFailure.UnprofitablePayout }
     )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/RebondValidationsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/RebondValidationsModule.kt
@@ -18,7 +18,7 @@ class RebondValidationsModule {
     fun provideFeeValidation() = RebondFeeValidation(
         feeExtractor = { it.fee },
         availableBalanceProducer = { it.controllerAsset.transferable },
-        errorProducer = { _, _ -> RebondValidationFailure.CANNOT_PAY_FEE }
+        errorProducer = { RebondValidationFailure.CANNOT_PAY_FEE }
     )
 
     @FeatureScope

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/RedeemValidationsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/RedeemValidationsModule.kt
@@ -16,7 +16,7 @@ class RedeemValidationsModule {
     fun provideFeeValidation() = RedeemFeeValidation(
         feeExtractor = { it.fee },
         availableBalanceProducer = { it.asset.transferable },
-        errorProducer = { _, _ -> RedeemValidationFailure.CANNOT_PAY_FEES }
+        errorProducer = {  RedeemValidationFailure.CANNOT_PAY_FEES }
     )
 
     @FeatureScope

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/RedeemValidationsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/RedeemValidationsModule.kt
@@ -16,7 +16,7 @@ class RedeemValidationsModule {
     fun provideFeeValidation() = RedeemFeeValidation(
         feeExtractor = { it.fee },
         availableBalanceProducer = { it.asset.transferable },
-        errorProducer = {  RedeemValidationFailure.CANNOT_PAY_FEES }
+        errorProducer = { RedeemValidationFailure.CANNOT_PAY_FEES }
     )
 
     @FeatureScope

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/RewardDestinationValidationsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/RewardDestinationValidationsModule.kt
@@ -19,7 +19,7 @@ class RewardDestinationValidationsModule {
     fun provideFeeValidation() = RewardDestinationFeeValidation(
         feeExtractor = { it.fee },
         availableBalanceProducer = { it.availableControllerBalance },
-        errorProducer = { _, _ -> RewardDestinationValidationFailure.CannotPayFees }
+        errorProducer = { RewardDestinationValidationFailure.CannotPayFees }
     )
 
     @Provides

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/SetControllerValidationsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/SetControllerValidationsModule.kt
@@ -23,7 +23,7 @@ class SetControllerValidationsModule {
         return EnoughAmountToTransferValidation(
             feeExtractor = { it.fee },
             availableBalanceProducer = { it.transferable },
-            errorProducer = { _, _ -> SetControllerValidationFailure.NOT_ENOUGH_TO_PAY_FEES }
+            errorProducer = { SetControllerValidationFailure.NOT_ENOUGH_TO_PAY_FEES }
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/UnbondValidationsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/validations/UnbondValidationsModule.kt
@@ -26,7 +26,7 @@ class UnbondValidationsModule {
     fun provideFeeValidation() = UnbondFeeValidation(
         feeExtractor = { it.fee },
         availableBalanceProducer = { it.asset.transferable },
-        errorProducer = { _, _ -> UnbondValidationFailure.CannotPayFees }
+        errorProducer = { UnbondValidationFailure.CannotPayFees }
     )
 
     @FeatureScope

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/bagList/rebag/validations/RebagValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/bagList/rebag/validations/RebagValidationPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_staking_impl.domain.bagList.rebag.validations
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class RebagValidationPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset,
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/bagList/rebag/validations/RebagValidationSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/bagList/rebag/validations/RebagValidationSystem.kt
@@ -9,11 +9,11 @@ fun ValidationSystem.Companion.rebagValidationSystem(): RebagValidationSystem = 
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             RebagValidationFailure.NotEnoughToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/validation/ProfitableActionValidation.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/validation/ProfitableActionValidation.kt
@@ -4,16 +4,19 @@ import io.novafoundation.nova.common.validation.Validation
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.ValidationSystemBuilder
 import io.novafoundation.nova.common.validation.isTrueOrWarning
+import io.novafoundation.nova.feature_wallet_api.domain.validation.FeeProducer
+import io.novafoundation.nova.feature_wallet_api.presentation.model.networkFeeDecimalAmount
 import java.math.BigDecimal
 
 class ProfitableActionValidation<P, E>(
     val amount: P.() -> BigDecimal,
-    val fee: P.() -> BigDecimal,
+    val fee: FeeProducer<P>,
     val error: (P) -> E
 ) : Validation<P, E> {
 
     override suspend fun validate(value: P): ValidationStatus<E> {
-        val isProfitable = value.fee() < value.amount()
+        // No matter who paid the fee we check that it is profitable
+        val isProfitable = fee(value).networkFeeDecimalAmount < value.amount()
 
         return isProfitable isTrueOrWarning {
             error(value)
@@ -23,7 +26,7 @@ class ProfitableActionValidation<P, E>(
 
 fun <P, E> ValidationSystemBuilder<P, E>.profitableAction(
     amount: P.() -> BigDecimal,
-    fee: P.() -> BigDecimal,
+    fee: FeeProducer<P>,
     error: (P) -> E
 ) {
     validate(ProfitableActionValidation(amount, fee, error))

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/bondMore/validations/Declarations.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/bondMore/validations/Declarations.kt
@@ -37,7 +37,7 @@ private fun NominationPoolsBondMoreValidationSystemBuilder.poolIsNotDestroying(f
 private fun NominationPoolsBondMoreValidationSystemBuilder.enoughAvailableToStakeInPool(factory: PoolAvailableBalanceValidationFactory) {
     factory.enoughAvailableBalanceToStake(
         asset = { it.asset },
-        fee = { it.fee.fee.amount },
+        fee = { it.fee },
         amount = { it.amount },
         error = NominationPoolsBondMoreValidationFailure::NotEnoughToBond
     )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/claimRewards/validations/Declarations.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/claimRewards/validations/Declarations.kt
@@ -41,11 +41,11 @@ private fun NominationPoolsClaimRewardsValidationSystemBuilder.enoughToPayFees()
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             NominationPoolsClaimRewardsValidationFailure.NotEnoughBalanceToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )
@@ -54,7 +54,7 @@ private fun NominationPoolsClaimRewardsValidationSystemBuilder.enoughToPayFees()
 private fun NominationPoolsClaimRewardsValidationSystemBuilder.profitableClaim() {
     profitableAction(
         amount = { pendingRewards },
-        fee = { fee },
+        fee = { it.fee },
         error = { NominationPoolsClaimRewardsValidationFailure.NonProfitableClaim }
     )
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/claimRewards/validations/NominationPoolsClaimRewardsValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/claimRewards/validations/NominationPoolsClaimRewardsValidationPayload.kt
@@ -3,11 +3,12 @@ package io.novafoundation.nova.feature_staking_impl.domain.nominationPools.claim
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigDecimal
 
 class NominationPoolsClaimRewardsValidationPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val pendingRewardsPlanks: Balance,
     val asset: Asset,
     val chain: Chain

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/redeem/validations/Declarations.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/redeem/validations/Declarations.kt
@@ -23,11 +23,11 @@ private fun NominationPoolsRedeemValidationSystemBuilder.enoughToPayFees() {
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             NominationPoolsRedeemValidationFailure.NotEnoughBalanceToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/redeem/validations/NominationPoolsRedeemValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/redeem/validations/NominationPoolsRedeemValidationPayload.kt
@@ -1,11 +1,11 @@
 package io.novafoundation.nova.feature_staking_impl.domain.nominationPools.redeem.validations
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import java.math.BigDecimal
 
 class NominationPoolsRedeemValidationPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset,
     val chain: Chain
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/unbond/validations/Declarations.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/unbond/validations/Declarations.kt
@@ -40,11 +40,11 @@ private fun NominationPoolsUnbondValidationSystemBuilder.enoughToPayFees() {
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, leftForFees ->
+        error = { context ->
             NominationPoolsUnbondValidationFailure.NotEnoughBalanceToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = leftForFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )
@@ -54,7 +54,7 @@ private fun NominationPoolsUnbondValidationSystemBuilder.enoughToUnbond() {
     sufficientBalance(
         available = { it.stakedBalance },
         amount = { it.amount },
-        error = { _, _ -> NominationPoolsUnbondValidationFailure.NotEnoughToUnbond }
+        error = { NominationPoolsUnbondValidationFailure.NotEnoughToUnbond }
     )
 }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/unbond/validations/NominationPoolsUnbondValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/unbond/validations/NominationPoolsUnbondValidationPayload.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.domain.nominationPools.unbon
 
 import io.novafoundation.nova.feature_staking_impl.data.nominationPools.network.blockhain.models.PoolMember
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import kotlinx.coroutines.CoroutineScope
 import java.math.BigDecimal
@@ -10,7 +11,7 @@ data class NominationPoolsUnbondValidationPayload(
     val poolMember: PoolMember,
     val stakedBalance: BigDecimal,
     val amount: BigDecimal,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset,
     val chain: Chain,
     val sharedComputationScope: CoroutineScope,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rebond/validations/ParachainStakingRebondValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rebond/validations/ParachainStakingRebondValidationPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.rebond.validations
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class ParachainStakingRebondValidationPayload(
     val asset: Asset,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rebond/validations/ParachainStakingUnbondValidationSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rebond/validations/ParachainStakingUnbondValidationSystem.kt
@@ -9,6 +9,6 @@ fun ValidationSystem.Companion.parachainStakingRebond(): ParachainStakingRebondV
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { _, _ -> ParachainStakingRebondValidationFailure.NotEnoughBalanceToPayFees }
+        error = { ParachainStakingRebondValidationFailure.NotEnoughBalanceToPayFees }
     )
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/redeem/validations/ParachainStakingRedeemValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/redeem/validations/ParachainStakingRedeemValidationPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.redeem.validations
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class ParachainStakingRedeemValidationPayload(
     val asset: Asset,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/redeem/validations/ParachainStakingUnbondValidationSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/redeem/validations/ParachainStakingUnbondValidationSystem.kt
@@ -9,6 +9,6 @@ fun ValidationSystem.Companion.parachainStakingRedeem(): ParachainStakingRedeemV
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { _, _ -> ParachainStakingRedeemValidationFailure.NotEnoughBalanceToPayFees }
+        error = { ParachainStakingRedeemValidationFailure.NotEnoughBalanceToPayFees }
     )
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/start/validations/StartParachainStakingValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/start/validations/StartParachainStakingValidationPayload.kt
@@ -3,11 +3,12 @@ package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.star
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.model.Collator
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 class StartParachainStakingValidationPayload(
     val amount: BigDecimal,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val collator: Collator,
     val asset: Asset,
     val delegatorState: DelegatorState,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/start/validations/StartParachainStakingValidationSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/start/validations/StartParachainStakingValidationSystem.kt
@@ -40,7 +40,7 @@ private fun StartParachainStakingValidationSystemBuilder.enoughToPayFees() {
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { _, _ -> StartParachainStakingValidationFailure.NotEnoughBalanceToPayFees }
+        error = { StartParachainStakingValidationFailure.NotEnoughBalanceToPayFees }
     )
 }
 
@@ -49,7 +49,7 @@ private fun StartParachainStakingValidationSystemBuilder.enoughStakeable() {
         fee = { it.fee },
         available = { it.stakeableAmount() },
         amount = { it.amount },
-        error = { _, _ -> StartParachainStakingValidationFailure.NotEnoughBalanceToPayFees }
+        error = { StartParachainStakingValidationFailure.NotEnoughBalanceToPayFees }
     )
 }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/unbond/validations/flow/ParachainStakingUnbondValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/unbond/validations/flow/ParachainStakingUnbondValidationPayload.kt
@@ -2,11 +2,12 @@ package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.unbo
 
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.common.model.Collator
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 data class ParachainStakingUnbondValidationPayload(
     val amount: BigDecimal,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val collator: Collator,
     val asset: Asset,
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/unbond/validations/flow/ParachainStakingUnbondValidationSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/unbond/validations/flow/ParachainStakingUnbondValidationSystem.kt
@@ -28,6 +28,6 @@ fun ValidationSystem.Companion.parachainStakingUnbond(
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { _, _ -> ParachainStakingUnbondValidationFailure.NotEnoughBalanceToPayFees }
+        error = { ParachainStakingUnbondValidationFailure.NotEnoughBalanceToPayFees }
     )
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/yieldBoost/validations/FirstTaskCanExecute.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/yieldBoost/validations/FirstTaskCanExecute.kt
@@ -20,7 +20,7 @@ class FirstTaskCanExecute(
         val token = value.asset.token
 
         val balanceBeforeTransaction = value.asset.transferable
-        val balanceAfterTransaction = balanceBeforeTransaction - value.fee
+        val balanceAfterTransaction = balanceBeforeTransaction - value.fee.networkFeeDecimalAmount
 
         val chainId = value.asset.token.configuration.chainId
 
@@ -32,7 +32,7 @@ class FirstTaskCanExecute(
         return when {
             taskExecutionFee > balanceAfterTransaction -> YieldBoostValidationFailure.FirstTaskCannotExecute(
                 minimumBalanceRequired = taskExecutionFee,
-                networkFee = value.fee,
+                networkFee = value.fee.networkFeeDecimalAmount,
                 availableBalanceBeforeFees = balanceBeforeTransaction,
                 type = EXECUTION_FEE,
                 chainAsset = token.configuration
@@ -40,7 +40,7 @@ class FirstTaskCanExecute(
 
             threshold > balanceAfterTransaction -> YieldBoostValidationFailure.FirstTaskCannotExecute(
                 minimumBalanceRequired = threshold,
-                networkFee = value.fee,
+                networkFee = value.fee.networkFeeDecimalAmount,
                 availableBalanceBeforeFees = balanceBeforeTransaction,
                 type = THRESHOLD,
                 chainAsset = token.configuration

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/yieldBoost/validations/ValidationSystem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/yieldBoost/validations/ValidationSystem.kt
@@ -16,11 +16,11 @@ fun ValidationSystem.Companion.yieldBoost(
     sufficientBalance(
         fee = { it.fee },
         available = { it.asset.transferable },
-        error = { payload, availableToPayFees ->
+        error = { context ->
             YieldBoostValidationFailure.NotEnoughToPayToPayFees(
-                chainAsset = payload.asset.token.configuration,
-                maxUsable = availableToPayFees,
-                fee = payload.fee
+                chainAsset = context.payload.asset.token.configuration,
+                maxUsable = context.availableToPayFees,
+                fee = context.fee
             )
         }
     )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/yieldBoost/validations/YieldBoostValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/yieldBoost/validations/YieldBoostValidationPayload.kt
@@ -4,12 +4,12 @@ import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.commo
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.yieldBoost.YieldBoostConfiguration
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.yieldBoost.YieldBoostTask
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class YieldBoostValidationPayload(
     val collator: Collator,
     val activeTasks: List<YieldBoostTask>,
     val configuration: YieldBoostConfiguration,
     val asset: Asset,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/validations/AvailableBalanceGapValidation.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/validations/AvailableBalanceGapValidation.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.valid
 import io.novafoundation.nova.common.validation.validationError
+import io.novafoundation.nova.feature_account_api.data.model.amountByRequestedAccount
 import io.novafoundation.nova.feature_staking_impl.data.asset
 import io.novafoundation.nova.feature_staking_impl.data.chain
 import io.novafoundation.nova.feature_staking_impl.data.stakingType
@@ -18,7 +19,7 @@ class AvailableBalanceGapValidation(
     override suspend fun validate(value: StartMultiStakingValidationPayload): ValidationStatus<StartMultiStakingValidationFailure> {
         val amount = value.selection.stake
         val stakingOption = value.selection.stakingOption
-        val fee = value.fee.fee.amount
+        val fee = value.fee.networkFee.amountByRequestedAccount
 
         val maxToStakeWithMinStakes = candidates.map {
             val maximumToStake = it.maximumToStake(value.asset, fee)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/direct/DirectStakingProperties.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/direct/DirectStakingProperties.kt
@@ -111,14 +111,14 @@ private class DirectStakingProperties(
 
     private fun StartMultiStakingValidationSystemBuilder.enoughAvailableToStake() {
         sufficientBalance(
-            fee = { it.fee.networkFeeDecimalAmount },
+            fee = { it.fee },
             available = { it.amountOf(availableBalance(it.asset)) },
             amount = { it.amountOf(it.selection.stake) },
-            error = { payload, availableToPayFees ->
+            error = { context ->
                 StartMultiStakingValidationFailure.NotEnoughToPayFees(
-                    chainAsset = payload.asset.token.configuration,
-                    maxUsable = availableToPayFees,
-                    fee = payload.fee.networkFeeDecimalAmount
+                    chainAsset = context.payload.asset.token.configuration,
+                    maxUsable = context.availableToPayFees,
+                    fee = context.fee
                 )
             }
         )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/pools/NominationPoolStakingProperties.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/pools/NominationPoolStakingProperties.kt
@@ -82,7 +82,7 @@ private class NominationPoolStakingProperties(
 
         poolAvailableBalanceValidationFactory.enoughAvailableBalanceToStake(
             asset = { it.asset },
-            fee = { it.fee.fee.amount },
+            fee = { it.fee },
             amount = { it.selection.stakeAmount() },
             error = StartMultiStakingValidationFailure::PoolAvailableBalance
         )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/selectionType/ManualMultiStakingSelectionType.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/selectionType/ManualMultiStakingSelectionType.kt
@@ -38,8 +38,8 @@ class ManualMultiStakingSelectionType(
         sufficientBalance(
             available = { it.amountOf(availableBalance(it.asset)) },
             amount = { it.amountOf(it.selection.stake) },
-            error = { _, _ -> StartMultiStakingValidationFailure.NotEnoughAvailableToStake },
-            fee = { it.fee.decimalAmount }
+            error = { StartMultiStakingValidationFailure.NotEnoughAvailableToStake },
+            fee = { it.fee }
         )
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/bond/BondMoreValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/bond/BondMoreValidationPayload.kt
@@ -1,11 +1,12 @@
 package io.novafoundation.nova.feature_staking_impl.domain.validations.bond
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 class BondMoreValidationPayload(
     val stashAddress: String,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val amount: BigDecimal,
     val stashAsset: Asset,
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/bond/Declarations.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/bond/Declarations.kt
@@ -21,7 +21,7 @@ private fun BondMoreValidationSystemBuilder.enoughToPayFees() {
     sufficientBalance(
         fee = { it.fee },
         available = { it.stashAsset.transferable },
-        error = { _, _ -> BondMoreValidationFailure.NOT_ENOUGH_TO_PAY_FEES }
+        error = { BondMoreValidationFailure.NOT_ENOUGH_TO_PAY_FEES }
     )
 }
 
@@ -30,7 +30,7 @@ private fun BondMoreValidationSystemBuilder.enoughStakeable() {
         fee = { it.fee },
         available = { it.stashAsset.stakeable },
         amount = { it.amount },
-        error = { _, _ -> BondMoreValidationFailure.NOT_ENOUGH_STAKEABLE }
+        error = { BondMoreValidationFailure.NOT_ENOUGH_STAKEABLE }
     )
 }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/controller/SetControllerValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/controller/SetControllerValidationPayload.kt
@@ -1,10 +1,11 @@
 package io.novafoundation.nova.feature_staking_impl.domain.validations.controller
 
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 class SetControllerValidationPayload(
     val stashAddress: String,
     val controllerAddress: String,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val transferable: BigDecimal
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/payout/MakePayoutPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/payout/MakePayoutPayload.kt
@@ -2,11 +2,12 @@ package io.novafoundation.nova.feature_staking_impl.domain.validations.payout
 
 import io.novafoundation.nova.feature_staking_impl.data.model.Payout
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 class MakePayoutPayload(
     val originAddress: String,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val totalReward: BigDecimal,
     val asset: Asset,
     val payouts: List<Payout>

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/rebond/RebondValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/rebond/RebondValidationPayload.kt
@@ -1,10 +1,11 @@
 package io.novafoundation.nova.feature_staking_impl.domain.validations.rebond
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 class RebondValidationPayload(
     val controllerAsset: Asset,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val rebondAmount: BigDecimal
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/reedeem/RedeemValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/reedeem/RedeemValidationPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_staking_impl.domain.validations.reedeem
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class RedeemValidationPayload(
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val asset: Asset
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/rewardDestination/RewardDestinationValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/rewardDestination/RewardDestinationValidationPayload.kt
@@ -1,10 +1,11 @@
 package io.novafoundation.nova.feature_staking_impl.domain.validations.rewardDestination
 
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 class RewardDestinationValidationPayload(
     val availableControllerBalance: BigDecimal,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val stashState: StakingState.Stash
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/setup/Declarations.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/setup/Declarations.kt
@@ -29,6 +29,6 @@ private fun SetupStakingValidationSystemBuilder.enoughToPayFee() {
     sufficientBalance(
         fee = { it.maxFee },
         available = { it.controllerAsset.transferable },
-        error = { _, _ -> SetupStakingValidationFailure.CannotPayFee }
+        error = { SetupStakingValidationFailure.CannotPayFee }
     )
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/setup/SetupStakingPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/setup/SetupStakingPayload.kt
@@ -1,9 +1,9 @@
 package io.novafoundation.nova.feature_staking_impl.domain.validations.setup
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import java.math.BigDecimal
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 
 class SetupStakingPayload(
-    val maxFee: BigDecimal,
+    val maxFee: DecimalFee,
     val controllerAsset: Asset,
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/unbond/UnbondValidationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/validations/unbond/UnbondValidationPayload.kt
@@ -2,11 +2,12 @@ package io.novafoundation.nova.feature_staking_impl.domain.validations.unbond
 
 import io.novafoundation.nova.feature_staking_api.domain.model.relaychain.StakingState
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import java.math.BigDecimal
 
 data class UnbondValidationPayload(
     val stash: StakingState.Stash,
-    val fee: BigDecimal,
+    val fee: DecimalFee,
     val amount: BigDecimal,
     val asset: Asset,
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/bagList/rebag/RebagViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/bagList/rebag/RebagViewModel.kt
@@ -25,6 +25,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.bagList.rebag.mo
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanksRange
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.WithFeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.state.chain
@@ -111,8 +112,12 @@ class RebagViewModel(
 
     private fun rebagIfValid() {
         launch {
-            val fee = originFeeMixin.awaitFee()
-            val validationPayload = RebagValidationPayload(fee, stashAsset.first())
+            _showNextProgress.value = true
+
+            val validationPayload = RebagValidationPayload(
+                fee = originFeeMixin.awaitDecimalFee(),
+                asset = stashAsset.first()
+            )
 
             validationExecutor.requireValid(
                 validationSystem = validationSystem,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/bondMore/confirm/NominationPoolsConfirmBondMoreViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/bondMore/confirm/NominationPoolsConfirmBondMoreViewModel.kt
@@ -71,7 +71,7 @@ class NominationPoolsConfirmBondMoreViewModel(
         .shareInBackground()
 
     val feeStatusFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.genericFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/bondMore/confirm/NominationPoolsConfirmBondMoreViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/bondMore/confirm/NominationPoolsConfirmBondMoreViewModel.kt
@@ -71,7 +71,7 @@ class NominationPoolsConfirmBondMoreViewModel(
         .shareInBackground()
 
     val feeStatusFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(decimalFee.fee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/claimRewards/NominationPoolsClaimRewardsViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/claimRewards/NominationPoolsClaimRewardsViewModel.kt
@@ -19,6 +19,7 @@ import io.novafoundation.nova.feature_staking_impl.domain.nominationPools.claimR
 import io.novafoundation.nova.feature_staking_impl.presentation.NominationPoolsRouter
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.connectWith
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
@@ -95,10 +96,12 @@ class NominationPoolsClaimRewardsViewModel(
     }
 
     private fun claimRewardsIfValid() = launch {
+        _showNextProgress.value = true
+
         val shouldRestake = shouldRestakeInput.first()
 
         val payload = NominationPoolsClaimRewardsValidationPayload(
-            fee = feeLoaderMixin.awaitFee(),
+            fee = feeLoaderMixin.awaitDecimalFee(),
             pendingRewardsPlanks = pendingRewards.first(),
             asset = assetFlow.first(),
             chain = stakingSharedState.chain()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/redeem/NominationPoolsRedeemViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/redeem/NominationPoolsRedeemViewModel.kt
@@ -20,6 +20,7 @@ import io.novafoundation.nova.feature_staking_impl.domain.nominationPools.redeem
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.connectWith
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
@@ -102,11 +103,11 @@ class NominationPoolsRedeemViewModel(
     }
 
     private fun redeemIfValid() = launch {
-        val asset = assetFlow.first()
+        _showNextProgress.value = true
 
         val payload = NominationPoolsRedeemValidationPayload(
-            fee = feeLoaderMixin.awaitFee(),
-            asset = asset,
+            fee = feeLoaderMixin.awaitDecimalFee(),
+            asset = assetFlow.first(),
             chain = stakingSharedState.chain()
         )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/NominationPoolsConfirmUnbondPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/NominationPoolsConfirmUnbondPayload.kt
@@ -1,11 +1,12 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.unbond.confirm
 
 import android.os.Parcelable
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
 
 @Parcelize
 class NominationPoolsConfirmUnbondPayload(
     val amount: BigDecimal,
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
 ) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/NominationPoolsConfirmUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/NominationPoolsConfirmUnbondViewModel.kt
@@ -24,6 +24,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.chain
 import kotlinx.coroutines.flow.Flow
@@ -49,6 +50,8 @@ class NominationPoolsConfirmUnbondViewModel(
     ExternalActions by externalActions,
     Validatable by validationExecutor {
 
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
     private val _showNextProgress = MutableStateFlow(false)
     val showNextProgress: Flow<Boolean> = _showNextProgress
 
@@ -66,7 +69,7 @@ class NominationPoolsConfirmUnbondViewModel(
         .shareInBackground()
 
     val feeStatusFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(payload.fee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }
@@ -102,7 +105,7 @@ class NominationPoolsConfirmUnbondViewModel(
         val stakedBalance = asset.token.amountFromPlanks(stakedBalance.first())
 
         val payload = NominationPoolsUnbondValidationPayload(
-            fee = payload.fee,
+            fee = decimalFee,
             amount = payload.amount,
             poolMember = poolMemberFlow.first(),
             asset = asset,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/NominationPoolsConfirmUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/NominationPoolsConfirmUnbondViewModel.kt
@@ -69,7 +69,7 @@ class NominationPoolsConfirmUnbondViewModel(
         .shareInBackground()
 
     val feeStatusFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.genericFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/setup/NominationPoolsSetupUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/setup/NominationPoolsSetupUnbondViewModel.kt
@@ -21,8 +21,10 @@ import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.connectWith
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.chain
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -110,7 +112,7 @@ class NominationPoolsSetupUnbondViewModel(
         val stakedBalance = asset.token.amountFromPlanks(stakedBalance.first())
 
         val payload = NominationPoolsUnbondValidationPayload(
-            fee = originFeeMixin.awaitFee(),
+            fee = originFeeMixin.awaitDecimalFee(),
             poolMember = poolMemberFlow.first(),
             stakedBalance = stakedBalance,
             asset = asset,
@@ -134,7 +136,7 @@ class NominationPoolsSetupUnbondViewModel(
     private fun openConfirm(validationPayload: NominationPoolsUnbondValidationPayload) = launch {
         val confirmPayload = NominationPoolsConfirmUnbondPayload(
             amount = validationPayload.amount,
-            fee = validationPayload.fee
+            fee = mapFeeToParcel(validationPayload.fee)
         )
 
         router.openConfirmUnbond(confirmPayload)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/redeem/ParachainStakingRedeemViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/redeem/ParachainStakingRedeemViewModel.kt
@@ -123,7 +123,6 @@ class ParachainStakingRedeemViewModel(
         }
     }
 
-
     private fun sendTransaction() = launch {
         interactor.redeem(delegatorState.first())
             .onFailure(::showError)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/start/confirm/ConfirmStartParachainStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/start/confirm/ConfirmStartParachainStakingViewModel.kt
@@ -151,7 +151,7 @@ class ConfirmStartParachainStakingViewModel(
     }
 
     private fun setInitialFee() = launch {
-        feeLoaderMixin.setFee(decimalFee.networkFee)
+        feeLoaderMixin.setFee(decimalFee.genericFee)
     }
 
     private fun sendTransactionIfValid() = launch {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/start/confirm/ConfirmStartParachainStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/start/confirm/ConfirmStartParachainStakingViewModel.kt
@@ -39,6 +39,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.validators.detai
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
@@ -50,7 +51,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.math.BigDecimal
 
 class ConfirmStartParachainStakingViewModel(
     private val parachainStakingRouter: ParachainStakingRouter,
@@ -76,6 +76,8 @@ class ConfirmStartParachainStakingViewModel(
     Validatable by validationExecutor,
     FeeLoaderMixin by feeLoaderMixin,
     ExternalActions by externalActions {
+
+    private val decimalFee = mapFeeFromParcel(payload.fee)
 
     // Take state only once since subscribing to it might cause switch to Delegator state while waiting for tx confirmation
     private val delegatorStateFlow = flowOf { delegatorStateUseCase.currentDelegatorState() }
@@ -149,27 +151,25 @@ class ConfirmStartParachainStakingViewModel(
     }
 
     private fun setInitialFee() = launch {
-        feeLoaderMixin.setFee(payload.fee)
+        feeLoaderMixin.setFee(decimalFee.networkFee)
     }
 
-    private fun sendTransactionIfValid() = requireFee { _ ->
-        launch {
-            val payload = StartParachainStakingValidationPayload(
-                amount = payload.amount,
-                fee = payload.fee,
-                collator = collator(),
-                asset = assetFlow.first(),
-                delegatorState = delegatorStateFlow.first(),
-            )
+    private fun sendTransactionIfValid() = launch {
+        val payload = StartParachainStakingValidationPayload(
+            amount = payload.amount,
+            fee = decimalFee,
+            collator = collator(),
+            asset = assetFlow.first(),
+            delegatorState = delegatorStateFlow.first(),
+        )
 
-            validationExecutor.requireValid(
-                validationSystem = validationSystem,
-                payload = payload,
-                validationFailureTransformer = { startParachainStakingValidationFailure(it, resourceManager) },
-                progressConsumer = _showNextProgress.progressConsumer()
-            ) {
-                sendTransaction()
-            }
+        validationExecutor.requireValid(
+            validationSystem = validationSystem,
+            payload = payload,
+            validationFailureTransformer = { startParachainStakingValidationFailure(it, resourceManager) },
+            progressConsumer = _showNextProgress.progressConsumer()
+        ) {
+            sendTransaction()
         }
     }
 
@@ -203,9 +203,4 @@ class ConfirmStartParachainStakingViewModel(
             StartParachainStakingMode.BOND_MORE -> parachainStakingRouter.returnToStakingMain()
         }
     }
-
-    private fun requireFee(block: (BigDecimal) -> Unit) = feeLoaderMixin.requireFee(
-        block,
-        onError = { title, message -> showError(title, message) }
-    )
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/start/confirm/model/ConfirmStartParachainStakingPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/start/confirm/model/ConfirmStartParachainStakingPayload.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.parachainStakin
 import android.os.Parcelable
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.select.model.CollatorParcelModel
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.start.common.StartParachainStakingMode
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
 
@@ -10,6 +11,6 @@ import java.math.BigDecimal
 class ConfirmStartParachainStakingPayload(
     val collator: CollatorParcelModel,
     val amount: BigDecimal,
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
     val flowMode: StartParachainStakingMode
 ) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/unbond/confirm/ParachainStakingUnbondConfirmViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/unbond/confirm/ParachainStakingUnbondConfirmViewModel.kt
@@ -128,7 +128,7 @@ class ParachainStakingUnbondConfirmViewModel(
     }
 
     private fun setInitialFee() = launch {
-        feeLoaderMixin.setFee(decimalFee.networkFee)
+        feeLoaderMixin.setFee(decimalFee.genericFee)
     }
 
     private fun sendTransactionIfValid() = launch {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/unbond/confirm/ParachainStakingUnbondConfirmViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/unbond/confirm/ParachainStakingUnbondConfirmViewModel.kt
@@ -32,6 +32,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.validators.detai
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
@@ -65,6 +66,8 @@ class ParachainStakingUnbondConfirmViewModel(
     Validatable by validationExecutor,
     FeeLoaderMixin by feeLoaderMixin,
     ExternalActions by externalActions {
+
+    private val decimalFee = mapFeeFromParcel(payload.fee)
 
     val hintsMixin = hintsMixinFactory.create(coroutineScope = this)
 
@@ -125,13 +128,13 @@ class ParachainStakingUnbondConfirmViewModel(
     }
 
     private fun setInitialFee() = launch {
-        feeLoaderMixin.setFee(payload.fee)
+        feeLoaderMixin.setFee(decimalFee.networkFee)
     }
 
     private fun sendTransactionIfValid() = launch {
         val payload = ParachainStakingUnbondValidationPayload(
             amount = payload.amount,
-            fee = payload.fee,
+            fee = decimalFee,
             collator = collator(),
             asset = assetFlow.first()
         )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/unbond/confirm/model/ParachainStakingUnbondConfirmPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/unbond/confirm/model/ParachainStakingUnbondConfirmPayload.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.parachainStakin
 
 import android.os.Parcelable
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.select.model.CollatorParcelModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
 
@@ -9,5 +10,5 @@ import java.math.BigDecimal
 class ParachainStakingUnbondConfirmPayload(
     val collator: CollatorParcelModel,
     val amount: BigDecimal,
-    val fee: BigDecimal
+    val fee: FeeParcelModel
 ) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/yieldBoost/confirm/YieldBoostConfirmViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/yieldBoost/confirm/YieldBoostConfirmViewModel.kt
@@ -36,6 +36,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.yieldBoost.confirm.model.YieldBoostConfirmPayload
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
@@ -68,6 +69,8 @@ class YieldBoostConfirmViewModel(
     Validatable by validationExecutor,
     FeeLoaderMixin by feeLoaderMixin,
     ExternalActions by externalActions {
+
+    private val decimalFee = mapFeeFromParcel(payload.fee)
 
     private val assetFlow = assetUseCase.currentAssetFlow()
         .shareInBackground()
@@ -138,14 +141,14 @@ class YieldBoostConfirmViewModel(
     }
 
     private fun setInitialFee() = launch {
-        feeLoaderMixin.setFee(payload.fee)
+        feeLoaderMixin.setFee(decimalFee.networkFee)
     }
 
     private fun sendTransactionIfValid() = launch {
         val payload = YieldBoostValidationPayload(
             collator = collator(),
             configuration = yieldBoostConfiguration(),
-            fee = payload.fee,
+            fee = decimalFee,
             activeTasks = activeTasksFlow.first(),
             asset = assetFlow.first()
         )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/yieldBoost/confirm/YieldBoostConfirmViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/yieldBoost/confirm/YieldBoostConfirmViewModel.kt
@@ -141,7 +141,7 @@ class YieldBoostConfirmViewModel(
     }
 
     private fun setInitialFee() = launch {
-        feeLoaderMixin.setFee(decimalFee.networkFee)
+        feeLoaderMixin.setFee(decimalFee.genericFee)
     }
 
     private fun sendTransactionIfValid() = launch {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/yieldBoost/confirm/model/YieldBoostConfirmPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/parachainStaking/yieldBoost/confirm/model/YieldBoostConfirmPayload.kt
@@ -3,15 +3,15 @@ package io.novafoundation.nova.feature_staking_impl.presentation.parachainStakin
 import android.os.Parcelable
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.yieldBoost.YieldBoostConfiguration
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.select.model.CollatorParcelModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
-import java.math.BigDecimal
 import java.math.BigInteger
 
 @Parcelize
 class YieldBoostConfirmPayload(
     val collator: CollatorParcelModel,
     val configurationParcel: YieldBoostConfigurationParcel,
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
 ) : Parcelable
 
 sealed class YieldBoostConfigurationParcel(open val collatorIdHex: String) : Parcelable {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/payouts/confirm/ConfirmPayoutViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/payouts/confirm/ConfirmPayoutViewModel.kt
@@ -26,7 +26,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.payouts.confirm.
 import io.novafoundation.nova.feature_staking_impl.presentation.payouts.model.mapPendingPayoutParcelToPayout
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.requireFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
@@ -101,22 +101,26 @@ class ConfirmPayoutViewModel(
         router.back()
     }
 
-    private fun sendTransactionIfValid() = feeLoaderMixin.requireFee(this) { fee ->
-        launch {
-            val asset = assetFlow.first()
-            val accountAddress = stakingStateFlow.first().accountAddress
-            val amount = asset.token.configuration.amountFromPlanks(payload.totalRewardInPlanks)
+    private fun sendTransactionIfValid() = launch {
+        val asset = assetFlow.first()
+        val accountAddress = stakingStateFlow.first().accountAddress
+        val amount = asset.token.configuration.amountFromPlanks(payload.totalRewardInPlanks)
 
-            val makePayoutPayload = MakePayoutPayload(accountAddress, fee, amount, asset, payouts)
+        val makePayoutPayload = MakePayoutPayload(
+            originAddress = accountAddress,
+            fee = feeLoaderMixin.awaitDecimalFee(),
+            totalReward = amount,
+            asset = asset,
+            payouts = payouts
+        )
 
-            validationExecutor.requireValid(
-                validationSystem = validationSystem,
-                payload = makePayoutPayload,
-                validationFailureTransformer = ::payloadValidationFailure,
-                progressConsumer = _showNextProgress.progressConsumer()
-            ) {
-                sendTransaction(makePayoutPayload)
-            }
+        validationExecutor.requireValid(
+            validationSystem = validationSystem,
+            payload = makePayoutPayload,
+            validationFailureTransformer = ::payloadValidationFailure,
+            progressConsumer = _showNextProgress.progressConsumer()
+        ) {
+            sendTransaction(makePayoutPayload)
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/bond/confirm/ConfirmBondMorePayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/bond/confirm/ConfirmBondMorePayload.kt
@@ -1,12 +1,13 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.staking.bond.confirm
 
 import android.os.Parcelable
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
 
 @Parcelize
 class ConfirmBondMorePayload(
     val amount: BigDecimal,
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
     val stashAddress: String,
 ) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/bond/confirm/ConfirmBondMoreViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/bond/confirm/ConfirmBondMoreViewModel.kt
@@ -24,6 +24,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.bond.bon
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
@@ -48,6 +49,8 @@ class ConfirmBondMoreViewModel(
     ExternalActions by externalActions,
     Validatable by validationExecutor {
 
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
     private val _showNextProgress = MutableLiveData(false)
     val showNextProgress: LiveData<Boolean> = _showNextProgress
 
@@ -68,7 +71,7 @@ class ConfirmBondMoreViewModel(
         .shareInBackground()
 
     val feeStatusFlow = stashAssetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(payload.fee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.genericFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }
@@ -94,7 +97,7 @@ class ConfirmBondMoreViewModel(
     private fun maybeGoToNext() = launch {
         val payload = BondMoreValidationPayload(
             stashAddress = payload.stashAddress,
-            fee = payload.fee,
+            fee = decimalFee,
             amount = payload.amount,
             stashAsset = stashAssetFlow.first()
         )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/bond/select/SelectBondMoreViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/bond/select/SelectBondMoreViewModel.kt
@@ -24,6 +24,8 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -102,37 +104,32 @@ class SelectBondMoreViewModel(
         )
     }
 
-    private fun requireFee(block: (BigDecimal) -> Unit) = feeLoaderMixin.requireFee(
-        block,
-        onError = { title, message -> showError(title, message) }
-    )
+    private fun maybeGoToNext() = launch {
+        _showNextProgress.value = true
 
-    private fun maybeGoToNext() = requireFee { fee ->
-        launch {
-            val payload = BondMoreValidationPayload(
-                stashAddress = stashAddress(),
-                fee = fee,
-                amount = amountChooserMixin.amount.first(),
-                stashAsset = assetFlow.first()
-            )
+        val payload = BondMoreValidationPayload(
+            stashAddress = stashAddress(),
+            fee = feeLoaderMixin.awaitDecimalFee(),
+            amount = amountChooserMixin.amount.first(),
+            stashAsset = assetFlow.first()
+        )
 
-            validationExecutor.requireValid(
-                validationSystem = validationSystem,
-                payload = payload,
-                validationFailureTransformer = { bondMoreValidationFailure(it, resourceManager) },
-                progressConsumer = _showNextProgress.progressConsumer()
-            ) {
-                _showNextProgress.value = false
+        validationExecutor.requireValid(
+            validationSystem = validationSystem,
+            payload = payload,
+            validationFailureTransformer = { bondMoreValidationFailure(it, resourceManager) },
+            progressConsumer = _showNextProgress.progressConsumer()
+        ) {
+            _showNextProgress.value = false
 
-                openConfirm(payload)
-            }
+            openConfirm(payload)
         }
     }
 
     private fun openConfirm(validationPayload: BondMoreValidationPayload) {
         val confirmPayload = ConfirmBondMorePayload(
             amount = validationPayload.amount,
-            fee = validationPayload.fee,
+            fee = mapFeeToParcel(validationPayload.fee),
             stashAddress = validationPayload.stashAddress,
         )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/controller/confirm/ConfirmSetControllerPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/controller/confirm/ConfirmSetControllerPayload.kt
@@ -1,12 +1,13 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.staking.controller.confirm
 
 import android.os.Parcelable
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
 
 @Parcelize
 class ConfirmSetControllerPayload(
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
     val stashAddress: String,
     val controllerAddress: String,
     val transferable: BigDecimal

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/controller/confirm/ConfirmSetControllerViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/controller/confirm/ConfirmSetControllerViewModel.kt
@@ -20,6 +20,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.controller.set.bondSetControllerValidationFailure
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,12 +43,14 @@ class ConfirmSetControllerViewModel(
     Validatable by validationExecutor,
     ExternalActions by externalActions {
 
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
     private val assetFlow = interactor.assetFlow(payload.stashAddress)
         .inBackground()
         .share()
 
     val feeStatusFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(payload.fee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }
@@ -90,7 +93,7 @@ class ConfirmSetControllerViewModel(
         val payload = SetControllerValidationPayload(
             stashAddress = payload.stashAddress,
             controllerAddress = payload.controllerAddress,
-            fee = payload.fee,
+            fee = decimalFee,
             transferable = payload.transferable
         )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/controller/confirm/ConfirmSetControllerViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/controller/confirm/ConfirmSetControllerViewModel.kt
@@ -50,7 +50,7 @@ class ConfirmSetControllerViewModel(
         .share()
 
     val feeStatusFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.genericFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/controller/set/SetControllerViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/controller/set/SetControllerViewModel.kt
@@ -35,7 +35,8 @@ import io.novafoundation.nova.feature_staking_impl.domain.validations.controller
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.controller.confirm.ConfirmSetControllerPayload
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.requireFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
 import kotlinx.coroutines.flow.Flow
@@ -199,34 +200,34 @@ class SetControllerViewModel(
 
     private suspend fun controllerAddress() = accountStakingFlow.first().controllerAddress
 
-    private fun maybeGoToConfirm() = feeLoaderMixin.requireFee(this) { fee ->
-        launch {
-            val controllerAddress = getNewControllerAddress()
+    private fun maybeGoToConfirm() = launch {
+        validationInProgress.value = true
 
-            val payload = SetControllerValidationPayload(
-                stashAddress = stashAddress(),
-                controllerAddress = controllerAddress,
-                fee = fee,
-                transferable = assetFlow.first().transferable
-            )
+        val controllerAddress = getNewControllerAddress()
 
-            validationExecutor.requireValid(
-                validationSystem = validationSystem,
-                payload = payload,
-                progressConsumer = validationInProgress.progressConsumer(),
-                validationFailureTransformer = { bondSetControllerValidationFailure(it, resourceManager) }
-            ) {
-                validationInProgress.value = false
+        val payload = SetControllerValidationPayload(
+            stashAddress = stashAddress(),
+            controllerAddress = controllerAddress,
+            fee = feeLoaderMixin.awaitDecimalFee(),
+            transferable = assetFlow.first().transferable
+        )
 
-                openConfirm(
-                    ConfirmSetControllerPayload(
-                        fee = fee,
-                        stashAddress = payload.stashAddress,
-                        controllerAddress = payload.controllerAddress,
-                        transferable = payload.transferable
-                    )
+        validationExecutor.requireValid(
+            validationSystem = validationSystem,
+            payload = payload,
+            progressConsumer = validationInProgress.progressConsumer(),
+            validationFailureTransformer = { bondSetControllerValidationFailure(it, resourceManager) }
+        ) {
+            validationInProgress.value = false
+
+            openConfirm(
+                ConfirmSetControllerPayload(
+                    fee = mapFeeToParcel(it.fee),
+                    stashAddress = payload.stashAddress,
+                    controllerAddress = payload.controllerAddress,
+                    transferable = payload.transferable
                 )
-            }
+            )
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/rewardDestination/confirm/ConfirmRewardDestinationViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/rewardDestination/confirm/ConfirmRewardDestinationViewModel.kt
@@ -29,6 +29,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.rewardDe
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.rewardDestination.select.rewardDestinationValidationFailure
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
 import kotlinx.coroutines.flow.filterIsInstance
@@ -52,6 +53,8 @@ class ConfirmRewardDestinationViewModel(
 ) : BaseViewModel(),
     Validatable by validationExecutor,
     ExternalActions by externalActions {
+
+    private val decimalFee = mapFeeFromParcel(payload.fee)
 
     private val _showNextProgress = MutableLiveData(false)
     val showNextProgress: LiveData<Boolean> = _showNextProgress
@@ -78,7 +81,7 @@ class ConfirmRewardDestinationViewModel(
         .shareInBackground()
 
     val feeStatusFlow = controllerAssetFlow.map {
-        FeeStatus.Loaded(mapFeeToFeeModel(payload.fee, it.token))
+        FeeStatus.Loaded(mapFeeToFeeModel(decimalFee.networkFee, it.token))
     }
         .shareInBackground()
 
@@ -128,7 +131,7 @@ class ConfirmRewardDestinationViewModel(
 
         val payload = RewardDestinationValidationPayload(
             availableControllerBalance = controllerAsset.transferable,
-            fee = payload.fee,
+            fee = decimalFee,
             stashState = stashState
         )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/rewardDestination/confirm/ConfirmRewardDestinationViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/rewardDestination/confirm/ConfirmRewardDestinationViewModel.kt
@@ -81,7 +81,7 @@ class ConfirmRewardDestinationViewModel(
         .shareInBackground()
 
     val feeStatusFlow = controllerAssetFlow.map {
-        FeeStatus.Loaded(mapFeeToFeeModel(decimalFee.networkFee, it.token))
+        FeeStatus.Loaded(mapFeeToFeeModel(decimalFee.genericFee, it.token))
     }
         .shareInBackground()
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/rewardDestination/confirm/parcel/ConfirmRewardDestinationPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/rewardDestination/confirm/parcel/ConfirmRewardDestinationPayload.kt
@@ -1,11 +1,11 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.staking.rewardDestination.confirm.parcel
 
 import android.os.Parcelable
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
-import java.math.BigDecimal
 
 @Parcelize
 class ConfirmRewardDestinationPayload(
-    val fee: BigDecimal,
+    val fee: FeeParcelModel,
     val rewardDestination: RewardDestinationParcelModel,
 ) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/confirm/ConfirmMultiStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/confirm/ConfirmMultiStakingViewModel.kt
@@ -104,7 +104,7 @@ class ConfirmMultiStakingViewModel(
         .shareInBackground()
 
     val feeStatusFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.genericFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/confirm/ConfirmMultiStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/confirm/ConfirmMultiStakingViewModel.kt
@@ -104,7 +104,7 @@ class ConfirmMultiStakingViewModel(
         .shareInBackground()
 
     val feeStatusFlow = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(decimalFee.fee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/ConfirmUnbondPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/ConfirmUnbondPayload.kt
@@ -1,11 +1,12 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.staking.unbond.confirm
 
 import android.os.Parcelable
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
 
 @Parcelize
 class ConfirmUnbondPayload(
     val amount: BigDecimal,
-    val fee: BigDecimal
+    val fee: FeeParcelModel
 ) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/ConfirmUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/ConfirmUnbondViewModel.kt
@@ -80,7 +80,7 @@ class ConfirmUnbondViewModel(
         .shareInBackground()
 
     val feeStatusLiveData = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.genericFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/ConfirmUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/ConfirmUnbondViewModel.kt
@@ -26,6 +26,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.unbond.u
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
@@ -52,6 +53,8 @@ class ConfirmUnbondViewModel(
     ExternalActions by externalActions,
     Validatable by validationExecutor {
 
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
     private val _showNextProgress = MutableLiveData(false)
     val showNextProgress: LiveData<Boolean> = _showNextProgress
 
@@ -77,7 +80,7 @@ class ConfirmUnbondViewModel(
         .shareInBackground()
 
     val feeStatusLiveData = assetFlow.map { asset ->
-        val feeModel = mapFeeToFeeModel(payload.fee, asset.token)
+        val feeModel = mapFeeToFeeModel(decimalFee.networkFee, asset.token)
 
         FeeStatus.Loaded(feeModel)
     }
@@ -111,7 +114,7 @@ class ConfirmUnbondViewModel(
         val payload = UnbondValidationPayload(
             asset = asset,
             stash = accountStakingFlow.first(),
-            fee = payload.fee,
+            fee = decimalFee,
             amount = payload.amount,
         )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/select/SelectUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/select/SelectUnbondViewModel.kt
@@ -126,7 +126,6 @@ class SelectUnbondViewModel(
         }
     }
 
-
     private fun openConfirm(validationPayload: UnbondValidationPayload) {
         val confirmUnbondPayload = ConfirmUnbondPayload(
             amount = validationPayload.amount,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/select/SelectUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/select/SelectUnbondViewModel.kt
@@ -22,6 +22,8 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.transferableAmountModelOf
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
@@ -100,39 +102,35 @@ class SelectUnbondViewModel(
         )
     }
 
-    private fun requireFee(block: (BigDecimal) -> Unit) = feeLoaderMixin.requireFee(
-        block,
-        onError = { title, message -> showError(title, message) }
-    )
+    private fun maybeGoToNext() = launch {
+        _showNextProgress.value = true
 
-    private fun maybeGoToNext() = requireFee { fee ->
-        launch {
-            val asset = assetFlow.first()
+        val asset = assetFlow.first()
 
-            val payload = UnbondValidationPayload(
-                stash = accountStakingFlow.first(),
-                asset = asset,
-                fee = fee,
-                amount = amountMixin.amount.first(),
-            )
+        val payload = UnbondValidationPayload(
+            stash = accountStakingFlow.first(),
+            asset = asset,
+            fee = feeLoaderMixin.awaitDecimalFee(),
+            amount = amountMixin.amount.first(),
+        )
 
-            validationExecutor.requireValid(
-                validationSystem = validationSystem,
-                payload = payload,
-                validationFailureTransformerCustom = { status, flowActions -> unbondValidationFailure(status, flowActions, resourceManager) },
-                progressConsumer = _showNextProgress.progressConsumer()
-            ) { correctPayload ->
-                _showNextProgress.value = false
+        validationExecutor.requireValid(
+            validationSystem = validationSystem,
+            payload = payload,
+            validationFailureTransformerCustom = { status, flowActions -> unbondValidationFailure(status, flowActions, resourceManager) },
+            progressConsumer = _showNextProgress.progressConsumer()
+        ) { correctPayload ->
+            _showNextProgress.value = false
 
-                openConfirm(correctPayload)
-            }
+            openConfirm(correctPayload)
         }
     }
+
 
     private fun openConfirm(validationPayload: UnbondValidationPayload) {
         val confirmUnbondPayload = ConfirmUnbondPayload(
             amount = validationPayload.amount,
-            fee = validationPayload.fee
+            fee = mapFeeToParcel(validationPayload.fee)
         )
 
         router.openConfirmUnbond(confirmUnbondPayload)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/confirm/ConfirmChangeValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/confirm/ConfirmChangeValidatorsViewModel.kt
@@ -34,6 +34,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.common.validatio
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.change.activeStake
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.change.confirm.hints.ConfirmStakeHintsMixinFactory
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.runtime.state.AnySelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chain
 import kotlinx.coroutines.flow.filterIsInstance
@@ -41,7 +42,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import java.math.BigDecimal
 
 class ConfirmChangeValidatorsViewModel(
     private val router: StakingRouter,
@@ -135,21 +135,21 @@ class ConfirmChangeValidatorsViewModel(
 
     private fun prepareNominations() = currentProcessState.validators.map(Validator::accountIdHex)
 
-    private fun sendTransactionIfValid() = requireFee { fee ->
-        launch {
-            val payload = SetupStakingPayload(
-                maxFee = fee,
-                controllerAsset = controllerAssetFlow.first()
-            )
+    private fun sendTransactionIfValid() = launch {
+        _showNextProgress.value = true
 
-            validationExecutor.requireValid(
-                validationSystem = validationSystem,
-                payload = payload,
-                validationFailureTransformer = { stakingValidationFailure(it, resourceManager) },
-                progressConsumer = _showNextProgress.progressConsumer()
-            ) {
-                sendTransaction()
-            }
+        val payload = SetupStakingPayload(
+            maxFee = feeLoaderMixin.awaitDecimalFee(),
+            controllerAsset = controllerAssetFlow.first()
+        )
+
+        validationExecutor.requireValid(
+            validationSystem = validationSystem,
+            payload = payload,
+            validationFailureTransformer = { stakingValidationFailure(it, resourceManager) },
+            progressConsumer = _showNextProgress.progressConsumer()
+        ) {
+            sendTransaction()
         }
     }
 
@@ -171,11 +171,6 @@ class ConfirmChangeValidatorsViewModel(
             showError(setupResult.requireException())
         }
     }
-
-    private fun requireFee(block: (BigDecimal) -> Unit) = feeLoaderMixin.requireFee(
-        block,
-        onError = { title, message -> showError(title, message) }
-    )
 
     private suspend fun generateDestinationModel(address: String, name: String?): AddressModel {
         return addressIconGenerator.createAddressModel(

--- a/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/model/SwapQuote.kt
+++ b/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/model/SwapQuote.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_swap_api.domain.model
 
 import io.novafoundation.nova.common.utils.Percent
 import io.novafoundation.nova.feature_account_api.data.model.Fee
+import io.novafoundation.nova.feature_account_api.data.model.amountByRequestedAccount
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.model.ChainAssetWithAmount
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
@@ -66,7 +67,7 @@ class SwapFee(
 ) : GenericFee
 
 val SwapFee.totalDeductedPlanks: Balance
-    get() = networkFee.amount + minimumBalanceBuyIn.commissionAssetToSpendOnBuyIn
+    get() = networkFee.amountByRequestedAccount + minimumBalanceBuyIn.commissionAssetToSpendOnBuyIn
 
 sealed class MinimumBalanceBuyIn {
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
@@ -11,7 +11,7 @@ import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.Tran
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_account_api.data.model.Fee
-import io.novafoundation.nova.feature_account_api.data.model.InlineFee
+import io.novafoundation.nova.feature_account_api.data.model.SubstrateFee
 import io.novafoundation.nova.feature_swap_api.domain.model.MinimumBalanceBuyIn
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapDirection
@@ -165,6 +165,9 @@ private class AssetConversionExchange(
         }
     }
 
+    // TODO we purposefully do not `nativeTokenFee.amountByRequestedAccount`
+    // since we have disabled fee payment in custom tokens for accounts where difference matters
+    // We should adapt it if we decide to remove the restriction
     private suspend fun calculateCustomTokenFee(
         nativeTokenFee: Fee,
         nativeAsset: Asset,
@@ -197,7 +200,7 @@ private class AssetConversionExchange(
         }
 
         return AssetExchangeFee(
-            networkFee = InlineFee(toBuyNativeFee),
+            networkFee = SubstrateFee(toBuyNativeFee, nativeTokenFee.submissionOrigin),
             minimumBalanceBuyIn = minimumBalanceBuyIn
         )
     }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
@@ -165,8 +165,8 @@ private class AssetConversionExchange(
         }
     }
 
-    // TODO we purposefully do not `nativeTokenFee.amountByRequestedAccount`
-    // since we have disabled fee payment in custom tokens for accounts where difference matters
+    // TODO we purposefully do not use `nativeTokenFee.amountByRequestedAccount`
+    // since we have disabled fee payment in custom tokens for accounts where the difference matters (e.g. proxy)
     // We should adapt it if we decide to remove the restriction
     private suspend fun calculateCustomTokenFee(
         nativeTokenFee: Fee,

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/repository/SwapTransactionHistoryRepository.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/repository/SwapTransactionHistoryRepository.kt
@@ -42,6 +42,7 @@ class RealSwapTransactionHistoryRepository(
                 hash = txSubmission.hash,
                 originAddress = chain.addressOf(txSubmission.submissionOrigin.requestedOrigin),
                 assetId = chainAsset.localId,
+                // Insert fee regardless of who actually paid it
                 fee = feeAsset.withAmountLocal(fee.networkFee.amount),
                 amountIn = assetIn.withAmountLocal(swapLimit.expectedAmountIn),
                 amountOut = assetOut.withAmountLocal(swapLimit.expectedAmountOut),

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureModule.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureModule.kt
@@ -13,13 +13,13 @@ import io.novafoundation.nova.feature_buy_api.domain.BuyTokenRegistry
 import io.novafoundation.nova.feature_swap_api.domain.interactor.SwapAvailabilityInteractor
 import io.novafoundation.nova.feature_swap_api.domain.swap.SwapService
 import io.novafoundation.nova.feature_swap_api.presentation.formatters.SwapRateFormatter
+import io.novafoundation.nova.feature_swap_api.presentation.state.SwapSettingsStateProvider
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.assetConversion.AssetConversionExchangeFactory
 import io.novafoundation.nova.feature_swap_impl.data.network.blockhain.updaters.SwapUpdateSystemFactory
 import io.novafoundation.nova.feature_swap_impl.data.repository.RealSwapTransactionHistoryRepository
 import io.novafoundation.nova.feature_swap_impl.data.repository.SwapTransactionHistoryRepository
-import io.novafoundation.nova.feature_swap_impl.domain.interactor.SwapInteractor
-import io.novafoundation.nova.feature_swap_api.presentation.state.SwapSettingsStateProvider
 import io.novafoundation.nova.feature_swap_impl.domain.interactor.RealSwapAvailabilityInteractor
+import io.novafoundation.nova.feature_swap_impl.domain.interactor.SwapInteractor
 import io.novafoundation.nova.feature_swap_impl.domain.swap.RealSwapService
 import io.novafoundation.nova.feature_swap_impl.presentation.common.PriceImpactFormatter
 import io.novafoundation.nova.feature_swap_impl.presentation.common.RealPriceImpactFormatter
@@ -69,9 +69,10 @@ class SwapFeatureModule {
     fun provideSwapService(
         assetConversionExchangeFactory: AssetConversionExchangeFactory,
         computationalCache: ComputationalCache,
-        chainRegistry: ChainRegistry
+        chainRegistry: ChainRegistry,
+        accountRepository: AccountRepository
     ): SwapService {
-        return RealSwapService(assetConversionExchangeFactory, computationalCache, chainRegistry)
+        return RealSwapService(assetConversionExchangeFactory, computationalCache, chainRegistry, accountRepository)
     }
 
     @Provides

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/interactor/SwapInteractor.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/interactor/SwapInteractor.kt
@@ -89,7 +89,10 @@ class SwapInteractor(
         return swapService.quote(quoteArgs)
     }
 
-    suspend fun executeSwap(swapExecuteArgs: SwapExecuteArgs, decimalFee: GenericDecimalFee<SwapFee>): Result<ExtrinsicSubmission> = withContext(Dispatchers.IO) {
+    suspend fun executeSwap(
+        swapExecuteArgs: SwapExecuteArgs,
+        decimalFee: GenericDecimalFee<SwapFee>
+    ): Result<ExtrinsicSubmission> = withContext(Dispatchers.IO) {
         swapService.swap(swapExecuteArgs)
             .onSuccess { submission ->
                 swapTransactionHistoryRepository.insertPendingSwap(

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SufficientBalanceConsideringNonSufficientAssetsValidation.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SufficientBalanceConsideringNonSufficientAssetsValidation.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_swap_impl.domain.validation
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.valid
 import io.novafoundation.nova.common.validation.validOrError
+import io.novafoundation.nova.feature_account_api.data.model.amountByRequestedAccount
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.AssetSourceRegistry
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.existentialDepositInPlanks
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.isSelfSufficientAsset
@@ -21,7 +22,7 @@ class SufficientBalanceConsideringNonSufficientAssetsValidation(
 
         if (!isSelfSufficientAssetOut && assetIn.token.configuration.isCommissionAsset) {
             val existentialDeposit = assetSourceRegistry.existentialDepositInPlanks(value.detailedAssetIn.chain, assetIn.token.configuration)
-            val fee = value.swapFee.networkFee.amount
+            val fee = value.decimalFee.networkFee.amountByRequestedAccount
 
             return validOrError(assetIn.balanceCountedTowardsEDInPlanks - existentialDeposit >= amount + fee) {
                 SwapValidationFailure.InsufficientBalance.BalanceNotConsiderInsufficientReceiveAsset(

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapPayloadValidation.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapPayloadValidation.kt
@@ -9,6 +9,7 @@ import io.novafoundation.nova.feature_swap_api.domain.model.commissionAssetToSpe
 import io.novafoundation.nova.feature_swap_api.domain.model.totalDeductedPlanks
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.GenericDecimalFee
 import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigInteger
@@ -18,7 +19,7 @@ data class SwapValidationPayload(
     val detailedAssetOut: SwapAssetData,
     val slippage: Percent,
     val feeAsset: Asset,
-    val swapFee: SwapFee,
+    val decimalFee: GenericDecimalFee<SwapFee>,
     val swapQuote: SwapQuote,
     val swapQuoteArgs: SwapQuoteArgs,
     val swapExecuteArgs: SwapExecuteArgs
@@ -43,14 +44,14 @@ val SwapValidationPayload.swapAmountInFeeToken: Balance
 
 val SwapValidationPayload.toBuyAmountToKeepMainEDInFeeAsset: Balance
     get() = if (isFeePayingByAssetIn) {
-        swapFee.minimumBalanceBuyIn.commissionAssetToSpendOnBuyIn
+        decimalFee.genericFee.minimumBalanceBuyIn.commissionAssetToSpendOnBuyIn
     } else {
         BigInteger.ZERO
     }
 
 val SwapValidationPayload.totalDeductedAmountInFeeToken: Balance
     get() = if (isFeePayingByAssetIn) {
-        swapFee.totalDeductedPlanks
+        decimalFee.genericFee.totalDeductedPlanks
     } else {
         BigInteger.ZERO
     }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/EnoughNativeAssetBalanceToPayFeeConsideringEDValidation.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/EnoughNativeAssetBalanceToPayFeeConsideringEDValidation.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_swap_impl.domain.validation.validations
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.valid
 import io.novafoundation.nova.common.validation.validOrError
+import io.novafoundation.nova.feature_account_api.data.model.amountByRequestedAccount
 import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidation
 import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure
 import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NotEnoughFunds
@@ -24,7 +25,7 @@ class EnoughNativeAssetBalanceToPayFeeConsideringEDValidation(
         if (feeChainAsset.isCommissionAsset) {
             val chain = chainRegistry.getChain(feeChainAsset.chainId)
             val existentialDeposit = assetSourceRegistry.existentialDepositInPlanks(chain, feeChainAsset)
-            return validOrError(value.feeAsset.balanceCountedTowardsEDInPlanks - value.swapFee.networkFee.amount >= existentialDeposit) {
+            return validOrError(value.feeAsset.balanceCountedTowardsEDInPlanks - value.decimalFee.networkFee.amountByRequestedAccount >= existentialDeposit) {
                 NotEnoughFunds.ToPayFeeAndStayAboveED(value.feeAsset.token.configuration)
             }
         }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/SwapFeeSufficientBalanceValidation.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/SwapFeeSufficientBalanceValidation.kt
@@ -28,16 +28,16 @@ class SwapFeeSufficientBalanceValidation : SwapValidation {
             val toBuyAmountToKeepEDInFeeAsset = value.toBuyAmountToKeepMainEDInFeeAsset
 
             return if (toBuyAmountToKeepEDInFeeAsset.isZero) {
-                InsufficientBalance.NoNeedsToBuyMainAssetED(chainAssetIn, feeAsset, maxAmountToSwap, value.swapFee.networkFee).validationError()
+                InsufficientBalance.NoNeedsToBuyMainAssetED(chainAssetIn, feeAsset, maxAmountToSwap, value.decimalFee.networkFee).validationError()
             } else {
                 InsufficientBalance.NeedsToBuyMainAssetED(
                     value.feeAsset.token.configuration,
                     chainAssetIn,
-                    value.swapFee.minimumBalanceBuyIn.requireNativeAsset(),
-                    toBuyAmountToKeepEDInCommissionAsset = value.swapFee.minimumBalanceBuyIn.nativeMinimumBalance,
+                    value.decimalFee.genericFee.minimumBalanceBuyIn.requireNativeAsset(),
+                    toBuyAmountToKeepEDInCommissionAsset = value.decimalFee.genericFee.minimumBalanceBuyIn.nativeMinimumBalance,
                     toSellAmountToKeepEDUsingAssetIn = toBuyAmountToKeepEDInFeeAsset,
                     maxAmountToSwap,
-                    value.swapFee.networkFee
+                    value.decimalFee.networkFee
                 ).validationError()
             }
         }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/SwapSmallRemainingBalanceValidation.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/SwapSmallRemainingBalanceValidation.kt
@@ -39,12 +39,12 @@ class SwapSmallRemainingBalanceValidation(
                 TooSmallRemainingBalance.NeedsToBuyMainAssetED(
                     feeChainAsset,
                     chainAssetIn,
-                    value.swapFee.minimumBalanceBuyIn.requireNativeAsset(),
+                    value.decimalFee.genericFee.minimumBalanceBuyIn.requireNativeAsset(),
                     assetInExistentialDeposit,
-                    toBuyAmountToKeepEDInCommissionAsset = value.swapFee.minimumBalanceBuyIn.nativeMinimumBalance,
+                    toBuyAmountToKeepEDInCommissionAsset = value.decimalFee.genericFee.minimumBalanceBuyIn.nativeMinimumBalance,
                     toSellAmountToKeepEDUsingAssetIn = toBuyAmountToKeepEDInFeeAsset,
                     remainingBalance,
-                    value.swapFee.networkFee
+                    value.decimalFee.networkFee
                 ).validationError()
             }
         }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/SwapConfirmationViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/SwapConfirmationViewModel.kt
@@ -60,7 +60,7 @@ import io.novafoundation.nova.feature_swap_impl.presentation.mixin.maxAction.Max
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFeeLoaderMixin
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.getFeeOrNull
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.getDecimalFeeOrNull
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AmountModel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.fullChainAssetId
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
@@ -253,7 +253,7 @@ class SwapConfirmationViewModel(
     }
 
     private fun executeSwap(validationPayload: SwapValidationPayload) = launch {
-        swapInteractor.executeSwap(validationPayload.swapExecuteArgs, validationPayload.swapFee)
+        swapInteractor.executeSwap(validationPayload.swapExecuteArgs, validationPayload.decimalFee)
             .onSuccess { navigateToNextScreen(validationPayload.swapExecuteArgs.assetIn) }
             .onFailure(::showError)
 
@@ -310,7 +310,7 @@ class SwapConfirmationViewModel(
 
     private suspend fun getValidationPayload(): SwapValidationPayload? {
         val confirmationState = confirmationStateFlow.value ?: return null
-        val swapFee = feeMixin.getFeeOrNull() ?: return null
+        val swapFee = feeMixin.getDecimalFeeOrNull() ?: return null
         return swapInteractor.getValidationPayload(
             assetIn = confirmationState.swapQuote.assetIn,
             assetOut = confirmationState.swapQuote.assetOut,

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/payload/SwapConfirmationPayload.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/payload/SwapConfirmationPayload.kt
@@ -3,9 +3,10 @@ package io.novafoundation.nova.feature_swap_impl.presentation.confirmation.paylo
 import android.os.Parcelable
 import io.novafoundation.nova.feature_swap_api.presentation.model.SwapDirectionModel
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
-import java.math.BigDecimal
 import kotlinx.android.parcel.Parcelize
+import java.math.BigDecimal
 
 @Parcelize
 class SwapConfirmationPayload(
@@ -28,7 +29,7 @@ class SwapConfirmationPayload(
 
     @Parcelize
     class FeeDetails(
-        val amount: Balance,
+        val networkFee: FeeParcelModel,
         val minimumBalanceBuyIn: MinimumBalanceBuyIn
     ) : Parcelable {
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
@@ -85,6 +85,7 @@ import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChoose
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeStatus
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFeeLoaderMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.loadedDecimalFeeOrNullFlow
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.loadedFeeModelOrNullFlow
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.loadedFeeOrNullFlow
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
@@ -773,7 +774,7 @@ class SwapMainSettingsViewModel(
             feeAsset = swapSettings.feeAsset ?: return null,
             quoteArgs = quotingState.quoteArgs,
             swapQuote = quotingState.value,
-            swapFee = feeMixin.loadedFeeOrNullFlow().first() ?: return null
+            swapFee = feeMixin.loadedDecimalFeeOrNullFlow().first() ?: return null
         )
     }
 
@@ -814,7 +815,7 @@ class SwapMainSettingsViewModel(
             feeAsset = validPayload.feeAsset.token.configuration.fullId.toAssetPayload(),
             rate = validPayload.swapQuote.swapRate(),
             slippage = validPayload.slippage.value,
-            swapFee = swapConfirmationPayloadFormatter.mapFeeToModel(validPayload.swapFee)
+            swapFee = swapConfirmationPayloadFormatter.mapFeeToModel(validPayload.decimalFee)
         )
 
         swapRouter.openSwapConfirmation(payload)

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
@@ -7,17 +7,18 @@ import io.novafoundation.nova.common.validation.TransformedFailure
 import io.novafoundation.nova.common.validation.ValidationFlowActions
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.asDefault
+import io.novafoundation.nova.feature_account_api.data.model.amountByRequestedAccount
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapFee
 import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure
-import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.TooSmallRemainingBalance
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.AmountOutIsTooLowToStayAboveED
 import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.FeeChangeDetected
 import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.InsufficientBalance
-import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.AmountOutIsTooLowToStayAboveED
-import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NotEnoughLiquidity
-import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NonPositiveAmount
-import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NewRateExceededSlippage
 import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.InvalidSlippage
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NewRateExceededSlippage
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NonPositiveAmount
 import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NotEnoughFunds
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.NotEnoughLiquidity
+import io.novafoundation.nova.feature_swap_impl.domain.validation.SwapValidationFailure.TooSmallRemainingBalance
 import io.novafoundation.nova.feature_wallet_api.R
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.validation.amountIsTooBig
@@ -28,9 +29,9 @@ import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatT
 import io.novafoundation.nova.feature_wallet_api.presentation.validation.handleInsufficientBalanceCommission
 import io.novafoundation.nova.feature_wallet_api.presentation.validation.handleNonPositiveAmount
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import kotlinx.coroutines.CoroutineScope
 import java.math.BigDecimal
 import java.math.BigInteger
-import kotlinx.coroutines.CoroutineScope
 
 fun CoroutineScope.mapSwapValidationFailureToUI(
     resourceManager: ResourceManager,
@@ -85,7 +86,7 @@ fun CoroutineScope.mapSwapValidationFailureToUI(
             message = resourceManager.getString(
                 R.string.swap_failure_too_small_remaining_balance_with_buy_ed_message,
                 reason.assetInExistentialDeposit.formatPlanks(reason.assetIn),
-                reason.fee.amount.formatPlanks(reason.feeAsset),
+                reason.fee.amountByRequestedAccount.formatPlanks(reason.feeAsset),
                 reason.toSellAmountToKeepEDUsingAssetIn.formatPlanks(reason.assetIn),
                 reason.toBuyAmountToKeepEDInCommissionAsset.formatPlanks(reason.nativeAsset),
                 reason.nativeAsset.symbol,
@@ -101,7 +102,7 @@ fun CoroutineScope.mapSwapValidationFailureToUI(
             message = resourceManager.getString(
                 R.string.swap_failure_insufficient_balance_message,
                 reason.maxSwapAmount.formatPlanks(reason.assetIn),
-                reason.fee.amount.formatPlanks(reason.feeAsset)
+                reason.fee.amountByRequestedAccount.formatPlanks(reason.feeAsset)
             ),
             resourceManager = resourceManager,
             positiveButtonClick = amountInSwapMaxAction
@@ -112,7 +113,7 @@ fun CoroutineScope.mapSwapValidationFailureToUI(
             message = resourceManager.getString(
                 R.string.swap_failure_insufficient_balance_with_buy_ed_message,
                 reason.maxSwapAmount.formatPlanks(reason.assetIn),
-                reason.fee.amount.formatPlanks(reason.feeAsset),
+                reason.fee.amountByRequestedAccount.formatPlanks(reason.feeAsset),
                 reason.toSellAmountToKeepEDUsingAssetIn.formatPlanks(reason.assetIn),
                 reason.toBuyAmountToKeepEDInCommissionAsset.formatPlanks(reason.nativeAsset),
                 reason.nativeAsset.symbol
@@ -126,7 +127,7 @@ fun CoroutineScope.mapSwapValidationFailureToUI(
             resourceManager.getString(
                 R.string.swap_failure_balance_not_consider_consumers,
                 reason.existentialDeposit.formatPlanks(reason.nativeAsset),
-                reason.swapFee.networkFee.amount.formatPlanks(reason.feeAsset)
+                reason.swapFee.networkFee.amountByRequestedAccount.formatPlanks(reason.feeAsset)
             )
         ).asDefault()
 

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/mappers/Fee.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/mappers/Fee.kt
@@ -1,17 +1,13 @@
 package io.novafoundation.nova.feature_wallet_api.data.mappers
 
 import io.novafoundation.nova.feature_account_api.data.model.Fee
-import io.novafoundation.nova.feature_account_api.data.model.InlineFee
 import io.novafoundation.nova.feature_wallet_api.domain.model.Token
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
-import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.SimpleFee
-import io.novafoundation.nova.feature_wallet_api.presentation.model.FeeModel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.GenericDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.model.GenericFeeModel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
-import java.math.BigDecimal
 
 fun <F : GenericFee> mapFeeToFeeModel(
     fee: F,
@@ -37,13 +33,3 @@ fun mapFeeToFeeModel(
     token: Token,
     includeZeroFiat: Boolean = true
 ) = mapFeeToFeeModel(SimpleFee(fee), token, includeZeroFiat)
-
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("Backward-compatible adapter")
-fun mapFeeToFeeModel(
-    feeAmount: BigDecimal,
-    token: Token,
-    includeZeroFiat: Boolean = true
-): FeeModel {
-    return mapFeeToFeeModel(InlineFee(token.planksFromAmount(feeAmount)), token, includeZeroFiat)
-}

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransferValidations.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransferValidations.kt
@@ -9,6 +9,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.validation.FeeChangeDete
 import io.novafoundation.nova.feature_wallet_api.domain.validation.InsufficientBalanceToStayAboveEDError
 import io.novafoundation.nova.feature_wallet_api.domain.validation.NotEnoughToPayFeesError
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.SimpleFee
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
 import io.novafoundation.nova.runtime.ext.commissionAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigDecimal
@@ -68,8 +69,8 @@ sealed class AssetTransferValidationFailure {
 
 data class AssetTransferPayload(
     val transfer: WeightedAssetTransfer,
-    val originFee: BigDecimal,
-    val crossChainFee: BigDecimal?,
+    val originFee: DecimalFee,
+    val crossChainFee: DecimalFee?,
     val originCommissionAsset: Asset,
     val originUsedAsset: Asset
 )
@@ -80,11 +81,11 @@ val AssetTransferPayload.isSendingCommissionAsset
 val AssetTransferPayload.isReceivingCommissionAsset
     get() = transfer.destinationChainAsset == transfer.destinationChain.commissionAsset
 
-val AssetTransferPayload.originFeeInUsedAsset: BigDecimal
+val AssetTransferPayload.originFeeInUsedAsset: DecimalFee?
     get() = if (isSendingCommissionAsset) {
         originFee
     } else {
-        BigDecimal.ZERO
+        null
     }
 
 val AssetTransferPayload.receivingAmountInCommissionAsset: BigInteger

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/EnoughAmountToTransferValidation.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/EnoughAmountToTransferValidation.kt
@@ -8,6 +8,9 @@ import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.ValidationSystemBuilder
 import io.novafoundation.nova.feature_wallet_api.R
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.SimpleFee
+import io.novafoundation.nova.feature_wallet_api.presentation.model.networkFeeByRequestedAccountOrZero
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigDecimal
 
@@ -17,18 +20,29 @@ interface NotEnoughToPayFeesError {
     val fee: BigDecimal
 }
 
-class EnoughAmountToTransferValidation<P, E>(
-    private val feeExtractor: AmountProducer<P>,
+typealias EnoughAmountToTransferValidation<P, E> = EnoughAmountToTransferValidationGeneric<P, E, SimpleFee>
+
+class EnoughAmountToTransferValidationGeneric<P, E, F: GenericFee>(
+    private val feeExtractor: GenericFeeProducer<F, P>,
     private val availableBalanceProducer: AmountProducer<P>,
-    private val errorProducer: (P, availableToPayFees: BigDecimal) -> E,
+    private val errorProducer: (ErrorContext<P>) -> E,
     private val skippable: Boolean = false,
     private val extraAmountExtractor: AmountProducer<P> = { BigDecimal.ZERO },
 ) : Validation<P, E> {
 
+    class ErrorContext<P>(
+
+        val payload: P,
+
+        val availableToPayFees: BigDecimal,
+
+        val fee: BigDecimal,
+    )
+
     companion object;
 
     override suspend fun validate(value: P): ValidationStatus<E> {
-        val fee = feeExtractor(value)
+        val fee = feeExtractor(value).networkFeeByRequestedAccountOrZero
         val available = availableBalanceProducer(value)
         val amount = extraAmountExtractor(value)
 
@@ -39,19 +53,35 @@ class EnoughAmountToTransferValidation<P, E>(
 
             val failureLevel = if (skippable) DefaultFailureLevel.WARNING else DefaultFailureLevel.ERROR
 
-            ValidationStatus.NotValid(failureLevel, errorProducer(value, maxUsable))
+            ValidationStatus.NotValid(failureLevel, errorProducer(ErrorContext(value, maxUsable, fee)))
         }
     }
 }
 
 fun <P, E> ValidationSystemBuilder<P, E>.sufficientBalance(
-    fee: AmountProducer<P> = { BigDecimal.ZERO },
+    fee: FeeProducer<P> = { null },
     amount: AmountProducer<P> = { BigDecimal.ZERO },
     available: AmountProducer<P>,
-    error: (P, availableToPayFees: BigDecimal) -> E,
+    error: (EnoughAmountToTransferValidationGeneric.ErrorContext<P>) -> E,
     skippable: Boolean = false
 ) = validate(
     EnoughAmountToTransferValidation(
+        feeExtractor = fee,
+        extraAmountExtractor = amount,
+        errorProducer = error,
+        skippable = skippable,
+        availableBalanceProducer = available
+    )
+)
+
+fun <P, E, F: GenericFee> ValidationSystemBuilder<P, E>.sufficientBalanceGeneric(
+    fee: GenericFeeProducer<F, P> = { null },
+    amount: AmountProducer<P> = { BigDecimal.ZERO },
+    available: AmountProducer<P>,
+    error: (EnoughAmountToTransferValidationGeneric.ErrorContext<P>) -> E,
+    skippable: Boolean = false
+) = validate(
+    EnoughAmountToTransferValidationGeneric(
         feeExtractor = fee,
         extraAmountExtractor = amount,
         errorProducer = error,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/EnoughAmountToTransferValidation.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/EnoughAmountToTransferValidation.kt
@@ -22,7 +22,7 @@ interface NotEnoughToPayFeesError {
 
 typealias EnoughAmountToTransferValidation<P, E> = EnoughAmountToTransferValidationGeneric<P, E, SimpleFee>
 
-class EnoughAmountToTransferValidationGeneric<P, E, F: GenericFee>(
+class EnoughAmountToTransferValidationGeneric<P, E, F : GenericFee>(
     private val feeExtractor: GenericFeeProducer<F, P>,
     private val availableBalanceProducer: AmountProducer<P>,
     private val errorProducer: (ErrorContext<P>) -> E,
@@ -74,7 +74,7 @@ fun <P, E> ValidationSystemBuilder<P, E>.sufficientBalance(
     )
 )
 
-fun <P, E, F: GenericFee> ValidationSystemBuilder<P, E>.sufficientBalanceGeneric(
+fun <P, E, F : GenericFee> ValidationSystemBuilder<P, E>.sufficientBalanceGeneric(
     fee: GenericFeeProducer<F, P> = { null },
     amount: AmountProducer<P> = { BigDecimal.ZERO },
     available: AmountProducer<P>,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/ExistentialDepositValidation.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/ExistentialDepositValidation.kt
@@ -4,13 +4,14 @@ import io.novafoundation.nova.common.validation.Validation
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.ValidationSystemBuilder
 import io.novafoundation.nova.common.validation.validOrWarning
+import io.novafoundation.nova.feature_wallet_api.presentation.model.networkFeeByRequestedAccountOrZero
 import java.math.BigDecimal
 
 typealias ExistentialDepositError<E, P> = (remainingAmount: BigDecimal, payload: P) -> E
 
 class ExistentialDepositValidation<P, E>(
     private val countableTowardsEdBalance: AmountProducer<P>,
-    private val feeProducer: AmountProducer<P>,
+    private val feeProducer: FeeProducer<P>,
     private val extraAmountProducer: AmountProducer<P>,
     private val errorProducer: ExistentialDepositError<E, P>,
     private val existentialDeposit: AmountProducer<P>
@@ -23,7 +24,7 @@ class ExistentialDepositValidation<P, E>(
         val fee = feeProducer(value)
         val extraAmount = extraAmountProducer(value)
 
-        val remainingAmount = countableTowardsEd - fee - extraAmount
+        val remainingAmount = countableTowardsEd - fee.networkFeeByRequestedAccountOrZero - extraAmount
 
         return validOrWarning(remainingAmount >= existentialDeposit) {
             errorProducer(remainingAmount, value)
@@ -33,7 +34,7 @@ class ExistentialDepositValidation<P, E>(
 
 fun <P, E> ValidationSystemBuilder<P, E>.doNotCrossExistentialDeposit(
     countableTowardsEdBalance: AmountProducer<P>,
-    fee: AmountProducer<P> = { BigDecimal.ZERO },
+    fee: FeeProducer<P> = { null },
     extraAmount: AmountProducer<P> = { BigDecimal.ZERO },
     existentialDeposit: AmountProducer<P>,
     error: ExistentialDepositError<E, P>,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/FeeChangeValidation.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/FeeChangeValidation.kt
@@ -14,8 +14,8 @@ import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_wallet_api.R
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.SimpleFee
 import io.novafoundation.nova.feature_wallet_api.presentation.model.GenericDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.model.networkFeeByRequestedAccount
@@ -103,16 +103,16 @@ fun <P, E, F : GenericFee> ValidationSystemBuilder<P, E>.checkForFeeChanges(
     )
 )
 
-fun <T : GenericFee> CoroutineScope.handleFeeSpikeDetected(
-    error: FeeChangeDetectedFailure<T>,
+fun <F : GenericFee> CoroutineScope.handleFeeSpikeDetected(
+    error: FeeChangeDetectedFailure<F>,
     resourceManager: ResourceManager,
-    feeLoaderMixin: FeeLoaderMixin.Presentation,
+    feeLoaderMixin: GenericFeeLoaderMixin.Presentation<F>,
     actions: ValidationFlowActions<*>
 ): TransformedFailure? = handleFeeSpikeDetected(
     error = error,
     resourceManager = resourceManager,
     actions = actions,
-    setFee = { feeLoaderMixin.setFee(it.newFee.networkFee) }
+    setFee = { feeLoaderMixin.setFee(it.newFee.genericFee) }
 )
 
 fun <T : GenericFee> CoroutineScope.handleFeeSpikeDetected(

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/Producers.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/Producers.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_wallet_api.domain.validation
 
-import io.novafoundation.nova.feature_wallet_api.domain.model.Token
+import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
+import io.novafoundation.nova.feature_wallet_api.presentation.model.GenericDecimalFee
 import java.math.BigDecimal
 import java.math.BigInteger
 
@@ -8,4 +9,6 @@ typealias AmountProducer<P> = suspend (P) -> BigDecimal
 
 typealias PlanksProducer<P> = suspend (P) -> BigInteger
 
-typealias TokenProducer<P> = suspend (P) -> Token
+typealias FeeProducer<P> = suspend (P) -> DecimalFee?
+
+typealias GenericFeeProducer<F, P> = suspend (P) -> GenericDecimalFee<F>?

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/FeeLoaderMixin.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/FeeLoaderMixin.kt
@@ -88,8 +88,6 @@ interface FeeLoaderMixin : GenericFeeLoaderMixin<SimpleFee> {
 
     interface Presentation : GenericFeeLoaderMixin.Presentation<SimpleFee>, FeeLoaderMixin {
 
-        suspend fun setFee(fee: Fee?) = setFee(fee?.let(::SimpleFee))
-
         fun loadFee(
             coroutineScope: CoroutineScope,
             expectedChain: ChainId? = null,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/FeeParcelModel.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/FeeParcelModel.kt
@@ -1,9 +1,12 @@
 package io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee
 
 import android.os.Parcelable
+import io.novafoundation.nova.feature_account_api.data.extrinsic.SubmissionOrigin
 import io.novafoundation.nova.feature_account_api.data.model.EvmFee
-import io.novafoundation.nova.feature_account_api.data.model.InlineFee
+import io.novafoundation.nova.feature_account_api.data.model.SubstrateFee
 import io.novafoundation.nova.feature_wallet_api.presentation.model.DecimalFee
+import io.novafoundation.nova.feature_wallet_api.presentation.model.GenericDecimalFee
+import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import kotlinx.android.parcel.Parcelize
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -11,33 +14,55 @@ import java.math.BigInteger
 sealed interface FeeParcelModel : Parcelable {
 
     val amount: BigDecimal
+
+    val submissionOrigin: SubmissionOriginParcelModel
 }
+
+@Parcelize
+class SubmissionOriginParcelModel(
+    val requested: AccountId,
+    val actual: AccountId
+) : Parcelable
 
 @Parcelize
 class EvmFeeParcelModel(
     val gasLimit: BigInteger,
     val gasPrice: BigInteger,
-    override val amount: BigDecimal
+    override val amount: BigDecimal,
+    override val submissionOrigin: SubmissionOriginParcelModel
 ) : FeeParcelModel
 
 @Parcelize
 class SimpleFeeParcelModel(
     val planks: BigInteger,
-    override val amount: BigDecimal
+    override val amount: BigDecimal,
+    override val submissionOrigin: SubmissionOriginParcelModel
 ) : FeeParcelModel
 
-fun mapFeeToParcel(decimalFee: DecimalFee): FeeParcelModel {
-    return when (val fee = decimalFee.fee) {
-        is EvmFee -> EvmFeeParcelModel(gasLimit = fee.gasLimit, gasPrice = fee.gasPrice, amount = decimalFee.decimalAmount)
-        else -> SimpleFeeParcelModel(decimalFee.fee.amount, decimalFee.decimalAmount)
+fun mapFeeToParcel(decimalFee: GenericDecimalFee<*>): FeeParcelModel {
+    val submissionOrigin = mapSubmissionOriginToParcel(decimalFee.networkFee.submissionOrigin)
+
+    return when (val fee = decimalFee.networkFee) {
+        is EvmFee -> EvmFeeParcelModel(gasLimit = fee.gasLimit, gasPrice = fee.gasPrice, amount = decimalFee.networkFeeDecimalAmount, submissionOrigin)
+        else -> SimpleFeeParcelModel(decimalFee.networkFee.amount, decimalFee.networkFeeDecimalAmount, submissionOrigin)
     }
 }
 
+private fun mapSubmissionOriginToParcel(submissionOrigin: SubmissionOrigin): SubmissionOriginParcelModel {
+    return with(submissionOrigin) { SubmissionOriginParcelModel(requested = requestedOrigin, actual = actualOrigin) }
+}
+
 fun mapFeeFromParcel(parcelFee: FeeParcelModel): DecimalFee {
+    val submissionOrigin = mapSubmissionOriginFromParcel(parcelFee.submissionOrigin)
+
     val fee = when (parcelFee) {
-        is EvmFeeParcelModel -> EvmFee(gasLimit = parcelFee.gasLimit, gasPrice = parcelFee.gasPrice)
-        is SimpleFeeParcelModel -> InlineFee(parcelFee.planks)
+        is EvmFeeParcelModel -> EvmFee(gasLimit = parcelFee.gasLimit, gasPrice = parcelFee.gasPrice, submissionOrigin)
+        is SimpleFeeParcelModel -> SubstrateFee(parcelFee.planks, submissionOrigin)
     }
 
     return DecimalFee(SimpleFee(fee), parcelFee.amount)
+}
+
+private fun mapSubmissionOriginFromParcel(submissionOrigin: SubmissionOriginParcelModel): SubmissionOrigin {
+    return with(submissionOrigin) { SubmissionOrigin(requestedOrigin = requested, actualOrigin = actual) }
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/GenericFeeLoaderProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/GenericFeeLoaderProvider.kt
@@ -5,11 +5,9 @@ import io.novafoundation.nova.common.mixin.api.RetryPayload
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.firstNotNull
-import io.novafoundation.nova.feature_account_api.data.model.InlineFee
 import io.novafoundation.nova.feature_wallet_api.R
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
 import io.novafoundation.nova.feature_wallet_api.domain.model.Token
-import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -19,7 +17,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.math.BigDecimal
 
 class FeeLoaderProviderFactory(
     private val resourceManager: ResourceManager,
@@ -44,33 +41,7 @@ private class FeeLoaderProvider(
     resourceManager: ResourceManager,
     configuration: GenericFeeLoaderMixin.Configuration<SimpleFee>,
     tokenFlow: Flow<Token?>,
-) : GenericFeeLoaderProvider<SimpleFee>(resourceManager, configuration, tokenFlow), FeeLoaderMixin.Presentation {
-
-    override suspend fun setFee(feeAmount: BigDecimal?) {
-        val fee = feeAmount?.let {
-            val token = tokenFlow.firstNotNull()
-            InlineFee(token.planksFromAmount(feeAmount))
-        }
-
-        setFee(fee)
-    }
-
-    override fun requireFee(
-        block: (BigDecimal) -> Unit,
-        onError: (title: String, message: String) -> Unit,
-    ) {
-        val feeStatus = feeLiveData.value
-
-        if (feeStatus is FeeStatus.Loaded) {
-            block(feeStatus.feeModel.decimalFee.decimalAmount)
-        } else {
-            onError(
-                resourceManager.getString(R.string.fee_not_yet_loaded_title),
-                resourceManager.getString(R.string.fee_not_yet_loaded_message)
-            )
-        }
-    }
-}
+) : GenericFeeLoaderProvider<SimpleFee>(resourceManager, configuration, tokenFlow), FeeLoaderMixin.Presentation
 
 private open class GenericFeeLoaderProvider<F : GenericFee>(
     protected val resourceManager: ResourceManager,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/model/FeeModel.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/model/FeeModel.kt
@@ -1,12 +1,13 @@
 package io.novafoundation.nova.feature_wallet_api.presentation.model
 
+import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.feature_account_api.data.model.Fee
+import io.novafoundation.nova.feature_account_api.data.model.requestedAccountPaysFees
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.GenericFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.SimpleFee
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigDecimal
 
-typealias FeeModel = GenericFeeModel<SimpleFee>
 typealias DecimalFee = GenericDecimalFee<SimpleFee>
 
 class GenericFeeModel<F : GenericFee>(
@@ -23,5 +24,14 @@ class GenericDecimalFee<F : GenericFee>(
     @Deprecated("This field has unclear semantics in a case of custom fee structure", replaceWith = ReplaceWith("networkFeeDecimalAmount"))
     val decimalAmount: BigDecimal = networkFeeDecimalAmount
 
-    val fee: Fee = genericFee.networkFee
+    val networkFee: Fee = genericFee.networkFee
 }
+
+val <F : GenericFee> GenericDecimalFee<F>.networkFeeByRequestedAccount: BigDecimal
+    get() = if (networkFee.requestedAccountPaysFees) networkFeeDecimalAmount else BigDecimal.ZERO
+
+val <F : GenericFee> GenericDecimalFee<F>?.networkFeeByRequestedAccountOrZero: BigDecimal
+    get() = this?.networkFeeByRequestedAccount.orZero()
+
+val <F : GenericFee> GenericDecimalFee<F>?.networkFeeDecimalAmount: BigDecimal
+    get() = this?.networkFeeDecimalAmount.orZero()

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/model/FeeModel.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/model/FeeModel.kt
@@ -21,9 +21,6 @@ class GenericDecimalFee<F : GenericFee>(
     val networkFeeDecimalAmount: BigDecimal
 ) {
 
-    @Deprecated("This field has unclear semantics in a case of custom fee structure", replaceWith = ReplaceWith("networkFeeDecimalAmount"))
-    val decimalAmount: BigDecimal = networkFeeDecimalAmount
-
     val networkFee: Fee = genericFee.networkFee
 }
 

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/BaseAssetTransfers.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/BaseAssetTransfers.kt
@@ -90,7 +90,7 @@ abstract class BaseAssetTransfers(
         recipientCanAcceptTransfer(assetSourceRegistry)
     }
 
-    protected fun AssetTransfersValidationSystemBuilder.doNotCrossExistentialDeposit() = doNotCrossExistentialDeposit(
+    private fun AssetTransfersValidationSystemBuilder.doNotCrossExistentialDeposit() = doNotCrossExistentialDeposit(
         assetSourceRegistry = assetSourceRegistry,
         fee = { it.originFeeInUsedAsset },
         extraAmount = { it.transfer.amount },

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/evmErc20/EvmErc20AssetTransfers.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/evmErc20/EvmErc20AssetTransfers.kt
@@ -56,7 +56,7 @@ class EvmErc20AssetTransfers(
     override suspend fun performTransfer(transfer: WeightedAssetTransfer): Result<ExtrinsicSubmission> {
         return evmTransactionService.transact(
             chainId = transfer.originChain.id,
-            presetFee = transfer.decimalFee.fee,
+            presetFee = transfer.decimalFee.networkFee,
             fallbackGasLimit = ERC_20_UPPER_GAS_LIMIT
         ) {
             transfer(transfer)

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/evmNative/EvmNativeAssetTransfers.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/evmNative/EvmNativeAssetTransfers.kt
@@ -53,7 +53,7 @@ class EvmNativeAssetTransfers(
         return evmTransactionService.transact(
             chainId = transfer.originChain.id,
             fallbackGasLimit = NATIVE_COIN_TRANSFER_GAS_LIMIT,
-            presetFee = transfer.decimalFee.fee,
+            presetFee = transfer.decimalFee.networkFee,
         ) {
             nativeTransfer(transfer)
         }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_wallet_impl.data.network.crosschain
 
 import io.novafoundation.nova.common.data.network.runtime.binding.Weight
-import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.utils.xTokensName
 import io.novafoundation.nova.common.utils.xcmPalletName
 import io.novafoundation.nova.common.validation.ValidationSystem
@@ -23,6 +22,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.XcmTransferType
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.domain.validation.EnoughTotalToStayAboveEDValidationFactory
 import io.novafoundation.nova.feature_wallet_api.domain.validation.PhishingValidationFactory
+import io.novafoundation.nova.feature_wallet_api.presentation.model.networkFeeByRequestedAccountOrZero
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.doNotCrossExistentialDeposit
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.notDeadRecipientInCommissionAsset
 import io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.transfers.validations.notDeadRecipientInUsedAsset
@@ -65,7 +65,7 @@ class RealCrossChainTransactor(
         doNotCrossExistentialDeposit(
             assetSourceRegistry = assetSourceRegistry,
             fee = { it.originFeeInUsedAsset },
-            extraAmount = { it.transfer.amount + it.crossChainFee.orZero() }
+            extraAmount = { it.transfer.amount + it.crossChainFee.networkFeeByRequestedAccountOrZero }
         )
     }
 

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/validations/CrossChainFeeValidation.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/validations/CrossChainFeeValidation.kt
@@ -1,6 +1,5 @@
 package io.novafoundation.nova.feature_wallet_impl.data.network.crosschain.validations
 
-import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.isTrueOrError
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransferPayload
@@ -8,13 +7,15 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.t
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransfersValidation
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.AssetTransfersValidationSystemBuilder
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers.originFeeInUsedAsset
+import io.novafoundation.nova.feature_wallet_api.presentation.model.networkFeeByRequestedAccountOrZero
 
 class CrossChainFeeValidation : AssetTransfersValidation {
 
     override suspend fun validate(value: AssetTransferPayload): ValidationStatus<AssetTransferValidationFailure> {
-        val remainingBalanceAfterTransfer = value.originUsedAsset.transferable - value.transfer.amount - value.originFeeInUsedAsset
+        val networkFeeInUsedAsset = value.originFeeInUsedAsset.networkFeeByRequestedAccountOrZero
+        val remainingBalanceAfterTransfer = value.originUsedAsset.transferable - value.transfer.amount - networkFeeInUsedAsset
 
-        val crossChainFee = value.crossChainFee.orZero()
+        val crossChainFee = value.crossChainFee.networkFeeByRequestedAccountOrZero
         val remainsEnoughToPayCrossChainFees = remainingBalanceAfterTransfer >= crossChainFee
 
         return remainsEnoughToPayCrossChainFees isTrueOrError {

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/signer/NovaSigner.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/signer/NovaSigner.kt
@@ -8,3 +8,19 @@ interface NovaSigner : Signer {
 
     suspend fun signerAccountId(chain: Chain): AccountId
 }
+
+interface FeeSigner : NovaSigner {
+
+    /**
+     * In contrast with [signerAccountId] which for [FeeSigner] is supposed to return an account id derived from a fake keypair,
+     * This method returns a real account id that later will sign the transaction we're calculating fee
+     * This is useful for the client code to understand which account which actually pay the fee since it might differ from the requested account id
+     */
+    suspend fun actualFeeSignerId(chain: Chain): AccountId
+
+    /**
+     * Similar to [actualFeeSignerId] but returns accountId that was specified as the transaction origin
+     * It might not be equal to [actualFeeSignerId] if [Signer] modifies the payload
+     */
+    suspend fun requestedFeeSignerId(chain: Chain): AccountId
+}


### PR DESCRIPTION
#869379g01

Basic idea: 
1. Extend `Fee` interface to hold information who will actually sign the transaction by adding field of type `SubmissionOrigin`. This requries extending `FeeSigner` interface to have ` actualFeeSignerId(chain: Chain)` and ` requestedFeeSignerId(chain: Chain` since `signerAccountId(chain: Chain)` returns fake id generated by fake keypair that will be used for signing
2. Migrate all screens to use not-so-ago added `DecimalFee` instead of `BigDecimal`
3. Modify validations that use fee to consider `submissionOrigin` by using `amountByRequestedAccount` instead of `amount`
4. Handle a few specific cases separately like Swaps, External Sign (Dapp browser + WC) and transaction history insertion

I've also replace `requireFee` with `awaitFee` with former being the outdated behavior