### PR TITLE
Fix/proxy ledger

### DIFF
--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/signer/SeparateFlowSignerState.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/signer/SeparateFlowSignerState.kt
@@ -1,0 +1,9 @@
+package io.novafoundation.nova.feature_account_api.data.signer
+
+import io.novafoundation.nova.common.utils.MutableSharedState
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
+
+typealias SigningSharedState = MutableSharedState<SeparateFlowSignerState>
+
+class SeparateFlowSignerState(val extrinsic: SignerPayloadExtrinsic, val metaAccount: MetaAccount)

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/di/AccountFeatureApi.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/di/AccountFeatureApi.kt
@@ -1,8 +1,7 @@
 package io.novafoundation.nova.feature_account_api.di
 
-import io.novafoundation.nova.common.sequrity.biometry.BiometricServiceFactory
 import io.novafoundation.nova.common.sequrity.TwoFactorVerificationExecutor
-import io.novafoundation.nova.common.utils.MutableSharedState
+import io.novafoundation.nova.common.sequrity.biometry.BiometricServiceFactory
 import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.EvmTransactionService
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_account_api.data.proxy.ProxySyncService
@@ -10,6 +9,7 @@ import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxyExt
 import io.novafoundation.nova.feature_account_api.data.repository.OnChainIdentityRepository
 import io.novafoundation.nova.feature_account_api.data.repository.addAccount.ledger.LedgerAddAccountRepository
 import io.novafoundation.nova.feature_account_api.data.signer.SignerProvider
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_api.domain.account.common.EncryptionDefaults
 import io.novafoundation.nova.feature_account_api.domain.account.identity.IdentityProvider
 import io.novafoundation.nova.feature_account_api.domain.account.identity.LocalIdentity
@@ -29,7 +29,6 @@ import io.novafoundation.nova.feature_account_api.presenatation.mixin.addressInp
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.identity.IdentityMixin
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.importType.ImportTypeChooserMixin
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectWallet.SelectWalletMixin
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 
 interface AccountFeatureApi {
 
@@ -67,7 +66,7 @@ interface AccountFeatureApi {
 
     val watchOnlyMissingKeysPresenter: WatchOnlyMissingKeysPresenter
 
-    val signSharedState: MutableSharedState<SignerPayloadExtrinsic>
+    val signSharedState: SigningSharedState
 
     val onChainIdentityRepository: OnChainIdentityRepository
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/SeparateFlowSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/SeparateFlowSigner.kt
@@ -1,7 +1,8 @@
 package io.novafoundation.nova.feature_account_impl.data.signer
 
 import io.novafoundation.nova.common.base.errors.SigningCancelledException
-import io.novafoundation.nova.common.utils.MutableSharedState
+import io.novafoundation.nova.feature_account_api.data.signer.SeparateFlowSignerState
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenRequester
@@ -13,13 +14,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 abstract class SeparateFlowSigner(
-    private val signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+    private val signingSharedState: SigningSharedState,
     private val signFlowRequester: SignInterScreenRequester,
-    metaAccount: MetaAccount
+    private val metaAccount: MetaAccount
 ) : LeafSigner(metaAccount) {
 
     override suspend fun signExtrinsic(payloadExtrinsic: SignerPayloadExtrinsic): SignedExtrinsic {
-        signingSharedState.set(payloadExtrinsic)
+        val payload = SeparateFlowSignerState(payloadExtrinsic, metaAccount)
+
+        signingSharedState.set(payload)
 
         val result = withContext(Dispatchers.Main) {
             try {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/ledger/LedgerSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/ledger/LedgerSigner.kt
@@ -2,18 +2,17 @@ package io.novafoundation.nova.feature_account_impl.data.signer.ledger
 
 import io.novafoundation.nova.common.base.errors.SigningCancelledException
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.MutableSharedState
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenRequester
 import io.novafoundation.nova.feature_account_impl.R
 import io.novafoundation.nova.feature_account_impl.data.signer.SeparateFlowSigner
 import io.novafoundation.nova.feature_account_impl.presentation.common.sign.notSupported.SigningNotSupportedPresentable
 import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignedRaw
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadRaw
 
 class LedgerSignerFactory(
-    private val signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+    private val signingSharedState: SigningSharedState,
     private val signFlowRequester: SignInterScreenRequester,
     private val resourceManager: ResourceManager,
     private val messageSigningNotSupported: SigningNotSupportedPresentable
@@ -32,7 +31,7 @@ class LedgerSignerFactory(
 
 class LedgerSigner(
     metaAccount: MetaAccount,
-    signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+    signingSharedState: SigningSharedState,
     signFlowRequester: SignInterScreenRequester,
     private val resourceManager: ResourceManager,
     private val messageSigningNotSupported: SigningNotSupportedPresentable

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/paritySigner/PolkadotVaultSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/paritySigner/PolkadotVaultSigner.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_account_impl.data.signer.paritySigner
 
 import io.novafoundation.nova.common.base.errors.SigningCancelledException
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.MutableSharedState
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.PolkadotVaultVariant
 import io.novafoundation.nova.feature_account_api.presenatation.account.polkadotVault.config.PolkadotVaultVariantConfigProvider
@@ -16,7 +16,7 @@ import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtr
 import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadRaw
 
 class PolkadotVaultVariantSignerFactory(
-    private val signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+    private val signingSharedState: SigningSharedState,
     private val signFlowRequester: PolkadotVaultVariantSignCommunicator,
     private val resourceManager: ResourceManager,
     private val polkadotVaultVariantConfigProvider: PolkadotVaultVariantConfigProvider,
@@ -47,7 +47,7 @@ class PolkadotVaultVariantSignerFactory(
 }
 
 abstract class PolkadotVaultVariantSigner(
-    signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+    signingSharedState: SigningSharedState,
     metaAccount: MetaAccount,
     private val signFlowRequester: PolkadotVaultVariantSignCommunicator,
     private val resourceManager: ResourceManager,
@@ -77,7 +77,7 @@ abstract class PolkadotVaultVariantSigner(
 }
 
 class ParitySignerSigner(
-    signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+    signingSharedState: SigningSharedState,
     metaAccount: MetaAccount,
     signFlowRequester: PolkadotVaultVariantSignCommunicator,
     resourceManager: ResourceManager,
@@ -94,7 +94,7 @@ class ParitySignerSigner(
 )
 
 class PolkadotVaultSigner(
-    signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+    signingSharedState: SigningSharedState,
     metaAccount: MetaAccount,
     signFlowRequester: PolkadotVaultVariantSignCommunicator,
     resourceManager: ResourceManager,

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/modules/ParitySignerModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/modules/ParitySignerModule.kt
@@ -5,12 +5,12 @@ import dagger.Provides
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.MutableSharedState
 import io.novafoundation.nova.common.utils.SharedState
+import io.novafoundation.nova.feature_account_api.data.signer.SeparateFlowSignerState
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_impl.data.signer.paritySigner.PolkadotVaultVariantSignCommunicator
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.common.QrCodeExpiredPresentableFactory
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 
 @Module
 class ParitySignerModule {
@@ -18,8 +18,8 @@ class ParitySignerModule {
     @Provides
     @FeatureScope
     fun provideReadOnlySharedState(
-        mutableSharedState: MutableSharedState<SignerPayloadExtrinsic>
-    ): SharedState<SignerPayloadExtrinsic> = mutableSharedState
+        mutableSharedState: SigningSharedState
+    ): SharedState<SeparateFlowSignerState> = mutableSharedState
 
     @Provides
     @FeatureScope

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/modules/signers/SignersModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/modules/signers/SignersModule.kt
@@ -7,8 +7,8 @@ import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.sequrity.TwoFactorVerificationService
 import io.novafoundation.nova.common.utils.DefaultMutableSharedState
-import io.novafoundation.nova.common.utils.MutableSharedState
 import io.novafoundation.nova.feature_account_api.data.signer.SignerProvider
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_account_api.presenatation.account.polkadotVault.config.PolkadotVaultVariantConfigProvider
 import io.novafoundation.nova.feature_account_api.presenatation.account.watchOnly.WatchOnlyMissingKeysPresenter
@@ -23,14 +23,13 @@ import io.novafoundation.nova.feature_account_impl.data.signer.secrets.SecretsSi
 import io.novafoundation.nova.feature_account_impl.data.signer.watchOnly.WatchOnlySignerFactory
 import io.novafoundation.nova.feature_account_impl.presentation.common.sign.notSupported.SigningNotSupportedPresentable
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 
 @Module(includes = [ProxiedSignerModule::class])
 class SignersModule {
 
     @Provides
     @FeatureScope
-    fun provideSignSharedState(): MutableSharedState<SignerPayloadExtrinsic> = DefaultMutableSharedState()
+    fun provideSignSharedState(): SigningSharedState = DefaultMutableSharedState()
 
     @Provides
     @FeatureScope
@@ -55,7 +54,7 @@ class SignersModule {
     @Provides
     @FeatureScope
     fun providePolkadotVaultVariantSignerFactory(
-        signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+        signingSharedState: SigningSharedState,
         communicator: PolkadotVaultVariantSignCommunicator,
         resourceManager: ResourceManager,
         polkadotVaultVariantConfigProvider: PolkadotVaultVariantConfigProvider,
@@ -71,7 +70,7 @@ class SignersModule {
     @Provides
     @FeatureScope
     fun provideLedgerSignerFactory(
-        signingSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+        signingSharedState: SigningSharedState,
         communicator: LedgerSignCommunicator,
         resourceManager: ResourceManager,
         signingNotSupportedPresentable: SigningNotSupportedPresentable

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/sign/scan/ScanSignParitySignerViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/sign/scan/ScanSignParitySignerViewModel.kt
@@ -5,9 +5,9 @@ import io.novafoundation.nova.common.mixin.actionAwaitable.awaitAction
 import io.novafoundation.nova.common.mixin.actionAwaitable.confirmingAction
 import io.novafoundation.nova.common.presentation.scan.ScanQrViewModel
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.SharedState
 import io.novafoundation.nova.common.utils.getOrThrow
 import io.novafoundation.nova.common.utils.permissions.PermissionsAsker
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_api.presenatation.account.polkadotVault.formatWithPolkadotVaultLabel
 import io.novafoundation.nova.feature_account_api.presenatation.sign.signed
 import io.novafoundation.nova.feature_account_impl.R
@@ -18,7 +18,6 @@ import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sig
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.scan.model.ScanSignParitySignerPayload
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.scan.model.mapValidityPeriodFromParcel
 import jp.co.soramitsu.fearless_utils.encrypt.SignatureWrapper.Sr25519
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 
@@ -26,7 +25,7 @@ class ScanSignParitySignerViewModel(
     private val router: AccountRouter,
     permissionsAsker: PermissionsAsker.Presentation,
     private val interactor: ScanSignParitySignerInteractor,
-    private val signSharedState: SharedState<SignerPayloadExtrinsic>,
+    private val signSharedState: SigningSharedState,
     private val actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
     private val responder: PolkadotVaultVariantSignCommunicator,
     private val payload: ScanSignParitySignerPayload,
@@ -55,7 +54,7 @@ class ScanSignParitySignerViewModel(
     }
 
     override suspend fun scanned(result: String) {
-        interactor.encodeAndVerifySignature(signSharedState.getOrThrow(), result)
+        interactor.encodeAndVerifySignature(signSharedState.getOrThrow().extrinsic, result)
             .onSuccess(::respondResult)
             .onFailure {
                 invalidQrConfirmation.awaitAction()

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/sign/scan/di/ScanSignParitySignerModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/sign/scan/di/ScanSignParitySignerModule.kt
@@ -10,9 +10,9 @@ import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.MutableSharedState
 import io.novafoundation.nova.common.utils.permissions.PermissionsAsker
 import io.novafoundation.nova.common.utils.permissions.PermissionsAskerFactory
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_impl.data.signer.paritySigner.PolkadotVaultVariantSignCommunicator
 import io.novafoundation.nova.feature_account_impl.domain.paritySigner.sign.scan.RealScanSignParitySignerInteractor
 import io.novafoundation.nova.feature_account_impl.domain.paritySigner.sign.scan.ScanSignParitySignerInteractor
@@ -20,7 +20,6 @@ import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.common.QrCodeExpiredPresentableFactory
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.scan.ScanSignParitySignerViewModel
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.scan.model.ScanSignParitySignerPayload
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 
 @Module(includes = [ViewModelModule::class])
 class ScanSignParitySignerModule {
@@ -42,7 +41,7 @@ class ScanSignParitySignerModule {
         router: AccountRouter,
         permissionsAsker: PermissionsAsker.Presentation,
         interactor: ScanSignParitySignerInteractor,
-        signSharedState: MutableSharedState<SignerPayloadExtrinsic>,
+        signSharedState: SigningSharedState,
         actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
         communicator: PolkadotVaultVariantSignCommunicator,
         payload: ScanSignParitySignerPayload,

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/sign/show/di/ShowSignParitySignerModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/sign/show/di/ShowSignParitySignerModule.kt
@@ -13,6 +13,7 @@ import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.QrCodeGenerator
 import io.novafoundation.nova.common.utils.SharedState
+import io.novafoundation.nova.feature_account_api.data.signer.SeparateFlowSignerState
 import io.novafoundation.nova.feature_account_api.presenatation.account.AddressDisplayUseCase
 import io.novafoundation.nova.feature_account_api.presenatation.account.polkadotVault.config.PolkadotVaultVariantConfigProvider
 import io.novafoundation.nova.feature_account_api.presenatation.actions.ExternalActions
@@ -39,7 +40,7 @@ class ShowSignParitySignerModule {
     @ViewModelKey(ShowSignParitySignerViewModel::class)
     fun provideViewModel(
         interactor: ShowSignParitySignerInteractor,
-        signSharedState: SharedState<SignerPayloadExtrinsic>,
+        signSharedState: SharedState<SeparateFlowSignerState>,
         qrCodeGenerator: QrCodeGenerator,
         communicator: PolkadotVaultVariantSignCommunicator,
         payload: ShowSignParitySignerPayload,

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/sign/show/di/ShowSignParitySignerModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/sign/show/di/ShowSignParitySignerModule.kt
@@ -26,7 +26,6 @@ import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sig
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.show.ShowSignParitySignerViewModel
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicValidityUseCase
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 
 @Module(includes = [ViewModelModule::class])
 class ShowSignParitySignerModule {

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/di/LedgerFeatureDependencies.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/di/LedgerFeatureDependencies.kt
@@ -7,12 +7,12 @@ import io.novafoundation.nova.common.data.secrets.v2.SecretStoreV2
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.MutableSharedState
 import io.novafoundation.nova.common.utils.bluetooth.BluetoothManager
 import io.novafoundation.nova.common.utils.location.LocationManager
 import io.novafoundation.nova.common.utils.permissions.PermissionsAskerFactory
 import io.novafoundation.nova.core_db.dao.MetaAccountDao
 import io.novafoundation.nova.feature_account_api.data.repository.addAccount.ledger.LedgerAddAccountRepository
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountInteractor
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_account_api.domain.interfaces.SelectedAccountUseCase
@@ -20,7 +20,6 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.A
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.TokenRepository
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicValidityUseCase
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 
 interface LedgerFeatureDependencies {
 
@@ -56,7 +55,7 @@ interface LedgerFeatureDependencies {
 
     val secretStoreV2: SecretStoreV2
 
-    val signSharedState: MutableSharedState<SignerPayloadExtrinsic>
+    val signSharedState: SigningSharedState
 
     val extrinsicValidityUseCase: ExtrinsicValidityUseCase
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/domain/account/sign/SignLedgerInteractor.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/domain/account/sign/SignLedgerInteractor.kt
@@ -1,32 +1,36 @@
 package io.novafoundation.nova.feature_ledger_impl.domain.account.sign
 
 import io.novafoundation.nova.common.utils.chainId
-import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.data.signer.SeparateFlowSignerState
 import io.novafoundation.nova.feature_account_api.domain.model.publicKeyIn
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import jp.co.soramitsu.fearless_utils.encrypt.SignatureVerifier
 import jp.co.soramitsu.fearless_utils.encrypt.SignatureWrapper
 import jp.co.soramitsu.fearless_utils.encrypt.Signer.MessageHashing
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.encodedSignaturePayload
 
 interface SignLedgerInteractor {
 
-    suspend fun verifySignature(payload: SignerPayloadExtrinsic, signature: SignatureWrapper): Boolean
+    suspend fun verifySignature(
+        payload: SeparateFlowSignerState,
+        signature: SignatureWrapper
+    ): Boolean
 }
 
 class RealSignLedgerInteractor(
-    private val metaAccountRepository: AccountRepository,
     private val chainRegistry: ChainRegistry,
 ) : SignLedgerInteractor {
 
-    override suspend fun verifySignature(payload: SignerPayloadExtrinsic, signature: SignatureWrapper): Boolean = runCatching {
-        val payloadBytes = payload.encodedSignaturePayload(hashBigPayloads = true)
-        val metaAccount = metaAccountRepository.getSelectedMetaAccount()
-        val chainId = payload.chainId
+    override suspend fun verifySignature(
+        payload: SeparateFlowSignerState,
+        signature: SignatureWrapper
+    ): Boolean = runCatching {
+        val extrinsic = payload.extrinsic
+        val payloadBytes = extrinsic.encodedSignaturePayload(hashBigPayloads = true)
+        val chainId = extrinsic.chainId
         val chain = chainRegistry.getChain(chainId)
 
-        val publicKey = metaAccount.publicKeyIn(chain) ?: throw IllegalStateException("No public key for chain $chainId")
+        val publicKey = payload.metaAccount.publicKeyIn(chain) ?: throw IllegalStateException("No public key for chain $chainId")
 
         SignatureVerifier.verify(signature, MessageHashing.SUBSTRATE, payloadBytes, publicKey)
     }.getOrDefault(false)

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/sign/di/SignLedgerModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/sign/di/SignLedgerModule.kt
@@ -10,15 +10,13 @@ import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.MutableSharedState
 import io.novafoundation.nova.common.utils.bluetooth.BluetoothManager
 import io.novafoundation.nova.common.utils.chainId
 import io.novafoundation.nova.common.utils.getOrThrow
 import io.novafoundation.nova.common.utils.location.LocationManager
 import io.novafoundation.nova.common.utils.permissions.PermissionsAsker
 import io.novafoundation.nova.common.utils.permissions.PermissionsAskerFactory
-import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
-import io.novafoundation.nova.feature_account_api.domain.interfaces.SelectedAccountUseCase
+import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
 import io.novafoundation.nova.feature_account_api.presenatation.sign.LedgerSignCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator
 import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.SubstrateLedgerApplication
@@ -30,17 +28,13 @@ import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.se
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerViewModel
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicValidityUseCase
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
-import jp.co.soramitsu.fearless_utils.runtime.extrinsic.signer.SignerPayloadExtrinsic
 
 @Module(includes = [ViewModelModule::class])
 class SignLedgerModule {
 
     @Provides
     @ScreenScope
-    fun provideInteractor(
-        accountRepository: AccountRepository,
-        chainRegistry: ChainRegistry,
-    ): SignLedgerInteractor = RealSignLedgerInteractor(accountRepository, chainRegistry)
+    fun provideInteractor(chainRegistry: ChainRegistry): SignLedgerInteractor = RealSignLedgerInteractor(chainRegistry)
 
     @Provides
     @ScreenScope
@@ -53,9 +47,9 @@ class SignLedgerModule {
     @Provides
     @ScreenScope
     fun provideSelectLedgerPayload(
-        signPayloadState: MutableSharedState<SignerPayloadExtrinsic>,
+        signPayloadState: SigningSharedState,
     ): SelectLedgerPayload = SelectLedgerPayload(
-        chainId = signPayloadState.getOrThrow().chainId
+        chainId = signPayloadState.getOrThrow().extrinsic.chainId
     )
 
     @Provides
@@ -71,9 +65,8 @@ class SignLedgerModule {
         router: LedgerRouter,
         resourceManager: ResourceManager,
         chainRegistry: ChainRegistry,
-        signPayloadState: MutableSharedState<SignerPayloadExtrinsic>,
+        signPayloadState: SigningSharedState,
         extrinsicValidityUseCase: ExtrinsicValidityUseCase,
-        selectedAccountUseCase: SelectedAccountUseCase,
         request: SignInterScreenCommunicator.Request,
         interactor: SignLedgerInteractor,
         responder: LedgerSignCommunicator,
@@ -90,7 +83,6 @@ class SignLedgerModule {
             chainRegistry = chainRegistry,
             signPayloadState = signPayloadState,
             extrinsicValidityUseCase = extrinsicValidityUseCase,
-            selectedAccountUseCase = selectedAccountUseCase,
             request = request,
             responder = responder,
             interactor = interactor


### PR DESCRIPTION
#8693fp8fu

Ledger flow used selected meta account to lookup derivation path, which will point to proxied that doesn't have ledger derivation path if proxied wallet is used. 
I've propagated actual meta account to the shared signing state for separate flow signing
I've also fixed signature verification for Polkadot Vault which had the same issue