### PR TITLE
Fix/staking reactive updates for relaychain staking

### DIFF
--- a/feature-staking-api/src/main/java/io/novafoundation/nova/feature_staking_api/domain/api/StakingRepository.kt
+++ b/feature-staking-api/src/main/java/io/novafoundation/nova/feature_staking_api/domain/api/StakingRepository.kt
@@ -47,7 +47,7 @@ interface StakingRepository {
 
     fun stakingStoriesFlow(): Flow<List<StakingStory>>
 
-    suspend fun ledgerFlow(stakingState: StakingState.Stash): Flow<StakingLedger>
+    fun ledgerFlow(stakingState: StakingState.Stash): Flow<StakingLedger>
 
     suspend fun ledger(chainId: ChainId, accountId: AccountId): StakingLedger?
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/StakingRepositoryImpl.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/StakingRepositoryImpl.kt
@@ -280,8 +280,8 @@ class StakingRepositoryImpl(
         return stakingStoriesDataSource.getStoriesFlow()
     }
 
-    override suspend fun ledgerFlow(stakingState: StakingState.Stash): Flow<StakingLedger> {
-        return localStorage.query(stakingState.chain.id) {
+    override fun ledgerFlow(stakingState: StakingState.Stash): Flow<StakingLedger> {
+        return localStorage.subscribe(stakingState.chain.id) {
             metadata.staking.ledger.observe(stakingState.controllerId)
         }.filterNotNull()
     }


### PR DESCRIPTION
#8693g0ewg
#8693g0jn4

We use `eraCalculatorFlow`, which is endless flow, as an inner flow inside `combineTransform` for unbondings and stake summary when staking state is "waiting for next era". Howerver, `combineTransform` does not process next upstream item until inner flow completes, so in case of "waiting for next era" no updates after initial state were processed

Fixed by replacing `combineTransform` with `combineToPair(...).flatMapLatest{...}`