### PR TITLE
Hydra/custom fee payment

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/FearlessLibExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/FearlessLibExt.kt
@@ -246,6 +246,8 @@ fun RuntimeMetadata.dynamicFeesOrNull() = moduleOrNull(Modules.DYNAMIC_FEES)
 
 fun RuntimeMetadata.dynamicFees() = module(Modules.DYNAMIC_FEES)
 
+fun RuntimeMetadata.multiTransactionPayment() = module(Modules.MULTI_TRANSACTION_PAYMENT)
+
 fun RuntimeMetadata.assetConversion() = module(Modules.ASSET_CONVERSION)
 
 fun RuntimeMetadata.proxy() = module(Modules.PROXY)
@@ -400,4 +402,6 @@ object Modules {
     const val OMNIPOOL = "Omnipool"
 
     const val DYNAMIC_FEES = "DynamicFees"
+
+    const val MULTI_TRANSACTION_PAYMENT = "MultiTransactionPayment"
 }

--- a/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/swap/SwapService.kt
+++ b/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/swap/SwapService.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_swap_api.domain.swap
 
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapExecuteArgs
@@ -29,5 +30,5 @@ interface SwapService {
 
     suspend fun slippageConfig(chainId: ChainId): SlippageConfig?
 
-    fun runSubscriptions(chainIn: Chain): Flow<ReQuoteTrigger>
+    fun runSubscriptions(chainIn: Chain, metaAccount: MetaAccount): Flow<ReQuoteTrigger>
 }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/AssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/AssetExchange.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_swap_impl.data.assetExchange
 import io.novafoundation.nova.common.utils.MultiMap
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_account_api.data.model.Fee
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_swap_api.domain.model.MinimumBalanceBuyIn
 import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
@@ -40,7 +41,7 @@ interface AssetExchange {
 
     suspend fun slippageConfig(): SlippageConfig
 
-    fun runSubscriptions(chain: Chain): Flow<ReQuoteTrigger>
+    fun runSubscriptions(chain: Chain, metaAccount: MetaAccount): Flow<ReQuoteTrigger>
 }
 
 class AssetExchangeQuote(

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
@@ -11,6 +11,7 @@ import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicServic
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_account_api.data.model.SubstrateFee
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_swap_api.domain.model.MinimumBalanceBuyIn
 import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
@@ -130,7 +131,7 @@ private class AssetConversionExchange(
         return SlippageConfig.default()
     }
 
-    override fun runSubscriptions(chain: Chain): Flow<ReQuoteTrigger> {
+    override fun runSubscriptions(chain: Chain, metaAccount: MetaAccount): Flow<ReQuoteTrigger> {
         return chainStateRepository.currentBlockNumberFlow(chain.id)
             .drop(1) // skip immediate value from the cache to not perform double-quote on chain change
             .map { ReQuoteTrigger }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/MultiTransactionPaymentApi.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/MultiTransactionPaymentApi.kt
@@ -1,0 +1,36 @@
+@file:Suppress("RedundantUnitExpression")
+
+package io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx
+
+import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
+import io.novafoundation.nova.common.utils.multiTransactionPayment
+import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.omnipool.model.OmniPoolTokenId
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
+import io.novafoundation.nova.runtime.storage.source.query.api.QueryableModule
+import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry1
+import io.novafoundation.nova.runtime.storage.source.query.api.storage1
+import jp.co.soramitsu.fearless_utils.runtime.AccountId
+import jp.co.soramitsu.fearless_utils.runtime.metadata.RuntimeMetadata
+import jp.co.soramitsu.fearless_utils.runtime.metadata.module.Module
+
+@JvmInline
+value class MultiTransactionPaymentApi(override val module: Module) : QueryableModule
+
+context(StorageQueryContext)
+val RuntimeMetadata.multiTransactionPayment: MultiTransactionPaymentApi
+    get() = MultiTransactionPaymentApi(multiTransactionPayment())
+
+context(StorageQueryContext)
+val MultiTransactionPaymentApi.acceptedCurrencies: QueryableStorageEntry1<OmniPoolTokenId, Balance>
+    get() = storage1(
+        name = "AcceptedCurrencies",
+        binding = { decoded, _ -> bindNumber(decoded) },
+    )
+
+context(StorageQueryContext)
+val MultiTransactionPaymentApi.accountCurrencyMap: QueryableStorageEntry1<AccountId, OmniPoolTokenId>
+    get() = storage1(
+        name = "AccountCurrencyMap",
+        binding = { decoded, _ -> bindNumber(decoded) },
+    )

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/omnipool/HydraDxOmnipoolExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/omnipool/HydraDxOmnipoolExchange.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.common.data.network.runtime.binding.bindNumberOrNu
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.MultiMap
 import io.novafoundation.nova.common.utils.dynamicFees
+import io.novafoundation.nova.common.utils.flatMap
 import io.novafoundation.nova.common.utils.mapNotNullToSet
 import io.novafoundation.nova.common.utils.mergeIfMultiple
 import io.novafoundation.nova.common.utils.numberConstant
@@ -15,9 +16,14 @@ import io.novafoundation.nova.common.utils.withFlowScope
 import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.TransactionOrigin
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
+import io.novafoundation.nova.feature_account_api.data.extrinsic.awaitInBlock
+import io.novafoundation.nova.feature_account_api.data.model.SubstrateFee
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
 import io.novafoundation.nova.feature_swap_api.domain.model.MinimumBalanceBuyIn
 import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapDirection
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapExecuteArgs
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapLimit
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapQuoteArgs
@@ -25,6 +31,9 @@ import io.novafoundation.nova.feature_swap_api.domain.model.SwapQuoteException
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.AssetExchange
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.AssetExchangeFee
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.AssetExchangeQuote
+import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.acceptedCurrencies
+import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.accountCurrencyMap
+import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.multiTransactionPayment
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.omnipool.model.DynamicFee
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.omnipool.model.OmniPool
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.omnipool.model.OmniPoolFees
@@ -38,6 +47,8 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Ba
 import io.novafoundation.nova.runtime.ethereum.StorageSharedRequestsBuilderFactory
 import io.novafoundation.nova.runtime.ext.decodeOrNull
 import io.novafoundation.nova.runtime.ext.fullId
+import io.novafoundation.nova.runtime.ext.isUtilityAsset
+import io.novafoundation.nova.runtime.ext.utilityAsset
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
@@ -95,9 +106,19 @@ private class HydraDxOmnipoolExchange(
 
     private val omniPoolFlow: MutableSharedFlow<OmniPool> = singleReplaySharedFlow()
 
+    private val currentPaymentAsset: MutableSharedFlow<OmniPoolTokenId> = singleReplaySharedFlow()
+
     override suspend fun canPayFeeInNonUtilityToken(asset: Chain.Asset): Boolean {
-        // TODO HydraDx supports custom token fee payment
-        return false
+        val runtime = chainRegistry.getRuntime(chain.id)
+        val onChainId = asset.requireOmniPoolTokenId(runtime)
+
+        if (onChainId == SYSTEM_ON_CHAIN_ASSET_ID) return true
+
+        val fallbackPrice = remoteStorageSource.query(chain.id) {
+            metadata.multiTransactionPayment.acceptedCurrencies.query(onChainId)
+        }
+
+        return fallbackPrice != null
     }
 
     override suspend fun availableSwapDirections(): MultiMap<FullChainAssetId, FullChainAssetId> {
@@ -129,16 +150,52 @@ private class HydraDxOmnipoolExchange(
     }
 
     override suspend fun estimateFee(args: SwapExecuteArgs): AssetExchangeFee {
-        val fee = extrinsicService.estimateFee(chain, TransactionOrigin.SelectedWallet) {
+        val feeAsset = args.usedFeeAsset
+        val paymentCurrencyToSet = getPaymentCurrencyToSetIfNeeded(feeAsset)
+
+        val setCurrencyFee = if (paymentCurrencyToSet != null) {
+            extrinsicService.estimateFee(chain, TransactionOrigin.SelectedWallet) {
+                setFeeCurrency(paymentCurrencyToSet)
+            }
+        } else {
+            null
+        }
+
+        val swapFee = extrinsicService.estimateFee(chain, TransactionOrigin.SelectedWallet) {
             executeSwap(args)
         }
 
-        return AssetExchangeFee(networkFee = fee, MinimumBalanceBuyIn.NoBuyInNeeded)
+        val totalNativeFee = swapFee.amount + setCurrencyFee?.amount.orZero()
+
+        val feeAmountInExpectedCurrency = if (!feeAsset.isUtilityAsset) {
+            convertNativeFeeToAssetFee(totalNativeFee, feeAsset)
+        } else {
+            totalNativeFee
+        }
+        val feeInExpectedCurrency = SubstrateFee(
+            amount = feeAmountInExpectedCurrency,
+            submissionOrigin = swapFee.submissionOrigin
+        )
+
+        return AssetExchangeFee(networkFee = feeInExpectedCurrency, MinimumBalanceBuyIn.NoBuyInNeeded)
     }
 
     override suspend fun swap(args: SwapExecuteArgs): Result<ExtrinsicSubmission> {
-        return extrinsicService.submitExtrinsic(chain, TransactionOrigin.SelectedWallet) {
-            executeSwap(args)
+        val feeAsset = args.usedFeeAsset
+        val paymentCurrencyToSet = getPaymentCurrencyToSetIfNeeded(feeAsset)
+
+        val setCurrencyResult = if (paymentCurrencyToSet != null) {
+            extrinsicService.submitAndWatchExtrinsic(chain, TransactionOrigin.SelectedWallet) {
+                setFeeCurrency(paymentCurrencyToSet)
+            }.awaitInBlock() // we need to wait for tx execution for currency update changes to be taken into account by runtime with executing swap itself
+        } else {
+            Result.success(Unit)
+        }
+
+        return setCurrencyResult.flatMap {
+            extrinsicService.submitExtrinsic(chain, TransactionOrigin.SelectedWallet) {
+                executeSwap(args)
+            }
         }
     }
 
@@ -147,7 +204,7 @@ private class HydraDxOmnipoolExchange(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun runSubscriptions(chain: Chain): Flow<ReQuoteTrigger> {
+    override fun runSubscriptions(chain: Chain, metaAccount: MetaAccount): Flow<ReQuoteTrigger> {
         omniPoolFlow.resetReplayCache()
 
         return withFlowScope { scope ->
@@ -184,14 +241,59 @@ private class HydraDxOmnipoolExchange(
 
             val defaultFees = getDefaultFees()
 
+            val userAccountId = metaAccount.requireAccountIdIn(chain)
+
+            val feeCurrency = remoteStorageSource.subscribe(chain.id, subscriptionBuilder) {
+                metadata.multiTransactionPayment.accountCurrencyMap.observe(userAccountId)
+            }
+
             subscriptionBuilder.subscribe(scope)
 
-            combine(omniPoolStateFlow, omniPoolBalancesFlow, feesFlow) { poolState, poolBalances, fees ->
+            val poolStateUpdates = combine(omniPoolStateFlow, omniPoolBalancesFlow, feesFlow) { poolState, poolBalances, fees ->
                 createOmniPool(poolState, poolBalances, fees, defaultFees)
             }
                 .onEach(omniPoolFlow::emit)
-                .map { ReQuoteTrigger }
+
+            val feeCurrencyUpdates = feeCurrency.onEach { tokenId ->
+                val feePaymentAsset = tokenId ?: SYSTEM_ON_CHAIN_ASSET_ID
+                currentPaymentAsset.emit(feePaymentAsset)
+            }
+
+            combine(poolStateUpdates, feeCurrencyUpdates) { _, _ ->
+                ReQuoteTrigger
+            }
         }
+    }
+
+    private val SwapExecuteArgs.usedFeeAsset: Chain.Asset
+        get() = customFeeAsset ?: chain.utilityAsset
+
+    private suspend fun convertNativeFeeToAssetFee(
+        nativeFeeAmount: Balance,
+        targetAsset: Chain.Asset
+    ): Balance {
+        val runtime = chainRegistry.getRuntime(chain.id)
+        val omniPool = omniPoolFlow.first()
+
+        val omniPoolTokenIdIn = targetAsset.requireOmniPoolTokenId(runtime)
+        val omniPoolTokenIdOut = chain.utilityAsset.requireOmniPoolTokenId(runtime)
+
+        val targetAssetAmount = omniPool.quote(
+            assetIdIn = omniPoolTokenIdIn,
+            assetIdOut = omniPoolTokenIdOut,
+            amount = nativeFeeAmount,
+            direction = SwapDirection.SPECIFIED_OUT
+        )
+
+        return requireNotNull(targetAssetAmount) // we don't expect liquidity run out for fee conversion
+    }
+
+    private suspend fun getPaymentCurrencyToSetIfNeeded(expectedPaymentAsset: Chain.Asset): OmniPoolTokenId? {
+        val runtime = chainRegistry.getRuntime(chain.id)
+        val currencyPaymentTokenId = currentPaymentAsset.first()
+        val expectedPaymentTokenId = expectedPaymentAsset.requireOmniPoolTokenId(runtime)
+
+        return expectedPaymentTokenId.takeIf { currencyPaymentTokenId != expectedPaymentTokenId }
     }
 
     private suspend fun getDefaultFees(): OmniPoolFees {
@@ -295,6 +397,16 @@ private class HydraDxOmnipoolExchange(
                 maxSellAmount = limit.amountInMax
             )
         }
+    }
+
+    private fun ExtrinsicBuilder.setFeeCurrency(onChainId: OmniPoolTokenId) {
+        call(
+            moduleName = "MultiTransactionPayment",
+            callName = "set_currency",
+            arguments = mapOf(
+                "currency" to onChainId
+            )
+        )
     }
 
     private fun ExtrinsicBuilder.sell(

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/omnipool/HydraDxOmnipoolExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/omnipool/HydraDxOmnipoolExchange.kt
@@ -268,6 +268,7 @@ private class HydraDxOmnipoolExchange(
     private val SwapExecuteArgs.usedFeeAsset: Chain.Asset
         get() = customFeeAsset ?: chain.utilityAsset
 
+    // This will most probably slightly over-estimate the fee since Hydra runtime uses not only Omni-pool to convert native fee
     private suspend fun convertNativeFeeToAssetFee(
         nativeFeeAmount: Balance,
         targetAsset: Chain.Asset

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/interactor/SwapInteractor.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/interactor/SwapInteractor.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.core.updater.UpdateSystem
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount.Type
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_buy_api.domain.BuyTokenRegistry
 import io.novafoundation.nova.feature_buy_api.domain.hasProvidersFor
 import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
@@ -122,8 +123,8 @@ class SwapInteractor(
         return swapService.slippageConfig(chainId)
     }
 
-    fun runSubscriptions(chainIn: Chain): Flow<ReQuoteTrigger> {
-        return swapService.runSubscriptions(chainIn)
+    fun runSubscriptions(chainIn: Chain, metaAccount: MetaAccount): Flow<ReQuoteTrigger> {
+        return swapService.runSubscriptions(chainIn, metaAccount)
     }
 
     private fun buyAvailable(chainAssetFlow: Flow<Chain.Asset?>): Flow<Boolean> {

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
@@ -15,6 +15,7 @@ import io.novafoundation.nova.common.utils.toPercent
 import io.novafoundation.nova.common.utils.withFlowScope
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.requestedAccountPaysFees
 import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
 import io.novafoundation.nova.feature_swap_api.domain.model.SlippageConfig
@@ -124,10 +125,10 @@ internal class RealSwapService(
         return exchanges[chainId]?.slippageConfig()
     }
 
-    override fun runSubscriptions(chainIn: Chain): Flow<ReQuoteTrigger> {
+    override fun runSubscriptions(chainIn: Chain, metaAccount: MetaAccount): Flow<ReQuoteTrigger> {
         return withFlowScope { scope ->
             val exchanges = exchanges(scope)
-            exchanges.getValue(chainIn.id).runSubscriptions(chainIn)
+            exchanges.getValue(chainIn.id).runSubscriptions(chainIn, metaAccount)
         }
     }
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
@@ -628,7 +628,7 @@ class SwapMainSettingsViewModel(
             .flatMapLatest { chainId ->
                 val chain = chainRegistry.getChain(chainId)
 
-                swapInteractor.runSubscriptions(chain)
+                swapInteractor.runSubscriptions(chain, selectedAccountUseCase.getSelectedMetaAccount())
                     .catch { Log.e(this@SwapMainSettingsViewModel.LOG_TAG, "Failure during subscriptions run", it) }
             }.onEach {
                 Log.d("Swap", "ReQuote triggered from subscription")


### PR DESCRIPTION
Hydra DX allows to specify tx payment currenty by executing a `MultiTransactionPayment.set_currency` call. Fee for that call is already taken in the new currency. However, it is not possible to batch this call with the other one, e.g. swap.
Moreover, if we submit swap call immedietely after set_currency, preliminary node checks will still check for native balance, so we need to wait for block inlusion of `set_currency` before submitting swap


![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/a170a5be-ea01-4fb2-bbc0-b2098ecac609)
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/5ee7c89e-c6be-47ae-8b9d-2838cb71b10a)
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/7ccf549a-f28e-486f-b9ed-d6c252b81d18)
