### PR TITLE
Fix - cannot lookup meta account when there is a chain account in another chain

### DIFF
--- a/core-db/src/main/java/io/novafoundation/nova/core_db/dao/MetaAccountDao.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/dao/MetaAccountDao.kt
@@ -26,9 +26,9 @@ import java.math.BigInteger
  */
 @Language("RoomSql")
 private const val FIND_BY_ADDRESS_WHERE_CLAUSE = """
-    LEFT JOIN chain_accounts as c ON m.id = c.metaId
+    LEFT JOIN chain_accounts as c ON m.id = c.metaId AND c.chainId = :chainId
     WHERE
-    (c.chainId = :chainId  AND c.accountId IS NOT NULL AND c.accountId = :accountId)
+    (c.accountId IS NOT NULL AND c.accountId = :accountId)
     OR (c.accountId IS NULL AND (substrateAccountId = :accountId OR ethereumAddress = :accountId))
     ORDER BY (CASE WHEN isSelected THEN 0 ELSE 1 END)
     """


### PR DESCRIPTION
Theory: https://stackoverflow.com/a/354094

`LEFT JOIN chain_accounts as c ON m.id = c.metaId` will result in all chain accounts being returned. so there will be a row associated with every existing chain account for the given meta account, but the issue is that there will be NO row with `null` chain account for unchanged chains

In the case when we search in the chain that has no chain accounts, such a request will only return rows with changed meta accounts and thus wont even detect that such meta account matches in the unchanged chain

The fix is to add `AND c.chainId = :chainId` to `ON` clasue to only return a single record that is either has or doesnt have associated chain account for a given chain. With such query, in a case of unchanged chain, we will see `null` in chain account field and will check for base accounts match