### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -100,10 +100,13 @@ env:
   CI_GITHUB_KEYSTORE_KEY_PASS: ${{ secrets.CI_GITHUB_KEYSTORE_KEY_PASS }}
   CI_GITHUB_KEYSTORE_KEY_FILE: ${{ secrets.BASE64_GITHUB_KEYSTORE_FILE }}
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-app:
-    name: Build and test android app
+    name: Build app and test
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -144,8 +147,8 @@ jobs:
         run: rm ./app/${{ inputs.keystore-file-name }}
 
       - name: ➡️ Upload build artifacts
-        uses: actions/upload-artifact@v2
         if: ${{ !startsWith(inputs.gradlew-command, 'false') }}
+        uses: actions/upload-artifact@v2
         with:
           name: apk
           path: app/build/outputs/apk/

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -11,17 +11,27 @@ runs:
         cache: 'gradle'
 
     - name: 🛠️ Install NDK
+      id: setup-ndk
       uses: nttld/setup-ndk@v1.4.2
       with:
         ndk-version: 'r26b'
-        local-cache: true
-        link-to-sdk: true
+
+    - name: Set ndk.dir in local.properties
+      run: echo "ndk.dir=${{ steps.setup-ndk.outputs.ndk-path }}" >> local.properties
+      shell: bash
 
     - name: 🦀 Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+
+    - name: Add targets
       run: |
-        curl https://sh.rustup.rs -sSf | sh -s -- -q -y --no-modify-path && \
-        rustup target add armv7-linux-androideabi && \
-        rustup target add i686-linux-android && \
-        rustup target add aarch64-linux-android && \
+        rustup target add armv7-linux-androideabi
+        rustup target add i686-linux-android
         rustup target add x86_64-linux-android
+        rustup target add aarch64-linux-android
       shell: bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,4 +9,5 @@ jobs:
     uses: novasamatech/nova-wallet-android/.github/workflows/android_build.yml@develop
     with:
       branch: ${{github.head_ref}}
+      gradlew-command: assembleDevelop
     secrets: inherit


### PR DESCRIPTION
Adding:
- set ndk path to local.properties
- concurrency in order to cancel run if new commit was pushed
- add build step to the pull_request check

Tested by:
https://github.com/novasamatech/nova-wallet-android/actions/runs/7992109309