### PR TITLE
Hotifx/console crashes

### DIFF
--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/amount/SelectSendViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/amount/SelectSendViewModel.kt
@@ -49,9 +49,9 @@ import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.SimpleGe
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitOptionalDecimalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.create
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.createGeneric
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.createGeneric
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -284,7 +284,11 @@ class SelectSendViewModel(
 
             is SendPayload.SpecifiedDestination -> {
                 val destination = chainRegistry.chainWithAsset(payload.destination.chainId, payload.destination.chainAssetId)
-                val origin = availableCrossChainDestinations.first().first().chainWithAsset
+
+                // When destination chain is specified we expect at least one destination to be available
+                val availableCrossChainDestinations = availableCrossChainDestinations.first { it.isNotEmpty() }
+                val origin = availableCrossChainDestinations.first().chainWithAsset
+
                 destinationChainWithAsset.emit(destination)
                 originChainWithAsset.emit(origin)
             }

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/metamask/states/PhishingDetectedMetamaskState.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/metamask/states/PhishingDetectedMetamaskState.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_dapp_impl.web3.metamask.states
 
 import io.novafoundation.nova.feature_dapp_impl.web3.metamask.model.MetamaskChain
+import io.novafoundation.nova.feature_dapp_impl.web3.metamask.transport.MetamaskError
 import io.novafoundation.nova.feature_dapp_impl.web3.metamask.transport.MetamaskTransportRequest
 import io.novafoundation.nova.feature_dapp_impl.web3.states.PhishingDetectedState
 
@@ -8,4 +9,8 @@ class PhishingDetectedMetamaskState(override val chain: MetamaskChain) :
     PhishingDetectedState<MetamaskTransportRequest<*>, MetamaskState>(), MetamaskState {
 
     override val selectedAccountAddress: String? = null
+
+    override fun rejectError(): Throwable {
+        return MetamaskError.Rejected()
+    }
 }

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/polkadotJs/states/PhishingDetectedPolkadotJsState.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/polkadotJs/states/PhishingDetectedPolkadotJsState.kt
@@ -3,4 +3,9 @@ package io.novafoundation.nova.feature_dapp_impl.web3.polkadotJs.states
 import io.novafoundation.nova.feature_dapp_impl.web3.polkadotJs.PolkadotJsTransportRequest
 import io.novafoundation.nova.feature_dapp_impl.web3.states.PhishingDetectedState
 
-class PhishingDetectedPolkadotJsState : PhishingDetectedState<PolkadotJsTransportRequest<*>, PolkadotJsState>(), PolkadotJsState
+class PhishingDetectedPolkadotJsState : PhishingDetectedState<PolkadotJsTransportRequest<*>, PolkadotJsState>(), PolkadotJsState {
+
+    override fun rejectError(): Throwable {
+        return IllegalAccessException("Phishing detected!")
+    }
+}

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/states/PhishingDetectedState.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/states/PhishingDetectedState.kt
@@ -5,10 +5,12 @@ import io.novafoundation.nova.feature_dapp_impl.web3.states.Web3ExtensionStateMa
 import io.novafoundation.nova.feature_dapp_impl.web3.states.Web3ExtensionStateMachine.State
 import io.novafoundation.nova.feature_dapp_impl.web3.states.Web3ExtensionStateMachine.StateMachineTransition
 
-open class PhishingDetectedState<R : Web3Transport.Request<*>, S> : State<R, S> {
+abstract class PhishingDetectedState<R : Web3Transport.Request<*>, S> : State<R, S> {
+
+    abstract fun rejectError(): Throwable
 
     override suspend fun acceptRequest(request: R, transition: StateMachineTransition<S>) {
-        request.reject(IllegalStateException("Phishing detected!"))
+        request.reject(rejectError())
     }
 
     override suspend fun acceptEvent(event: ExternalEvent, transition: StateMachineTransition<S>) {


### PR DESCRIPTION
1. Race condition when setting initial state of send screen in cross-in mode

Sometimes app crashes when  trying to get tokens through crosschain during swap

`availableCrossChainDestinations ` have `onStart { emit(emptyList()) }` so we should wait for first non-empty list when setting up initial state in cross-in mode

2. Crash when phishing is detected for EVM websites 

Can be checked on plaiv.top

Metamask transport requires errors to be subscallses of MetamaskError, hower both PhishingDetected state drops IllegalArgumentException