### PR TITLE
Fixed slippage message

### DIFF
--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidationFailure.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/SwapValidationFailure.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_swap_impl.domain.validation
 
+import io.novafoundation.nova.common.utils.Percent
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapFee
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
@@ -14,7 +15,7 @@ sealed class SwapValidationFailure {
 
     object NonPositiveAmount : SwapValidationFailure()
 
-    object InvalidSlippage : SwapValidationFailure()
+    class InvalidSlippage(val minSlippage: Percent, val maxSlippage: Percent) : SwapValidationFailure()
 
     class NewRateExceededSlippage(
         val assetIn: Chain.Asset,

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/SwapSlippageRangeValidation.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/validation/validations/SwapSlippageRangeValidation.kt
@@ -17,7 +17,7 @@ class SwapSlippageRangeValidation(
         val slippageConfig = swapService.slippageConfig(value.detailedAssetIn.chain.id)!!
 
         if (value.slippage.value !in slippageConfig.minAvailableSlippage.value..slippageConfig.maxAvailableSlippage.value) {
-            return InvalidSlippage.validationError()
+            return InvalidSlippage(slippageConfig.minAvailableSlippage, slippageConfig.maxAvailableSlippage).validationError()
         }
 
         return valid()

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
@@ -4,7 +4,6 @@ import io.novafoundation.nova.common.base.TitleAndMessage
 import io.novafoundation.nova.common.mixin.api.CustomDialogDisplayer
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.formatting.format
-import io.novafoundation.nova.common.utils.formatting.formatWithoutSymbol
 import io.novafoundation.nova.common.validation.TransformedFailure
 import io.novafoundation.nova.common.validation.ValidationFlowActions
 import io.novafoundation.nova.common.validation.ValidationStatus

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapValidationFailureUi.kt
@@ -3,6 +3,8 @@ package io.novafoundation.nova.feature_swap_impl.presentation.main
 import io.novafoundation.nova.common.base.TitleAndMessage
 import io.novafoundation.nova.common.mixin.api.CustomDialogDisplayer
 import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.utils.formatting.format
+import io.novafoundation.nova.common.utils.formatting.formatWithoutSymbol
 import io.novafoundation.nova.common.validation.TransformedFailure
 import io.novafoundation.nova.common.validation.ValidationFlowActions
 import io.novafoundation.nova.common.validation.ValidationStatus
@@ -48,9 +50,9 @@ fun CoroutineScope.mapSwapValidationFailureToUI(
 
         NotEnoughFunds.ToPayFee -> resourceManager.notSufficientBalanceToPayFeeErrorMessage().asDefault()
 
-        InvalidSlippage -> TitleAndMessage(
+        is InvalidSlippage -> TitleAndMessage(
             resourceManager.getString(R.string.swap_invalid_slippage_failure_title),
-            resourceManager.getString(R.string.swap_invalid_slippage_failure_message)
+            resourceManager.getString(R.string.swap_invalid_slippage_failure_message, reason.minSlippage.format(), reason.maxSlippage.format())
         ).asDefault()
 
         is NewRateExceededSlippage -> TitleAndMessage(


### PR DESCRIPTION
#8693c4vfm
I checked this validation and it's useless since we are detecting when slippage not in range on slippage setup screen.
I'm not sure if it would be useful in future and I think we can remove it.

But as a fastest fix I just fixed a text message params