### PR TITLE
Fix Subsquare OpenGov API

### DIFF
--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/data/offchain/referendum/subsquare/v2/SubSquareV2Api.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/data/offchain/referendum/subsquare/v2/SubSquareV2Api.kt
@@ -11,7 +11,7 @@ interface SubSquareV2Api {
     @GET
     suspend fun getReferendumPreviews(
         @Url url: String,
-        @Query("page_size") pageSize: Int = 1000
+        @Query("page_size") pageSize: Int = 100
     ): ReferendaPreviewV2Response
 
     @GET


### PR DESCRIPTION
* Only request 100 entries
* Only call Subsquare API once when screen is opened
* Do not wait for Subsquare  to return results and display referenda without metadata untill Subsquare results are loaded (to match iOS implementation)
#8694988u4

![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/7ee9cbb9-90b9-4469-8cda-df49280ced2c)