### PR TITLE
Generic ledger/runtime v15

### DIFF
--- a/app/src/androidTest/java/io/novafoundation/nova/balances/BalancesIntegrationTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/balances/BalancesIntegrationTest.kt
@@ -126,7 +126,7 @@ class BalancesIntegrationTest(
 
     private suspend fun testFeeLoadingAsync(chain: Chain) {
         return coroutineScope {
-            withTimeout(80.seconds) {
+            withTimeout(10.seconds) {
                 extrinsicService.estimateFee(chain, testTransactionOrigin()) {
                     systemRemark(byteArrayOf(0))
 

--- a/app/src/androidTest/java/io/novafoundation/nova/balances/BalancesIntegrationTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/balances/BalancesIntegrationTest.kt
@@ -126,7 +126,7 @@ class BalancesIntegrationTest(
 
     private suspend fun testFeeLoadingAsync(chain: Chain) {
         return coroutineScope {
-            withTimeout(10.seconds) {
+            withTimeout(80.seconds) {
                 extrinsicService.estimateFee(chain, testTransactionOrigin()) {
                     systemRemark(byteArrayOf(0))
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ buildscript {
 
         web3jVersion = '4.9.5'
 
-        substrateSdkVersion = '2.0.2'
+        substrateSdkVersion = '2.0.3'
 
         gifVersion = '1.2.19'
 

--- a/common/src/main/java/io/novafoundation/nova/common/utils/CryptoUtils.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/CryptoUtils.kt
@@ -3,10 +3,10 @@ package io.novafoundation.nova.common.utils
 import android.util.Base64
 import io.novasama.substrate_sdk_android.hash.Hasher.blake2b256
 import org.bouncycastle.jcajce.provider.digest.SHA256
+import org.bouncycastle.jcajce.provider.digest.SHA512
 import java.security.MessageDigest
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import org.bouncycastle.jcajce.provider.digest.SHA512
 
 fun String.hmacSHA256(secret: String): ByteArray {
     val chiper: Mac = Mac.getInstance("HmacSHA256")
@@ -39,6 +39,12 @@ fun String.md5(): String {
     val hasher = MessageDigest.getInstance("MD5")
 
     return hasher.digest(encodeToByteArray()).decodeToString()
+}
+
+fun ByteArray.md5(): String {
+    val hasher = MessageDigest.getInstance("MD5")
+
+    return hasher.digest(this).decodeToString()
 }
 
 fun ByteArray.toBase64() = Base64.encodeToString(this, Base64.NO_WRAP)

--- a/common/src/main/java/io/novafoundation/nova/common/utils/FearlessLibExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/FearlessLibExt.kt
@@ -369,6 +369,7 @@ fun Module.storageOrFallback(name: String, vararg fallbacks: String): StorageEnt
         ?.let { storage?.get(it) } ?: throw NoSuchElementException()
 
 object Modules {
+
     const val VESTING: String = "Vesting"
     const val STAKING = "Staking"
     const val BALANCES = "Balances"

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
@@ -62,6 +62,7 @@ import io.novafoundation.nova.core_db.migrations.AddGovernanceDapps_25_26
 import io.novafoundation.nova.core_db.migrations.AddGovernanceExternalApiToChain_27_28
 import io.novafoundation.nova.core_db.migrations.AddGovernanceFlagToChains_24_25
 import io.novafoundation.nova.core_db.migrations.AddGovernanceNetworkToExternalApi_33_34
+import io.novafoundation.nova.core_db.migrations.AddLocalMigratorVersionToChainRuntimes_57_58
 import io.novafoundation.nova.core_db.migrations.AddLocks_22_23
 import io.novafoundation.nova.core_db.migrations.AddMetaAccountType_14_15
 import io.novafoundation.nova.core_db.migrations.AddNfts_5_6
@@ -138,7 +139,7 @@ import io.novafoundation.nova.core_db.model.operation.SwapTypeLocal
 import io.novafoundation.nova.core_db.model.operation.TransferTypeLocal
 
 @Database(
-    version = 57,
+    version = 58,
     entities = [
         AccountLocal::class,
         NodeLocal::class,
@@ -229,7 +230,7 @@ abstract class AppDatabase : RoomDatabase() {
                     .addMigrations(AddPoolIdToOperations_46_47, AddEventIdToOperation_47_48, AddSwapOption_48_49)
                     .addMigrations(RefactorOperations_49_50, AddTransactionVersionToRuntime_50_51, AddBalanceModesToAssets_51_52)
                     .addMigrations(ChangeSessionTopicToParing_52_53, AddConnectionStateToChains_53_54, AddProxyAccount_54_55)
-                    .addMigrations(AddFungibleNfts_55_56, ChainPushSupport_56_57)
+                    .addMigrations(AddFungibleNfts_55_56, ChainPushSupport_56_57, AddLocalMigratorVersionToChainRuntimes_57_58)
                     .build()
             }
             return instance!!

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/dao/ChainDao.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/dao/ChainDao.kt
@@ -119,20 +119,31 @@ abstract class ChainDao {
     @Query("SELECT * FROM chain_runtimes")
     abstract suspend fun allRuntimeInfos(): List<ChainRuntimeInfoLocal>
 
-    @Query("UPDATE chain_runtimes SET syncedVersion = :syncedVersion WHERE chainId = :chainId")
-    abstract suspend fun updateSyncedRuntimeVersion(chainId: String, syncedVersion: Int)
+    @Query("UPDATE chain_runtimes SET syncedVersion = :syncedVersion, localMigratorVersion = :localMigratorVersion WHERE chainId = :chainId")
+    abstract suspend fun updateSyncedRuntimeVersion(chainId: String, syncedVersion: Int, localMigratorVersion: Int)
 
     @Query("UPDATE chains SET connectionState = :connectionState WHERE id = :chainId")
     abstract suspend fun setConnectionState(chainId: String, connectionState: ChainLocal.ConnectionStateLocal)
 
     @Transaction
-    open suspend fun updateRemoteRuntimeVersionIfChainExists(chainId: String, runtimeVersion: Int, transactionVersion: Int) {
+    open suspend fun updateRemoteRuntimeVersionIfChainExists(
+        chainId: String,
+        runtimeVersion: Int,
+        transactionVersion: Int,
+    ) {
         if (!chainExists(chainId)) return
 
         if (isRuntimeInfoExists(chainId)) {
             updateRemoteRuntimeVersionUnsafe(chainId, runtimeVersion, transactionVersion)
         } else {
-            insertRuntimeInfo(ChainRuntimeInfoLocal(chainId, syncedVersion = 0, remoteVersion = runtimeVersion, transactionVersion = transactionVersion))
+            val runtimeInfoLocal = ChainRuntimeInfoLocal(
+                chainId,
+                syncedVersion = 0,
+                remoteVersion = runtimeVersion,
+                transactionVersion = transactionVersion,
+                localMigratorVersion = 1
+            )
+            insertRuntimeInfo(runtimeInfoLocal)
         }
     }
 

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/57_58_AddLocalMigratorVersionToChainRuntimes.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/57_58_AddLocalMigratorVersionToChainRuntimes.kt
@@ -1,0 +1,11 @@
+package io.novafoundation.nova.core_db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val AddLocalMigratorVersionToChainRuntimes_57_58 = object : Migration(57, 58) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE `chain_runtimes` ADD COLUMN `localMigratorVersion` INTEGER NOT NULL DEFAULT 1")
+    }
+}

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/ChainRuntimeInfoLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/ChainRuntimeInfoLocal.kt
@@ -24,4 +24,5 @@ class ChainRuntimeInfoLocal(
     val syncedVersion: Int,
     val remoteVersion: Int,
     val transactionVersion: Int?,
+    val localMigratorVersion: Int
 )

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/application/substrate/RealSubstrateLedgerApplication.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/application/substrate/RealSubstrateLedgerApplication.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.utils.dropBytes
 import io.novafoundation.nova.common.utils.dropBytesLast
 import io.novafoundation.nova.common.utils.isValidSS58Address
 import io.novafoundation.nova.common.utils.toBigEndianU16
+import io.novafoundation.nova.feature_ledger_api.data.repository.LedgerRepository
 import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.LedgerApplicationResponse
 import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.LedgerSubstrateAccount
 import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.SubstrateApplicationConfig
@@ -13,7 +14,6 @@ import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.Subst
 import io.novafoundation.nova.feature_ledger_api.sdk.device.LedgerDevice
 import io.novafoundation.nova.feature_ledger_api.sdk.transport.LedgerTransport
 import io.novafoundation.nova.feature_ledger_api.sdk.transport.send
-import io.novafoundation.nova.feature_ledger_api.data.repository.LedgerRepository
 import io.novafoundation.nova.feature_ledger_impl.sdk.application.substrate.DisplayVerificationDialog.NO
 import io.novafoundation.nova.feature_ledger_impl.sdk.application.substrate.DisplayVerificationDialog.YES
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
@@ -55,9 +55,9 @@ private fun SignPayloadType(chunkIndex: Int, total: Int): SignPayloadType {
     }
 }
 
-const val PUBLIC_KEY_LENGTH = 32
-const val RESPONSE_CODE_LENGTH = 2
-const val CHUNK_SIZE = 250
+private const val PUBLIC_KEY_LENGTH = 32
+private const val RESPONSE_CODE_LENGTH = 2
+private const val CHUNK_SIZE = 250
 
 class RealSubstrateLedgerApplication(
     private val transport: LedgerTransport,

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/call/RuntimeCallsApi.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/call/RuntimeCallsApi.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.runtime.call
 
 import io.novafoundation.nova.common.data.network.runtime.binding.fromHexOrIncompatible
 import io.novafoundation.nova.runtime.network.rpc.StateCallRequest
+import io.novafoundation.nova.runtime.network.rpc.stateCall
 import io.novasama.substrate_sdk_android.extensions.requireHexPrefix
 import io.novasama.substrate_sdk_android.extensions.toHexString
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
@@ -9,8 +10,6 @@ import io.novasama.substrate_sdk_android.runtime.definitions.registry.TypeRegist
 import io.novasama.substrate_sdk_android.runtime.definitions.registry.getOrThrow
 import io.novasama.substrate_sdk_android.runtime.definitions.types.bytes
 import io.novasama.substrate_sdk_android.wsrpc.SocketService
-import io.novasama.substrate_sdk_android.wsrpc.executeAsync
-import io.novasama.substrate_sdk_android.wsrpc.mappers.pojo
 
 typealias RuntimeTypeName = String
 typealias RuntimeTypeValue = Any?
@@ -52,7 +51,7 @@ internal class RealRuntimeCallsApi(
         val data = encodeArguments(arguments)
 
         val request = StateCallRequest(runtimeApiName, data)
-        val response = socketService.executeAsync(request, mapper = pojo<String>()).result
+        val response = socketService.stateCall(request)
 
         val decoded = decodeResponse(response, returnType)
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RawRuntimeMetadata.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RawRuntimeMetadata.kt
@@ -1,0 +1,14 @@
+package io.novafoundation.nova.runtime.multiNetwork.runtime
+
+class RawRuntimeMetadata(
+    val metadataContent: ByteArray,
+
+    /**
+     * Whether metadata stored is opaque form
+     *
+     * Opaque form of metadata is equivalent to Option<Vec<u8>>
+     * So the layout for opaque metadata will have a form
+     * 1 byte (`Optional` flag) + 2..4 bytes (CompactInt, length of Vec) + regular metadata (content of Vec)
+     */
+    val isOpaque: Boolean
+)

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeCacheMigrator.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeCacheMigrator.kt
@@ -1,0 +1,17 @@
+package io.novafoundation.nova.runtime.multiNetwork.runtime
+
+class RuntimeCacheMigrator {
+
+    companion object {
+
+        private const val LATEST_VERSION = 2
+    }
+
+    fun needsMetadataFetch(localVersion: Int): Boolean {
+        return localVersion < LATEST_VERSION
+    }
+
+    fun latestVersion(): Int {
+        return LATEST_VERSION
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeMetadataFetcher.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeMetadataFetcher.kt
@@ -1,0 +1,70 @@
+package io.novafoundation.nova.runtime.multiNetwork.runtime
+
+import android.util.Log
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.network.rpc.StateCallRequest
+import io.novafoundation.nova.runtime.network.rpc.stateCall
+import io.novasama.substrate_sdk_android.extensions.fromHex
+import io.novasama.substrate_sdk_android.runtime.metadata.GetMetadataRequest
+import io.novasama.substrate_sdk_android.scale.dataType.list
+import io.novasama.substrate_sdk_android.scale.dataType.toHex
+import io.novasama.substrate_sdk_android.scale.dataType.uint32
+import io.novasama.substrate_sdk_android.wsrpc.SocketService
+import io.novasama.substrate_sdk_android.wsrpc.executeAsync
+import io.novasama.substrate_sdk_android.wsrpc.mappers.nonNull
+import io.novasama.substrate_sdk_android.wsrpc.mappers.pojo
+
+private const val LATEST_SUPPORTED_METADATA_VERSION = 15
+
+class RuntimeMetadataFetcher {
+
+    suspend fun fetchRawMetadata(
+        chainId: ChainId,
+        socketService: SocketService
+    ): RawRuntimeMetadata {
+        return runCatching {
+            socketService.fetchNewestMetadata()
+        }.onSuccess {
+            Log.d("RuntimeMetadataFetcher", "Fetched metadata via runtime call for $chainId")
+        }.getOrElse {
+            Log.d("RuntimeMetadataFetcher", "Failed to sync metadata via runtime call, fall-backing to legacy rpc call for chain $chainId", it)
+
+            socketService.fetchLegacyMetadata()
+        }
+    }
+
+    private suspend fun SocketService.fetchNewestMetadata(): RawRuntimeMetadata {
+        val availableVersions = getAvailableMetadataVersions()
+        val latestSupported = availableVersions.sorted().last { it <= LATEST_SUPPORTED_METADATA_VERSION }
+
+        return RawRuntimeMetadata(
+            metadataContent = getMetadataAtVersion(latestSupported),
+            isOpaque = true
+        )
+    }
+
+    private suspend fun SocketService.fetchLegacyMetadata(): RawRuntimeMetadata {
+        val result = executeAsync(GetMetadataRequest, mapper = pojo<String>().nonNull())
+
+        return RawRuntimeMetadata(
+            metadataContent = result.fromHex(),
+            isOpaque = false
+        )
+    }
+
+    private suspend fun SocketService.getAvailableMetadataVersions(): List<Int> {
+        val request = StateCallRequest(runtimeRpcName = "Metadata_metadata_versions", "0x")
+        return stateCall(request, returnType = list(uint32)).map { it.toInt() }
+    }
+
+    private suspend fun SocketService.getMetadataAtVersion(version: Int): ByteArray {
+        val versionEncoded = uint32.toHex(version.toUInt())
+        val request = StateCallRequest("Metadata_metadata_at_version", versionEncoded)
+        val response = stateCall(request)
+        requireNotNull(response) {
+            "Non existent metadata"
+        }
+
+        return response.fromHex()
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeProvider.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeProvider.kt
@@ -140,7 +140,7 @@ class RuntimeProvider(
                     NoRuntimeVersionException -> {
                         Log.w(this@RuntimeProvider.LOG_TAG, "Runtime version for $chainId was not found in database")
                     } // pass
-                    else -> Log.e(this@RuntimeProvider.LOG_TAG, "Failed to construct runtime ($chainId): ${it.message}")
+                    else -> Log.e(this@RuntimeProvider.LOG_TAG, "Failed to construct runtime ($chainId)", it)
                 }
             }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/network/rpc/RpcCalls.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/network/rpc/RpcCalls.kt
@@ -16,6 +16,7 @@ import io.novafoundation.nova.common.data.network.runtime.model.SignedBlock
 import io.novafoundation.nova.common.data.network.runtime.model.SignedBlock.Block.Header
 import io.novafoundation.nova.common.utils.asGsonParsedNumber
 import io.novafoundation.nova.common.utils.extrinsicHash
+import io.novafoundation.nova.common.utils.fromHex
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.runtime.call.MultiChainRuntimeCallsApi
 import io.novafoundation.nova.runtime.ext.feeViaRuntimeCall
@@ -27,6 +28,8 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.multiNetwork.getRuntime
 import io.novafoundation.nova.runtime.multiNetwork.getSocket
 import io.novasama.substrate_sdk_android.extensions.fromHex
+import io.novasama.substrate_sdk_android.scale.dataType.DataType
+import io.novasama.substrate_sdk_android.wsrpc.SocketService
 import io.novasama.substrate_sdk_android.wsrpc.executeAsync
 import io.novasama.substrate_sdk_android.wsrpc.mappers.nonNull
 import io.novasama.substrate_sdk_android.wsrpc.mappers.pojo
@@ -158,4 +161,17 @@ class RpcCalls(
             weight = bindWeight(asStruct["weight"])
         )
     }
+}
+
+suspend fun SocketService.stateCall(request: StateCallRequest): String? {
+    return executeAsync(request, mapper = pojo<String>()).result
+}
+
+suspend fun <T> SocketService.stateCall(request: StateCallRequest, returnType: DataType<T>): T {
+    val rawResult = stateCall(request)
+    requireNotNull(rawResult) {
+        "Unexpected state call null response"
+    }
+
+    return returnType.fromHex(rawResult)
 }


### PR DESCRIPTION
Requires https://github.com/novasamatech/substrate-sdk-android/pull/89

* Adjust metadata fetching logic:
1. Fetch all available metadata versions, take the latest known to the app (15 or lower)
2. Fetch the determined version using state_call
3. If (1) or (2) fails - fallback to rpc fetching

* Store the flag for whether metadta is opaque or not since state_call and rpc call have different format
* Introduce metadata cache migrator - force metadata fetching for all networks after app update to get v15 metadata for already updated networks 