### PR TITLE
Signing

### DIFF
--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/ledger/LedgerSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/ledger/LedgerSignCommunicatorImpl.kt
@@ -4,13 +4,17 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.NavigationHolder
 import io.novafoundation.nova.app.root.navigation.getBackStackEntryBefore
+import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant
 import io.novafoundation.nova.feature_account_api.presenatation.sign.LedgerSignCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator.Request
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator.Response
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerFragment
+import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerPayload
 
 class LedgerSignCommunicatorImpl(navigationHolder: NavigationHolder) :
     NavStackInterScreenCommunicator<Request, Response>(navigationHolder), LedgerSignCommunicator {
+
+    private var usedVariant: LedgerVariant? = null
 
     override fun respond(response: Response) {
         val requester = navController.getBackStackEntryBefore(R.id.signLedgerFragment)
@@ -18,10 +22,15 @@ class LedgerSignCommunicatorImpl(navigationHolder: NavigationHolder) :
         saveResultTo(requester, response)
     }
 
+    override fun setUsedVariant(variant: LedgerVariant) {
+        usedVariant = variant
+    }
+
     override fun openRequest(request: Request) {
         super.openRequest(request)
 
-        val bundle = SignLedgerFragment.getBundle(request)
+        val payload = SignLedgerPayload(request, requireNotNull(usedVariant))
+        val bundle = SignLedgerFragment.getBundle(payload)
         navController.navigate(R.id.action_open_sign_ledger, bundle)
     }
 }

--- a/common/src/main/java/io/novafoundation/nova/common/mixin/api/Browserable.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/mixin/api/Browserable.kt
@@ -7,7 +7,7 @@ import io.novafoundation.nova.common.utils.Event
 interface Browserable {
     val openBrowserEvent: LiveData<Event<String>>
 
-    interface Presentation: Browserable {
+    interface Presentation : Browserable {
         companion object // extensions
 
         fun showBrowser(url: String)

--- a/common/src/main/java/io/novafoundation/nova/common/mixin/api/Browserable.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/mixin/api/Browserable.kt
@@ -7,7 +7,7 @@ import io.novafoundation.nova.common.utils.Event
 interface Browserable {
     val openBrowserEvent: LiveData<Event<String>>
 
-    interface Presentation {
+    interface Presentation: Browserable {
         companion object // extensions
 
         fun showBrowser(url: String)
@@ -19,4 +19,8 @@ fun Browserable.Presentation.Companion.of(liveData: MutableLiveData<Event<String
     override fun showBrowser(url: String) {
         liveData.value = Event(url)
     }
+
+    override val openBrowserEvent = liveData
 }
+
+fun Browserable(): Browserable.Presentation = Browserable.Presentation.of(MutableLiveData())

--- a/common/src/main/java/io/novafoundation/nova/common/view/AlertView.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/view/AlertView.kt
@@ -25,6 +25,16 @@ import kotlinx.android.synthetic.main.view_alert.view.alertSubMessage
 
 typealias SimpleAlertModel = String
 
+class AlertModel(
+    val style: AlertView.StylePreset,
+    val message: String,
+    val subMessage: String?,
+    val action: ActionModel?
+) {
+
+    class ActionModel(val text: String, val listener: () -> Unit)
+}
+
 class AlertView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -116,5 +126,19 @@ class AlertView @JvmOverloads constructor(
         StylePreset.INFO -> Style(R.drawable.ic_info_accent, R.color.individual_chip_background)
     }
 }
+
+fun AlertView.setModel(model: AlertModel) {
+    setMessage(model.message)
+    setSubMessage(model.subMessage)
+
+    if (model.action != null) {
+        setActionText(model.action.text)
+        setOnActionClickedListener(model.action.listener)
+    }
+
+    setStylePreset(model.style)
+}
+
+fun AlertView.setModelOrHide(maybeModel: AlertModel?) = letOrHide(maybeModel, ::setModel)
 
 fun AlertView.setMessageOrHide(text: String?) = letOrHide(text, ::setMessage)

--- a/common/src/main/java/io/novafoundation/nova/common/view/ChipLabelView.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/view/ChipLabelView.kt
@@ -22,7 +22,7 @@ data class ChipLabelModel(
     val title: String
 )
 
-class TintedIcon(val canApplyOwnTint: Boolean, @DrawableRes val icon: Int) {
+data class TintedIcon(val canApplyOwnTint: Boolean, @DrawableRes val icon: Int) {
 
     companion object {
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="TypographyEllipsis">
+    <string name="account_ledger_migration_deprecation_message">The Migration app will be unavailable in the near future. Use it to migrate your accounts to the new Ledger app to avoid losing your funds.</string>
+
     <string name="account_ledger_migration_app">Migration</string>
     <string name="account_ledger_migration_generic">Generic</string>
 

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/LedgerVariant.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/LedgerVariant.kt
@@ -1,0 +1,5 @@
+package io.novafoundation.nova.feature_account_api.domain.model
+
+enum class LedgerVariant {
+    LEGACY, GENERIC
+}

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/chain/preview/BaseChainAccountsPreviewViewModel.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/chain/preview/BaseChainAccountsPreviewViewModel.kt
@@ -20,7 +20,7 @@ abstract class BaseChainAccountsPreviewViewModel(
     private val externalActions: ExternalActions.Presentation,
     private val chainRegistry: ChainRegistry,
     private val router: ReturnableRouter,
-) : BaseViewModel(), ExternalActions by externalActions {
+) : BaseViewModel(), ExternalActions.Presentation by externalActions {
 
     open val subtitle: String? = null
 

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/sign/LedgerSignCommunicator.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/sign/LedgerSignCommunicator.kt
@@ -1,3 +1,8 @@
 package io.novafoundation.nova.feature_account_api.presenatation.sign
 
-interface LedgerSignCommunicator : SignInterScreenCommunicator
+import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant
+
+interface LedgerSignCommunicator : SignInterScreenCommunicator {
+
+    fun setUsedVariant(variant: LedgerVariant)
+}

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/RealSignerProvider.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/RealSignerProvider.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_account_impl.data.signer
 
 import io.novafoundation.nova.feature_account_api.data.signer.SignerProvider
+import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant
 import io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_impl.data.signer.ledger.LedgerSignerFactory
@@ -49,9 +50,8 @@ internal class RealSignerProvider(
             LightMetaAccount.Type.WATCH_ONLY -> watchOnlySigner.create(metaAccount)
             LightMetaAccount.Type.PARITY_SIGNER -> polkadotVaultSignerFactory.createParitySigner(metaAccount)
             LightMetaAccount.Type.POLKADOT_VAULT -> polkadotVaultSignerFactory.createPolkadotVault(metaAccount)
-            // TODO ledger signing
-            LightMetaAccount.Type.LEDGER -> ledgerSignerFactory.create(metaAccount)
-            LightMetaAccount.Type.LEDGER_LEGACY -> ledgerSignerFactory.create(metaAccount)
+            LightMetaAccount.Type.LEDGER -> ledgerSignerFactory.create(metaAccount, LedgerVariant.GENERIC)
+            LightMetaAccount.Type.LEDGER_LEGACY -> ledgerSignerFactory.create(metaAccount, LedgerVariant.LEGACY)
             LightMetaAccount.Type.PROXIED -> proxiedSignerFactory.create(metaAccount, this, isRoot)
         }
     }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/ledger/LedgerSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/ledger/LedgerSigner.kt
@@ -3,28 +3,32 @@ package io.novafoundation.nova.feature_account_impl.data.signer.ledger
 import io.novafoundation.nova.common.base.errors.SigningCancelledException
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_account_api.data.signer.SigningSharedState
+import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
-import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenRequester
+import io.novafoundation.nova.feature_account_api.presenatation.sign.LedgerSignCommunicator
 import io.novafoundation.nova.feature_account_impl.R
 import io.novafoundation.nova.feature_account_impl.data.signer.SeparateFlowSigner
 import io.novafoundation.nova.feature_account_impl.presentation.common.sign.notSupported.SigningNotSupportedPresentable
+import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignedExtrinsic
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignedRaw
+import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignerPayloadExtrinsic
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignerPayloadRaw
 
 class LedgerSignerFactory(
     private val signingSharedState: SigningSharedState,
-    private val signFlowRequester: SignInterScreenRequester,
+    private val signFlowRequester: LedgerSignCommunicator,
     private val resourceManager: ResourceManager,
     private val messageSigningNotSupported: SigningNotSupportedPresentable
 ) {
 
-    fun create(metaAccount: MetaAccount): LedgerSigner {
+    fun create(metaAccount: MetaAccount, ledgerVariant: LedgerVariant): LedgerSigner {
         return LedgerSigner(
             metaAccount = metaAccount,
             signingSharedState = signingSharedState,
             signFlowRequester = signFlowRequester,
             resourceManager = resourceManager,
-            messageSigningNotSupported = messageSigningNotSupported
+            messageSigningNotSupported = messageSigningNotSupported,
+            ledgerVariant = ledgerVariant
         )
     }
 }
@@ -32,10 +36,17 @@ class LedgerSignerFactory(
 class LedgerSigner(
     metaAccount: MetaAccount,
     signingSharedState: SigningSharedState,
-    signFlowRequester: SignInterScreenRequester,
+    private val signFlowRequester: LedgerSignCommunicator,
+    private val ledgerVariant: LedgerVariant,
     private val resourceManager: ResourceManager,
     private val messageSigningNotSupported: SigningNotSupportedPresentable
 ) : SeparateFlowSigner(signingSharedState, signFlowRequester, metaAccount) {
+
+    override suspend fun signExtrinsic(payloadExtrinsic: SignerPayloadExtrinsic): SignedExtrinsic {
+        signFlowRequester.setUsedVariant(ledgerVariant)
+
+        return super.signExtrinsic(payloadExtrinsic)
+    }
 
     override suspend fun signRaw(payload: SignerPayloadRaw): SignedRaw {
         messageSigningNotSupported.presentSigningNotSupported(

--- a/feature-ledger-api/src/main/java/io/novafoundation/nova/feature_ledger_api/sdk/application/substrate/SubstrateApplicationConfig.kt
+++ b/feature-ledger-api/src/main/java/io/novafoundation/nova/feature_ledger_api/sdk/application/substrate/SubstrateApplicationConfig.kt
@@ -35,7 +35,7 @@ class SubstrateApplicationConfig(
         fun all() = ALL
 
         private fun novasamaLedgerTestnetFakeApp(): SubstrateApplicationConfig? {
-            return SubstrateApplicationConfig(chainId = "76a8acb4955b08219ac23524f00f23eea13048148a851f3b4e8881b9bcc95429", coin = 354, cla = 0x90u)
+            return SubstrateApplicationConfig(chainId = "d67c91ca75c199ff1ee9555567dfad21b9033165c39977170ec8d3f6c1fa433c", coin = 434, cla = 0x90u)
                 .takeIf { BuildConfig.DEBUG }
         }
     }

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/di/LedgerFeatureModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/di/LedgerFeatureModule.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_ledger_impl.di
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.data.secrets.v2.SecretStoreV2
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.resources.ContextManager
@@ -79,8 +80,9 @@ class LedgerFeatureModule {
         resourceManager: ResourceManager,
         migrationTracker: LedgerMigrationTracker,
         chainRegistry: ChainRegistry,
+        appLinksProvider: AppLinksProvider,
     ): LedgerMessageFormatterFactory {
-        return LedgerMessageFormatterFactory(resourceManager, migrationTracker, chainRegistry)
+        return LedgerMessageFormatterFactory(resourceManager, migrationTracker, chainRegistry, appLinksProvider)
     }
 
     @Provides

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/domain/account/sign/SignLedgerInteractor.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/domain/account/sign/SignLedgerInteractor.kt
@@ -43,7 +43,11 @@ class RealSignLedgerInteractor(
     private val genericApp: GenericSubstrateLedgerApplication,
 ) : SignLedgerInteractor {
 
-    override suspend fun getSignature(device: LedgerDevice, metaId: Long, payload: SignerPayloadExtrinsic): SignatureWrapper = withContext(Dispatchers.Default) {
+    override suspend fun getSignature(
+        device: LedgerDevice,
+        metaId: Long,
+        payload: SignerPayloadExtrinsic
+    ): SignatureWrapper = withContext(Dispatchers.Default) {
         val chainId = payload.chainId
         val app = determineLedgerApp(chainId)
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/domain/account/sign/SignLedgerInteractor.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/domain/account/sign/SignLedgerInteractor.kt
@@ -2,14 +2,31 @@ package io.novafoundation.nova.feature_ledger_impl.domain.account.sign
 
 import io.novafoundation.nova.common.utils.chainId
 import io.novafoundation.nova.feature_account_api.data.signer.SeparateFlowSignerState
+import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant
 import io.novafoundation.nova.feature_account_api.domain.model.publicKeyIn
+import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.SubstrateLedgerApplication
+import io.novafoundation.nova.feature_ledger_api.sdk.device.LedgerDevice
+import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
+import io.novafoundation.nova.feature_ledger_impl.sdk.application.substrate.legacyApp.LegacySubstrateLedgerApplication
+import io.novafoundation.nova.feature_ledger_impl.sdk.application.substrate.newApp.GenericSubstrateLedgerApplication
+import io.novafoundation.nova.feature_ledger_impl.sdk.application.substrate.newApp.MigrationSubstrateLedgerApplication
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novasama.substrate_sdk_android.encrypt.SignatureVerifier
 import io.novasama.substrate_sdk_android.encrypt.SignatureWrapper
 import io.novasama.substrate_sdk_android.encrypt.Signer.MessageHashing
+import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignerPayloadExtrinsic
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.encodedSignaturePayload
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 interface SignLedgerInteractor {
+
+    suspend fun getSignature(
+        device: LedgerDevice,
+        metaId: Long,
+        payload: SignerPayloadExtrinsic,
+    ): SignatureWrapper
 
     suspend fun verifySignature(
         payload: SeparateFlowSignerState,
@@ -19,7 +36,19 @@ interface SignLedgerInteractor {
 
 class RealSignLedgerInteractor(
     private val chainRegistry: ChainRegistry,
+    private val usedVariant: LedgerVariant,
+    private val migrationTracker: LedgerMigrationTracker,
+    private val legacyApp: LegacySubstrateLedgerApplication,
+    private val migrationApp: MigrationSubstrateLedgerApplication,
+    private val genericApp: GenericSubstrateLedgerApplication,
 ) : SignLedgerInteractor {
+
+    override suspend fun getSignature(device: LedgerDevice, metaId: Long, payload: SignerPayloadExtrinsic): SignatureWrapper = withContext(Dispatchers.Default) {
+        val chainId = payload.chainId
+        val app = determineLedgerApp(chainId)
+
+        app.getSignature(device, metaId, chainId, payload)
+    }
 
     override suspend fun verifySignature(
         payload: SeparateFlowSignerState,
@@ -34,4 +63,12 @@ class RealSignLedgerInteractor(
 
         SignatureVerifier.verify(signature, MessageHashing.SUBSTRATE, payloadBytes, publicKey)
     }.getOrDefault(false)
+
+    private suspend fun determineLedgerApp(chainId: ChainId): SubstrateLedgerApplication {
+        return when {
+            usedVariant == LedgerVariant.GENERIC -> genericApp
+            migrationTracker.shouldUseMigrationApp(chainId) -> migrationApp
+            else -> legacyApp
+        }
+    }
 }

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/addChain/selectAddress/di/AddLedgerChainAccountSelectAddressModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/addChain/selectAddress/di/AddLedgerChainAccountSelectAddressModule.kt
@@ -46,7 +46,7 @@ class AddLedgerChainAccountSelectAddressModule {
     fun provideMessageFormatter(
         screenPayload: AddLedgerChainAccountSelectAddressPayload,
         factory: LedgerMessageFormatterFactory,
-    ): LedgerMessageFormatter = factory.createLegacy(screenPayload.chainId)
+    ): LedgerMessageFormatter = factory.createLegacy(screenPayload.chainId, showAlerts = false)
 
     @Provides
     @IntoMap

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/addChain/selectLedger/di/AddChainAccountSelectLedgerModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/addChain/selectLedger/di/AddChainAccountSelectLedgerModule.kt
@@ -44,7 +44,7 @@ class AddChainAccountSelectLedgerModule {
     fun provideMessageFormatter(
         screenPayload: AddAccountPayload.ChainAccount,
         factory: LedgerMessageFormatterFactory,
-    ): LedgerMessageFormatter = factory.createLegacy(screenPayload.chainId)
+    ): LedgerMessageFormatter = factory.createLegacy(screenPayload.chainId, showAlerts = false)
 
     @Provides
     @IntoMap

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/errors/LedgerApplicationErrors.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/errors/LedgerApplicationErrors.kt
@@ -1,9 +1,11 @@
 package io.novafoundation.nova.feature_ledger_impl.presentation.account.common.errors
 
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.mixin.api.Browserable
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.event
+import io.novafoundation.nova.common.view.AlertModel
 import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.LedgerApplicationResponse
 import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.SubstrateLedgerApplicationError
 import io.novafoundation.nova.feature_ledger_impl.R
@@ -11,6 +13,7 @@ import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.bo
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.bottomSheet.LedgerMessageCommand.Show.Error.RecoverableError
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.bottomSheet.LedgerMessageCommands
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.formatters.LedgerMessageFormatter
+import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.formatters.LedgerMessageFormatter.MessageKind
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
@@ -19,7 +22,7 @@ fun <V> V.handleLedgerError(
     messageFormatter: LedgerMessageFormatter,
     resourceManager: ResourceManager,
     retry: () -> Unit
-) where V : BaseViewModel, V : LedgerMessageCommands {
+) where V : BaseViewModel, V : LedgerMessageCommands, V : Browserable.Presentation {
     reason.printStackTrace()
 
     launch {
@@ -27,60 +30,71 @@ fun <V> V.handleLedgerError(
             is CancellationException -> {
                 // do nothing on coroutines cancellation
             }
-            is SubstrateLedgerApplicationError.Response -> handleSubstrateApplicationError(reason.response, messageFormatter.appName(), resourceManager, retry)
-            else -> handleUnknownError(reason, resourceManager, retry)
+
+            is SubstrateLedgerApplicationError.Response -> handleSubstrateApplicationError(reason.response, messageFormatter, resourceManager, retry)
+            else -> handleUnknownError(reason, resourceManager, messageFormatter, retry)
         }
     }
 }
 
-private fun LedgerMessageCommands.handleUnknownError(
+private suspend fun <V> V.handleUnknownError(
     reason: Throwable,
     resourceManager: ResourceManager,
+    ledgerMessageFormatter: LedgerMessageFormatter,
     retry: () -> Unit,
-) {
+) where V : LedgerMessageCommands, V : Browserable.Presentation {
     ledgerMessageCommands.value = RetryCommand(
         title = resourceManager.getString(R.string.ledger_error_general_title),
         subtitle = resourceManager.getString(R.string.ledger_error_general_message),
+        alertModel = ledgerMessageFormatter.alertForKind(MessageKind.OTHER),
         retry = retry,
     )
 }
 
-private fun LedgerMessageCommands.handleSubstrateApplicationError(
+private suspend fun <V> V.handleSubstrateApplicationError(
     reason: LedgerApplicationResponse,
-    ledgerAppName: String,
+    ledgerMessageFormatter: LedgerMessageFormatter,
     resourceManager: ResourceManager,
     retry: () -> Unit
-) {
+) where V : LedgerMessageCommands, V : Browserable.Presentation {
     val errorTitle: String
     val errorMessage: String
+    val alert: AlertModel?
 
     when (reason) {
         LedgerApplicationResponse.APP_NOT_OPEN, LedgerApplicationResponse.WRONG_APP_OPEN -> {
-            errorTitle = resourceManager.getString(R.string.ledger_error_app_not_launched_title, ledgerAppName)
-            errorMessage = resourceManager.getString(R.string.ledger_error_app_not_launched_message, ledgerAppName)
+            val appName = ledgerMessageFormatter.appName()
+
+            errorTitle = resourceManager.getString(R.string.ledger_error_app_not_launched_title, appName)
+            errorMessage = resourceManager.getString(R.string.ledger_error_app_not_launched_message, appName)
+            alert = ledgerMessageFormatter.alertForKind(MessageKind.APP_NOT_OPEN)
         }
 
         LedgerApplicationResponse.TRANSACTION_REJECTED -> {
             errorTitle = resourceManager.getString(R.string.ledger_error_app_cancelled_title)
             errorMessage = resourceManager.getString(R.string.ledger_error_app_cancelled_message)
+            alert = ledgerMessageFormatter.alertForKind(MessageKind.OTHER)
         }
 
         else -> {
             errorTitle = resourceManager.getString(R.string.ledger_error_general_title)
             errorMessage = resourceManager.getString(R.string.ledger_error_general_message)
+            alert = ledgerMessageFormatter.alertForKind(MessageKind.OTHER)
         }
     }
 
-    ledgerMessageCommands.value = RetryCommand(retry, errorTitle, errorMessage)
+    ledgerMessageCommands.value = RetryCommand(retry = retry, title = errorTitle, subtitle = errorMessage, alertModel = alert)
 }
 
 private fun LedgerMessageCommands.RetryCommand(
     retry: () -> Unit,
     title: String,
-    subtitle: String
+    subtitle: String,
+    alertModel: AlertModel?
 ): Event<LedgerMessageCommand> = RecoverableError(
     title = title,
     subtitle = subtitle,
+    alert = alertModel,
     onCancel = ::hide,
     onRetry = retry
 ).event()

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/GenericLedgerMessageFormatter.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/GenericLedgerMessageFormatter.kt
@@ -1,13 +1,21 @@
 package io.novafoundation.nova.feature_ledger_impl.presentation.account.common.formatters
 
+import io.novafoundation.nova.common.mixin.api.Browserable
 import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.view.AlertModel
 import io.novafoundation.nova.feature_ledger_impl.R
 
 class GenericLedgerMessageFormatter(
-    private val resourceManager: ResourceManager
+    private val resourceManager: ResourceManager,
 ) : LedgerMessageFormatter {
 
     override suspend fun appName(): String {
         return resourceManager.getString(R.string.account_ledger_migration_generic)
+    }
+
+    context(Browserable.Presentation)
+    override suspend fun alertForKind(messageKind: LedgerMessageFormatter.MessageKind): AlertModel? {
+        // We do not show any alerts for new ledger app
+        return null
     }
 }

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/LedgerMessageFormatter.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/LedgerMessageFormatter.kt
@@ -1,6 +1,18 @@
 package io.novafoundation.nova.feature_ledger_impl.presentation.account.common.formatters
 
+import io.novafoundation.nova.common.mixin.api.Browserable
+import io.novafoundation.nova.common.view.AlertModel
+
 interface LedgerMessageFormatter {
 
+    enum class MessageKind {
+        APP_NOT_OPEN, OTHER
+    }
+
     suspend fun appName(): String
+
+    context(Browserable.Presentation)
+    suspend fun alertForKind(
+        messageKind: MessageKind,
+    ): AlertModel?
 }

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/LedgerMessageFormatterFactory.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/LedgerMessageFormatterFactory.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_ledger_impl.presentation.account.common.formatters
 
+import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
@@ -9,10 +10,11 @@ class LedgerMessageFormatterFactory(
     private val resourceManager: ResourceManager,
     private val migrationTracker: LedgerMigrationTracker,
     private val chainRegistry: ChainRegistry,
+    private val appLinksProvider: AppLinksProvider,
 ) {
 
-    fun createLegacy(chainId: ChainId): LedgerMessageFormatter {
-        return LegacyLedgerMessageFormatter(migrationTracker, resourceManager, chainRegistry, chainId)
+    fun createLegacy(chainId: ChainId, showAlerts: Boolean): LedgerMessageFormatter {
+        return LegacyLedgerMessageFormatter(migrationTracker, resourceManager, chainRegistry, appLinksProvider, chainId, showAlerts)
     }
 
     fun createGeneric(): LedgerMessageFormatter {

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/LegacyLedgerMessageFormatter.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/LegacyLedgerMessageFormatter.kt
@@ -1,6 +1,11 @@
 package io.novafoundation.nova.feature_ledger_impl.presentation.account.common.formatters
 
+import io.novafoundation.nova.common.data.network.AppLinksProvider
+import io.novafoundation.nova.common.mixin.api.Browserable
 import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.view.AlertModel
+import io.novafoundation.nova.common.view.AlertModel.ActionModel
+import io.novafoundation.nova.common.view.AlertView.StylePreset
 import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
 import io.novafoundation.nova.feature_ledger_impl.R
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
@@ -12,28 +17,56 @@ class LegacyLedgerMessageFormatter(
     private val migrationTracker: LedgerMigrationTracker,
     private val resourceManager: ResourceManager,
     private val chainRegistry: ChainRegistry,
-    private val chainId: ChainId
+    private val appLinksProvider: AppLinksProvider,
+    private val chainId: ChainId,
+    private val showAlerts: Boolean
 ) : LedgerMessageFormatter {
 
-    private var cache: String? = null
+    private var shouldUseMigrationApp: Boolean? = null
     private val cacheMutex = Mutex()
 
     override suspend fun appName(): String {
-        return cacheMutex.withLock {
-            if (cache == null) {
-                cache = computeAppName()
-            }
-
-            cache!!
-        }
-    }
-
-    private suspend fun computeAppName(): String {
-        return if (migrationTracker.shouldUseMigrationApp(chainId)) {
+        return if (shouldUseMigrationApp()) {
             resourceManager.getString(R.string.account_ledger_migration_app)
         } else {
             val chain = chainRegistry.getChain(chainId)
             chain.name
         }
+    }
+
+    context(Browserable.Presentation)
+    override suspend fun alertForKind(messageKind: LedgerMessageFormatter.MessageKind): AlertModel? {
+        val shouldShowAlert = showAlerts && shouldUseMigrationApp()
+        if (!shouldShowAlert) return null
+
+        return when(messageKind) {
+            LedgerMessageFormatter.MessageKind.APP_NOT_OPEN -> AlertModel(
+                style = StylePreset.INFO,
+                message = resourceManager.getString(R.string.account_ledger_legacy_warning_title),
+                subMessage = resourceManager.getString(R.string.account_ledger_legacy_warning_message),
+                action = ActionModel(
+                    text = resourceManager.getString(R.string.common_find_out_more),
+                    listener = { showBrowser(appLinksProvider.ledgerMigrationArticle) }
+                )
+            )
+
+            LedgerMessageFormatter.MessageKind.OTHER ->  AlertModel(
+                style = StylePreset.INFO,
+                message = resourceManager.getString(R.string.account_ledger_legacy_warning_title),
+                subMessage = resourceManager.getString(R.string.account_ledger_migration_deprecation_message),
+                action = ActionModel(
+                    text = resourceManager.getString(R.string.common_find_out_more),
+                    listener = { showBrowser(appLinksProvider.ledgerMigrationArticle) }
+                )
+            )
+        }
+    }
+
+    private suspend fun shouldUseMigrationApp(): Boolean = cacheMutex.withLock {
+        if (shouldUseMigrationApp == null) {
+            shouldUseMigrationApp = migrationTracker.shouldUseMigrationApp(chainId)
+        }
+
+        shouldUseMigrationApp!!
     }
 }

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/LegacyLedgerMessageFormatter.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/formatters/LegacyLedgerMessageFormatter.kt
@@ -39,7 +39,7 @@ class LegacyLedgerMessageFormatter(
         val shouldShowAlert = showAlerts && shouldUseMigrationApp()
         if (!shouldShowAlert) return null
 
-        return when(messageKind) {
+        return when (messageKind) {
             LedgerMessageFormatter.MessageKind.APP_NOT_OPEN -> AlertModel(
                 style = StylePreset.INFO,
                 message = resourceManager.getString(R.string.account_ledger_legacy_warning_title),
@@ -50,7 +50,7 @@ class LegacyLedgerMessageFormatter(
                 )
             )
 
-            LedgerMessageFormatter.MessageKind.OTHER ->  AlertModel(
+            LedgerMessageFormatter.MessageKind.OTHER -> AlertModel(
                 style = StylePreset.INFO,
                 message = resourceManager.getString(R.string.account_ledger_legacy_warning_title),
                 subMessage = resourceManager.getString(R.string.account_ledger_migration_deprecation_message),

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectAddress/SelectAddressLedgerViewModel.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectAddress/SelectAddressLedgerViewModel.kt
@@ -45,7 +45,8 @@ abstract class SelectAddressLedgerViewModel(
     private val payload: SelectLedgerAddressPayload,
     private val chainRegistry: ChainRegistry,
     private val messageFormatter: LedgerMessageFormatter
-) : BaseViewModel(), LedgerMessageCommands,
+) : BaseViewModel(),
+    LedgerMessageCommands,
     Browserable.Presentation by Browserable() {
 
     override val ledgerMessageCommands: MutableLiveData<Event<LedgerMessageCommand>> = MutableLiveData()

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectAddress/SelectAddressLedgerViewModel.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectAddress/SelectAddressLedgerViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.mixin.api.Browserable
 import io.novafoundation.nova.common.presentation.DescriptiveButtonState
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
@@ -44,7 +45,8 @@ abstract class SelectAddressLedgerViewModel(
     private val payload: SelectLedgerAddressPayload,
     private val chainRegistry: ChainRegistry,
     private val messageFormatter: LedgerMessageFormatter
-) : BaseViewModel(), LedgerMessageCommands {
+) : BaseViewModel(), LedgerMessageCommands,
+    Browserable.Presentation by Browserable() {
 
     override val ledgerMessageCommands: MutableLiveData<Event<LedgerMessageCommand>> = MutableLiveData()
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectLedger/SelectLedgerFragment.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectLedger/SelectLedgerFragment.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.mixin.impl.observeBrowserEvents
 import io.novafoundation.nova.common.utils.applyStatusBarInsets
 import io.novafoundation.nova.common.utils.permissions.setupPermissionAsker
 import io.novafoundation.nova.common.utils.setVisible
@@ -95,6 +96,7 @@ abstract class SelectLedgerFragment<V : SelectLedgerViewModel> : BaseFragment<V>
 
         setupPermissionAsker(viewModel)
         setupLedgerMessages(ledgerMessagePresentable)
+        observeBrowserEvents(viewModel)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectLedger/SelectLedgerViewModel.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/common/selectLedger/SelectLedgerViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.mixin.api.Browserable
 import io.novafoundation.nova.common.navigation.ReturnableRouter
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
@@ -48,7 +49,10 @@ abstract class SelectLedgerViewModel(
     private val router: ReturnableRouter,
     private val resourceManager: ResourceManager,
     private val messageFormatter: LedgerMessageFormatter,
-) : BaseViewModel(), PermissionsAsker by permissionsAsker, LedgerMessageCommands {
+) : BaseViewModel(),
+    PermissionsAsker by permissionsAsker,
+    LedgerMessageCommands,
+    Browserable.Presentation by Browserable() {
 
     private val stateMachine = StateMachine(WaitingForPermissionsState(), coroutineScope = this)
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/generic/preview/PreviewImportGenericLedgerViewModel.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/generic/preview/PreviewImportGenericLedgerViewModel.kt
@@ -40,8 +40,7 @@ class PreviewImportGenericLedgerViewModel(
     externalActions = externalActions,
     chainRegistry = chainRegistry,
     router = router
-),
-    LedgerMessageCommands {
+), LedgerMessageCommands {
 
     override val ledgerMessageCommands: MutableLiveData<Event<LedgerMessageCommand>> = MutableLiveData()
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/generic/preview/PreviewImportGenericLedgerViewModel.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/generic/preview/PreviewImportGenericLedgerViewModel.kt
@@ -40,7 +40,8 @@ class PreviewImportGenericLedgerViewModel(
     externalActions = externalActions,
     chainRegistry = chainRegistry,
     router = router
-), LedgerMessageCommands {
+),
+    LedgerMessageCommands {
 
     override val ledgerMessageCommands: MutableLiveData<Event<LedgerMessageCommand>> = MutableLiveData()
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/selectAddress/di/SelectAddressImportLedgerModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/selectAddress/di/SelectAddressImportLedgerModule.kt
@@ -28,7 +28,7 @@ class SelectAddressImportLedgerModule {
     fun provideMessageFormatter(
         screenPayload: SelectLedgerAddressPayload,
         factory: LedgerMessageFormatterFactory,
-    ): LedgerMessageFormatter = factory.createLegacy(screenPayload.chainId)
+    ): LedgerMessageFormatter = factory.createLegacy(screenPayload.chainId, showAlerts = false)
 
     @Provides
     @IntoMap

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/selectLedger/di/SelectLedgerImportLedgerModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/selectLedger/di/SelectLedgerImportLedgerModule.kt
@@ -37,7 +37,7 @@ class SelectLedgerImportLedgerModule {
     fun provideMessageFormatter(
         selectLedgerPayload: SelectLedgerPayload,
         factory: LedgerMessageFormatterFactory,
-    ): LedgerMessageFormatter = factory.createLegacy(selectLedgerPayload.chainId)
+    ): LedgerMessageFormatter = factory.createLegacy(selectLedgerPayload.chainId, showAlerts = false)
 
     @Provides
     @IntoMap

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/sign/SignLedgerFragment.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/sign/SignLedgerFragment.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.feature_ledger_impl.presentation.account.sign
 
 import android.os.Bundle
 import io.novafoundation.nova.common.di.FeatureUtils
-import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator
 import io.novafoundation.nova.feature_ledger_api.di.LedgerFeatureApi
 import io.novafoundation.nova.feature_ledger_impl.di.LedgerFeatureComponent
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.selectLedger.SelectLedgerFragment
@@ -14,7 +13,7 @@ class SignLedgerFragment : SelectLedgerFragment<SignLedgerViewModel>() {
         private const val PAYLOAD_KEY = "SignLedgerFragment.Payload"
 
         fun getBundle(
-            payload: SignInterScreenCommunicator.Request
+            payload: SignLedgerPayload
         ): Bundle {
             return Bundle().apply {
                 putParcelable(PAYLOAD_KEY, payload)

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/sign/SignLedgerPayload.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/sign/SignLedgerPayload.kt
@@ -1,0 +1,12 @@
+package io.novafoundation.nova.feature_ledger_impl.presentation.account.sign
+
+import android.os.Parcelable
+import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant
+import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+class SignLedgerPayload(
+    val request: SignInterScreenCommunicator.Request,
+    val ledgerVariant: LedgerVariant,
+) : Parcelable

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/sign/di/SignLedgerComponent.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/sign/di/SignLedgerComponent.kt
@@ -4,8 +4,8 @@ import androidx.fragment.app.Fragment
 import dagger.BindsInstance
 import dagger.Subcomponent
 import io.novafoundation.nova.common.di.scope.ScreenScope
-import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerFragment
+import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerPayload
 
 @Subcomponent(
     modules = [
@@ -20,7 +20,7 @@ interface SignLedgerComponent {
 
         fun create(
             @BindsInstance fragment: Fragment,
-            @BindsInstance request: SignInterScreenCommunicator.Request,
+            @BindsInstance request: SignLedgerPayload,
         ): SignLedgerComponent
     }
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/application/substrate/newApp/NewSubstrateLedgerApplication.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/application/substrate/newApp/NewSubstrateLedgerApplication.kt
@@ -17,7 +17,6 @@ import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerServic
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novasama.substrate_sdk_android.encrypt.SignatureWrapper
-import io.novasama.substrate_sdk_android.extensions.toHexString
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignerPayloadExtrinsic
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.encodedSignaturePayload
 
@@ -99,9 +98,6 @@ abstract class NewSubstrateLedgerApplication(
         val encodedTxPayloadLength = payloadBytes.size.toShort().littleEndianBytes
 
         val metadataProof = metadataShortenerService.generateExtrinsicProof(payload)
-
-        Log.e("Ledger", "Tx blob: ${payloadBytes.toHexString(withPrefix = true)}")
-        Log.e("Ledger", "Metadata proof: ${metadataProof.toHexString(withPrefix = true)}")
 
         val wholePayload = payloadBytes + metadataProof
 

--- a/feature-ledger-impl/src/main/res/layout/fragment_ledger_message.xml
+++ b/feature-ledger-impl/src/main/res/layout/fragment_ledger_message.xml
@@ -38,21 +38,30 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="40dp"
+        android:layout_marginBottom="8dp"
         android:gravity="center_horizontal"
-        android:minLines="2"
+        android:paddingBottom="24dp"
         android:textColor="@color/text_secondary"
         tools:text="Press both buttons on your Nano X E426 to verify address" />
+
+    <io.novafoundation.nova.common.view.AlertView
+        android:id="@+id/ledgerMessageAlert"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_marginHorizontal="16dp" />
+
 
     <TextView
         android:id="@+id/ledgerMessageFooterMessage"
         android:layout_width="match_parent"
         android:layout_height="52dp"
         android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:gravity="center"
-        android:visibility="gone"
         android:textColor="@color/text_primary"
+        android:visibility="gone"
         tools:text="Transaction is valid for 05:39" />
 
     <LinearLayout
@@ -60,6 +69,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:visibility="visible">
 


### PR DESCRIPTION
Legacy, migration and generic signing flows

Implementation reuses the same flow for all flows, differentiating between legacy / generic by the variant supplied by the Signer. Its basically the same approach we use for Parity Signer / Polkadot Vault differentiation

The main difference is that Legacy/Migration flow contains alerts in bottom sheets which is reflect in `LedgerMessageFormatter` adjustments

![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/01cc6463-bf65-48ff-b663-838dbeae5773)
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/1100d576-0cb0-4217-b105-5d9205d53e7b)
![image](https://github.com/novasamatech/nova-wallet-android/assets/70131744/158cd24f-5d98-4f65-937b-1a702c91dc20)
