### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -10,11 +10,9 @@ runs:
         java-version: '11'
         cache: 'gradle'
 
-    - name: 🛠️ Install NDK
-      id: setup-ndk
-      uses: nttld/setup-ndk@v1.4.2
-      with:
-        ndk-version: 'r26b'
+    - name: Install NDK
+      run: echo "y" | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "ndk;26.1.10909125" --sdk_root=${ANDROID_SDK_ROOT}
+      shell: bash
 
     - name: Set ndk.dir in local.properties
       run: echo "ndk.dir=${{ steps.setup-ndk.outputs.ndk-path }}" >> local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'

--- a/build.gradle
+++ b/build.gradle
@@ -209,9 +209,9 @@ buildscript {
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
-        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'

--- a/build.gradle
+++ b/build.gradle
@@ -226,10 +226,10 @@ buildscript {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
         maven { url "https://jitpack.io" }
         maven { url "https://nexus.iroha.tech/repository/maven-soramitsu/" }
-        mavenCentral()
         mavenLocal()
         flatDir { dirs "$rootDir/common/libs" }
     }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/di/ChainRegistryModule.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/di/ChainRegistryModule.kt
@@ -23,6 +23,7 @@ import io.novafoundation.nova.runtime.multiNetwork.connection.ConnectionSecrets
 import io.novafoundation.nova.runtime.multiNetwork.connection.Web3ApiPool
 import io.novafoundation.nova.runtime.multiNetwork.connection.autobalance.NodeAutobalancer
 import io.novafoundation.nova.runtime.multiNetwork.connection.autobalance.strategy.AutoBalanceStrategyProvider
+import io.novafoundation.nova.runtime.multiNetwork.runtime.AsyncChainSyncDispatcher
 import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeCacheMigrator
 import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeFactory
 import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeFilesCache
@@ -115,7 +116,8 @@ class ChainRegistryModule {
         runtimeFilesCache = runtimeFilesCache,
         chainDao = chainDao,
         runtimeMetadataFetcher = runtimeMetadataFetcher,
-        cacheMigrator = runtimeCacheMigrator
+        cacheMigrator = runtimeCacheMigrator,
+        chainSyncDispatcher = AsyncChainSyncDispatcher()
     )
 
     @Provides

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/ChainSyncDispatcher.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/ChainSyncDispatcher.kt
@@ -1,0 +1,44 @@
+package io.novafoundation.nova.runtime.multiNetwork.runtime
+
+import io.novafoundation.nova.common.utils.newLimitedThreadPoolExecutor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+interface ChainSyncDispatcher {
+
+    fun isSyncing(chainId: String): Boolean
+
+    fun syncFinished(chainId: String)
+
+    fun cancelExistingSync(chainId: String)
+
+    fun launchSync(chainId: String, action: suspend () -> Unit)
+}
+
+class AsyncChainSyncDispatcher(maxConcurrentUpdates: Int = 8) : ChainSyncDispatcher, CoroutineScope by CoroutineScope(Dispatchers.Default) {
+
+    private val syncDispatcher = newLimitedThreadPoolExecutor(maxConcurrentUpdates).asCoroutineDispatcher()
+    private val syncingChains = ConcurrentHashMap<String, Job>()
+
+    override fun isSyncing(chainId: String): Boolean {
+        return syncingChains.contains(chainId)
+    }
+
+    override fun syncFinished(chainId: String) {
+        syncingChains.remove(chainId)
+    }
+
+    override fun cancelExistingSync(chainId: String) {
+        syncingChains.remove(chainId)?.apply { cancel() }
+    }
+
+    override fun launchSync(chainId: String, action: suspend () -> Unit) {
+        syncingChains[chainId] =  launch(syncDispatcher) {
+            action()
+        }
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/ChainSyncDispatcher.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/ChainSyncDispatcher.kt
@@ -37,7 +37,7 @@ class AsyncChainSyncDispatcher(maxConcurrentUpdates: Int = 8) : ChainSyncDispatc
     }
 
     override fun launchSync(chainId: String, action: suspend () -> Unit) {
-        syncingChains[chainId] =  launch(syncDispatcher) {
+        syncingChains[chainId] = launch(syncDispatcher) {
             action()
         }
     }

--- a/runtime/src/test/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeProviderTest.kt
+++ b/runtime/src/test/java/io/novafoundation/nova/runtime/multiNetwork/runtime/RuntimeProviderTest.kt
@@ -41,6 +41,9 @@ class RuntimeProviderTest {
     lateinit var runtimeSyncService: RuntimeSyncService
 
     @Mock
+    lateinit var runtimeCache: RuntimeFilesCache
+
+    @Mock
     lateinit var runtimeFactory: RuntimeFactory
 
     @Mock
@@ -310,6 +313,6 @@ class RuntimeProviderTest {
 
         whenever(chain.types).thenReturn(types)
 
-        runtimeProvider = RuntimeProvider(runtimeFactory, runtimeSyncService, baseTypesSynchronizer, chain)
+        runtimeProvider = RuntimeProvider(runtimeFactory, runtimeSyncService, baseTypesSynchronizer, runtimeCache, chain)
     }
 }


### PR DESCRIPTION
Abstracted async internals of RuntimeSyncService that make hard to keep tests without race conditions:

`ChainSyncDispatcher ` interface that is responsible for launching sync jobs and keeping track of them
`AsyncChainSyncDispatcher` basically the same async code that was in `RuntimeSyncService`
`SyncChainSyncDispatcher` test implementation that does all syncs syncronously

`ChainSyncDispatcher ` also allowed us for easier verification in tests of whether sync was launched or not and how many times. Previosly we were relying in `isSyncing` which is buggy due to race conditions

Also added a new test for local migrator functionality