### PR TITLE
Use legacy app when there is no flag in config

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="account_ledger_nano_x_generic">Ledger Nano X (Generic App)</string>
     <string name="account_ledger_nano_x_legacy">Ledger Nano X (Legacy)</string>
 
-<!--    <string name="account_ledger_nano_x">Ledger Nano X</string>-->
+    <string name="account_ledger_nano_x">Ledger Nano X</string>
 
     <string name="accounts_ledger_legacy">Ledger (Legacy)</string>
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/ledger/LedgerSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/ledger/LedgerSigner.kt
@@ -51,7 +51,7 @@ class LedgerSigner(
     }
 
     override suspend fun supportsCheckMetadataHash(chain: Chain): Boolean {
-        return when(ledgerVariant) {
+        return when (ledgerVariant) {
             LedgerVariant.LEGACY -> chain.additional.isMigrationLedgerAppSupported()
 
             LedgerVariant.GENERIC -> true

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/ledger/LedgerSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/ledger/LedgerSigner.kt
@@ -9,6 +9,8 @@ import io.novafoundation.nova.feature_account_api.presenatation.sign.LedgerSignC
 import io.novafoundation.nova.feature_account_impl.R
 import io.novafoundation.nova.feature_account_impl.data.signer.SeparateFlowSigner
 import io.novafoundation.nova.feature_account_impl.presentation.common.sign.notSupported.SigningNotSupportedPresentable
+import io.novafoundation.nova.runtime.ext.isMigrationLedgerAppSupported
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignedExtrinsic
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignedRaw
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignerPayloadExtrinsic
@@ -39,13 +41,21 @@ class LedgerSigner(
     private val signFlowRequester: LedgerSignCommunicator,
     private val ledgerVariant: LedgerVariant,
     private val resourceManager: ResourceManager,
-    private val messageSigningNotSupported: SigningNotSupportedPresentable
+    private val messageSigningNotSupported: SigningNotSupportedPresentable,
 ) : SeparateFlowSigner(signingSharedState, signFlowRequester, metaAccount) {
 
     override suspend fun signExtrinsic(payloadExtrinsic: SignerPayloadExtrinsic): SignedExtrinsic {
         signFlowRequester.setUsedVariant(ledgerVariant)
 
         return super.signExtrinsic(payloadExtrinsic)
+    }
+
+    override suspend fun supportsCheckMetadataHash(chain: Chain): Boolean {
+        return when(ledgerVariant) {
+            LedgerVariant.LEGACY -> chain.additional.isMigrationLedgerAppSupported()
+
+            LedgerVariant.GENERIC -> true
+        }
     }
 
     override suspend fun signRaw(payload: SignerPayloadRaw): SignedRaw {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureModule.kt
@@ -100,6 +100,7 @@ import io.novafoundation.nova.feature_account_impl.presentation.mixin.identity.R
 import io.novafoundation.nova.feature_account_impl.presentation.mixin.selectWallet.RealRealSelectWalletMixinFactory
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.config.RealPolkadotVaultVariantConfigProvider
 import io.novafoundation.nova.feature_currency_api.domain.interfaces.CurrencyRepository
+import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
 import io.novafoundation.nova.feature_proxy_api.data.repository.GetProxyRepository
 import io.novafoundation.nova.runtime.di.REMOTE_STORAGE_SOURCE
 import io.novafoundation.nova.runtime.ethereum.gas.GasPriceProviderFactory
@@ -423,7 +424,8 @@ class AccountFeatureModule {
     fun provideAccountTypePresentationMapper(
         resourceManager: ResourceManager,
         polkadotVaultVariantConfigProvider: PolkadotVaultVariantConfigProvider,
-    ) = MetaAccountTypePresentationMapper(resourceManager, polkadotVaultVariantConfigProvider)
+        ledgerMigrationTracker: LedgerMigrationTracker
+    ) = MetaAccountTypePresentationMapper(resourceManager, polkadotVaultVariantConfigProvider, ledgerMigrationTracker)
 
     @Provides
     @FeatureScope

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/common/listing/MetaAccountTypePresentationMapper.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/common/listing/MetaAccountTypePresentationMapper.kt
@@ -20,7 +20,7 @@ class MetaAccountTypePresentationMapper(
     suspend fun mapMetaAccountTypeToUi(type: LightMetaAccount.Type): AccountChipGroupRvItem? {
         var ledgerGenericAvailable: Boolean? = null
 
-        //Cache result of `ledgerMigrationTracker.anyChainSupportsMigrationApp()` in the method scope
+        // Cache result of `ledgerMigrationTracker.anyChainSupportsMigrationApp()` in the method scope
         val genericLedgerAvailabilityChecker: GenericLedgerAvailabilityChecker = {
             if (ledgerGenericAvailable == null) {
                 ledgerGenericAvailable = ledgerMigrationTracker.anyChainSupportsMigrationApp()

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/details/mixin/LegacyLedgerWalletDetailsMixin.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/details/mixin/LegacyLedgerWalletDetailsMixin.kt
@@ -57,7 +57,6 @@ class LegacyLedgerWalletDetailsMixin(
                 message = resourceManager.getString(R.string.ledger_wallet_details_description)
             )
         }
-
     }
 
     override suspend fun getChainProjections(): GroupedList<AccountInChain.From, AccountInChain> {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/details/mixin/LegacyLedgerWalletDetailsMixin.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/details/mixin/LegacyLedgerWalletDetailsMixin.kt
@@ -19,6 +19,7 @@ import io.novafoundation.nova.feature_account_impl.presentation.account.details.
 import io.novafoundation.nova.feature_account_impl.presentation.account.details.mixin.common.notHasAccountComparator
 import io.novafoundation.nova.feature_account_impl.presentation.account.details.mixin.common.withChainComparator
 import io.novafoundation.nova.feature_ledger_api.sdk.application.substrate.SubstrateApplicationConfig
+import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 
@@ -28,6 +29,7 @@ class LegacyLedgerWalletDetailsMixin(
     private val interactor: WalletDetailsInteractor,
     private val host: WalletDetailsMixinHost,
     private val appLinksProvider: AppLinksProvider,
+    private val ledgerMigrationTracker: LedgerMigrationTracker,
     metaAccount: MetaAccount
 ) : WalletDetailsMixin(metaAccount) {
 
@@ -36,15 +38,26 @@ class LegacyLedgerWalletDetailsMixin(
     override val availableAccountActions: Flow<Set<AccountAction>> = flowOf { setOf(AccountAction.CHANGE) }
 
     override val typeAlert: Flow<AlertModel?> = flowOf {
-        AlertModel(
-            style = AlertView.Style.fromPreset(AlertView.StylePreset.WARNING),
-            message = resourceManager.getString(R.string.account_ledger_legacy_warning_title),
-            subMessage = resourceManager.getString(R.string.account_ledger_legacy_warning_message),
-            action = AlertModel.ActionModel(
-                text = resourceManager.getString(R.string.common_find_out_more),
-                listener = { host.browserableDelegate.showBrowser(appLinksProvider.ledgerMigrationArticle) }
+        if (ledgerMigrationTracker.anyChainSupportsMigrationApp()) {
+            AlertModel(
+                style = AlertView.Style.fromPreset(AlertView.StylePreset.WARNING),
+                message = resourceManager.getString(R.string.account_ledger_legacy_warning_title),
+                subMessage = resourceManager.getString(R.string.account_ledger_legacy_warning_message),
+                action = AlertModel.ActionModel(
+                    text = resourceManager.getString(R.string.common_find_out_more),
+                    listener = { host.browserableDelegate.showBrowser(appLinksProvider.ledgerMigrationArticle) }
+                )
             )
-        )
+        } else {
+            AlertModel(
+                style = AlertView.Style(
+                    backgroundColorRes = R.color.block_background,
+                    iconRes = R.drawable.ic_ledger
+                ),
+                message = resourceManager.getString(R.string.ledger_wallet_details_description)
+            )
+        }
+
     }
 
     override suspend fun getChainProjections(): GroupedList<AccountInChain.From, AccountInChain> {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/details/mixin/WalletDetailsMixinFactory.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/details/mixin/WalletDetailsMixinFactory.kt
@@ -43,7 +43,8 @@ class WalletDetailsMixinFactory(
                 interactor = interactor,
                 host = host,
                 appLinksProvider = appLinksProvider,
-                metaAccount = metaAccount
+                metaAccount = metaAccount,
+                ledgerMigrationTracker = ledgerMigrationTracker
             )
 
             Type.LEDGER -> GenericLedgerWalletDetailsMixin(

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/start/StartImportLedgerFragment.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/start/StartImportLedgerFragment.kt
@@ -8,6 +8,7 @@ import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.mixin.impl.observeBrowserEvents
 import io.novafoundation.nova.common.utils.applyStatusBarInsets
+import io.novafoundation.nova.common.utils.setVisible
 import io.novafoundation.nova.feature_ledger_api.di.LedgerFeatureApi
 import io.novafoundation.nova.feature_ledger_impl.R
 import io.novafoundation.nova.feature_ledger_impl.di.LedgerFeatureComponent
@@ -27,6 +28,7 @@ class StartImportLedgerFragment : BaseFragment<StartImportLedgerViewModel>() {
         startImportLedgerToolbar.applyStatusBarInsets()
 
         startImportLedgerContinue.setOnClickListener { viewModel.continueClicked() }
+
         startImportLedgerDepractionWarning.setOnClickListener { viewModel.deprecationWarningClicked() }
 
         startImportLedgerGuideLink.setOnClickListener { viewModel.guideClicked() }
@@ -41,5 +43,7 @@ class StartImportLedgerFragment : BaseFragment<StartImportLedgerViewModel>() {
 
     override fun subscribe(viewModel: StartImportLedgerViewModel) {
         observeBrowserEvents(viewModel)
+
+        viewModel.shouldShowWarning.observe(startImportLedgerDepractionWarning::setVisible)
     }
 }

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/start/StartImportLedgerViewModel.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/start/StartImportLedgerViewModel.kt
@@ -6,14 +6,22 @@ import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.mixin.api.Browserable
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.event
+import io.novafoundation.nova.common.utils.flowOf
+import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
 import io.novafoundation.nova.feature_ledger_impl.presentation.LedgerRouter
+import kotlinx.coroutines.flow.onStart
 
 class StartImportLedgerViewModel(
     private val router: LedgerRouter,
     private val appLinksProvider: AppLinksProvider,
+    private val ledgerMigrationTracker: LedgerMigrationTracker,
 ) : BaseViewModel(), Browserable {
 
     override val openBrowserEvent = MutableLiveData<Event<String>>()
+
+    val shouldShowWarning = flowOf { ledgerMigrationTracker.anyChainSupportsMigrationApp() }
+        .onStart { emit(false) }
+        .shareInBackground()
 
     fun backClicked() {
         router.back()

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/start/di/StartImportLedgerModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/start/di/StartImportLedgerModule.kt
@@ -9,6 +9,7 @@ import dagger.multibindings.IntoMap
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
 import io.novafoundation.nova.feature_ledger_impl.presentation.LedgerRouter
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.legacy.start.StartImportLedgerViewModel
 
@@ -21,8 +22,9 @@ class StartImportLedgerModule {
     fun provideViewModel(
         router: LedgerRouter,
         appLinksProvider: AppLinksProvider,
+        ledgerMigrationTracker: LedgerMigrationTracker,
     ): ViewModel {
-        return StartImportLedgerViewModel(router, appLinksProvider)
+        return StartImportLedgerViewModel(router, appLinksProvider, ledgerMigrationTracker)
     }
 
     @Provides

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/application/substrate/newApp/NewSubstrateLedgerApplication.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/application/substrate/newApp/NewSubstrateLedgerApplication.kt
@@ -101,6 +101,8 @@ abstract class NewSubstrateLedgerApplication(
 
         val wholePayload = payloadBytes + metadataProof
 
+        Log.d("Ledger", "Whole payload size: ${wholePayload.size}, metadata proof size: ${metadataProof.size}")
+
         val firstChunk = encodedDerivationPath + encodedTxPayloadLength
         val nextChunks = wholePayload.chunked(CHUNK_SIZE)
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/connection/usb/UsbLedgerConnection.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/connection/usb/UsbLedgerConnection.kt
@@ -64,7 +64,8 @@ class UsbLedgerConnection(
         }
 
         for (chunk in chunks) {
-            val result = connection.bulkTransfer(endpoint, chunk, chunk.size, 1000)
+            Log.w("Ledger", "Attempting to send chunk of size ${chunk.size} over usb")
+            val result = connection.bulkTransfer(endpoint, chunk, chunk.size, 10000)
             if (result < 0) {
                 Log.w("Ledger", "Failed to send bytes over usb: $result")
             } else {

--- a/feature-ledger-impl/src/main/res/layout/fragment_import_ledger_start.xml
+++ b/feature-ledger-impl/src/main/res/layout/fragment_import_ledger_start.xml
@@ -89,6 +89,8 @@
                 android:layout_height="wrap_content"
                 android:text="@string/account_ledger_legacy_warning_title"
                 app:alertMode="warning"
+                android:visibility="gone"
+                tools:visibility="visible"
                 android:id="@+id/startImportLedgerDepractionWarning"
                 app:AlertView_description="@string/account_ledger_legacy_warning_message"
                 app:AlertView_action="@string/common_find_out_more" />

--- a/feature-onboarding-impl/build.gradle
+++ b/feature-onboarding-impl/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation project(':feature-onboarding-api')
     implementation project(':feature-account-api')
     implementation project(':feature-wallet-api')
+    implementation project(':feature-ledger-core')
     implementation project(':feature-versions-api')
 
     implementation kotlinDep

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/di/OnboardingFeatureComponent.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/di/OnboardingFeatureComponent.kt
@@ -5,6 +5,7 @@ import dagger.Component
 import io.novafoundation.nova.common.di.CommonApi
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.feature_account_api.di.AccountFeatureApi
+import io.novafoundation.nova.feature_ledger_core.di.LedgerCoreApi
 import io.novafoundation.nova.feature_onboarding_api.di.OnboardingFeatureApi
 import io.novafoundation.nova.feature_onboarding_impl.OnboardingRouter
 import io.novafoundation.nova.feature_onboarding_impl.presentation.welcome.di.WelcomeComponent
@@ -36,7 +37,8 @@ interface OnboardingFeatureComponent : OnboardingFeatureApi {
         dependencies = [
             CommonApi::class,
             AccountFeatureApi::class,
-            VersionsFeatureApi::class
+            VersionsFeatureApi::class,
+            LedgerCoreApi::class
         ]
     )
     interface OnboardingFeatureDependenciesComponent : OnboardingFeatureDependencies

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/di/OnboardingFeatureDependencies.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/di/OnboardingFeatureDependencies.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.importType.ImportTypeChooserMixin
+import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
 import io.novafoundation.nova.feature_versions_api.domain.UpdateNotificationsInteractor
 
 interface OnboardingFeatureDependencies {
@@ -20,4 +21,6 @@ interface OnboardingFeatureDependencies {
     fun importTypeChooserMixin(): ImportTypeChooserMixin.Presentation
 
     val actionAwaitableMixinFactory: ActionAwaitableMixin.Factory
+
+    val ledgerMigrationTracker: LedgerMigrationTracker
 }

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/di/OnboardingFeatureHolder.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/di/OnboardingFeatureHolder.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.common.di.FeatureApiHolder
 import io.novafoundation.nova.common.di.FeatureContainer
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.feature_account_api.di.AccountFeatureApi
+import io.novafoundation.nova.feature_ledger_core.di.LedgerCoreApi
 import io.novafoundation.nova.feature_onboarding_impl.OnboardingRouter
 import io.novafoundation.nova.feature_versions_api.di.VersionsFeatureApi
 import javax.inject.Inject
@@ -19,6 +20,7 @@ class OnboardingFeatureHolder @Inject constructor(
             .commonApi(commonApi())
             .versionsFeatureApi(getFeature(VersionsFeatureApi::class.java))
             .accountFeatureApi(getFeature(AccountFeatureApi::class.java))
+            .ledgerCoreApi(getFeature(LedgerCoreApi::class.java))
             .build()
         return DaggerOnboardingFeatureComponent.factory()
             .create(onboardingRouter, onboardingFeatureDependencies)

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/SelectHardwareWalletBottomSheet.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/SelectHardwareWalletBottomSheet.kt
@@ -61,7 +61,6 @@ class SelectHardwareWalletBottomSheet(
             )
         }
 
-
         polkadotVaultItem(PolkadotVaultVariant.PARITY_SIGNER)
     }
 

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/SelectHardwareWalletBottomSheet.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/SelectHardwareWalletBottomSheet.kt
@@ -13,8 +13,13 @@ import io.novafoundation.nova.feature_onboarding_impl.presentation.welcome.model
 
 class SelectHardwareWalletBottomSheet(
     context: Context,
+    private val payload: Payload,
     private val onSuccess: (HardwareWalletModel) -> Unit
 ) : FixedListBottomSheet(context) {
+
+    class Payload(
+        val genericLedgerSupported: Boolean
+    )
 
     private val polkadotVaultVariantConfigProvider: PolkadotVaultVariantConfigProvider
 
@@ -31,20 +36,31 @@ class SelectHardwareWalletBottomSheet(
 
         polkadotVaultItem(PolkadotVaultVariant.POLKADOT_VAULT)
 
-        textItem(
-            iconRes = R.drawable.ic_ledger,
-            titleRes = R.string.account_ledger_nano_x_generic,
-            showArrow = true,
-            onClick = { onSuccess(HardwareWalletModel.LedgerGeneric) }
-        )
+        if (payload.genericLedgerSupported) {
+            textItem(
+                iconRes = R.drawable.ic_ledger,
+                titleRes = R.string.account_ledger_nano_x_generic,
+                showArrow = true,
+                onClick = { onSuccess(HardwareWalletModel.LedgerGeneric) }
+            )
 
-        textItem(
-            iconRes = R.drawable.ic_ledger_legacy,
-            titleRes = R.string.account_ledger_nano_x_legacy,
-            showArrow = true,
-            applyIconTint = false,
-            onClick = { onSuccess(HardwareWalletModel.LedgerLegacy) }
-        )
+            textItem(
+                iconRes = R.drawable.ic_ledger_legacy,
+                titleRes = R.string.account_ledger_nano_x_legacy,
+                showArrow = true,
+                applyIconTint = false,
+                onClick = { onSuccess(HardwareWalletModel.LedgerLegacy) }
+            )
+        } else {
+            textItem(
+                iconRes = R.drawable.ic_ledger,
+                titleRes = R.string.account_ledger_nano_x,
+                showArrow = true,
+                applyIconTint = false,
+                onClick = { onSuccess(HardwareWalletModel.LedgerLegacy) }
+            )
+        }
+
 
         polkadotVaultItem(PolkadotVaultVariant.PARITY_SIGNER)
     }

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/WelcomeFragment.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/WelcomeFragment.kt
@@ -84,7 +84,7 @@ class WelcomeFragment : BaseFragment<WelcomeViewModel>() {
         viewModel.shouldShowBackLiveData.observe(back::setVisible)
 
         viewModel.selectHardwareWallet.awaitableActionLiveData.observeEvent {
-            SelectHardwareWalletBottomSheet(requireContext(), it.onSuccess)
+            SelectHardwareWalletBottomSheet(requireContext(), it.payload, it.onSuccess)
                 .show()
         }
     }

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/di/WelcomeModule.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/di/WelcomeModule.kt
@@ -12,6 +12,7 @@ import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.feature_account_api.presenatation.account.add.AddAccountPayload
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.importType.ImportTypeChooserMixin
+import io.novafoundation.nova.feature_ledger_core.domain.LedgerMigrationTracker
 import io.novafoundation.nova.feature_onboarding_impl.OnboardingRouter
 import io.novafoundation.nova.feature_onboarding_impl.presentation.welcome.WelcomeViewModel
 import io.novafoundation.nova.feature_versions_api.domain.UpdateNotificationsInteractor
@@ -29,7 +30,8 @@ class WelcomeModule {
         importTypeChooserMixin: ImportTypeChooserMixin.Presentation,
         addAccountPayload: AddAccountPayload,
         actionAwaitableMixin: ActionAwaitableMixin.Factory,
-        updateNotificationsInteractor: UpdateNotificationsInteractor
+        updateNotificationsInteractor: UpdateNotificationsInteractor,
+        ledgerMigrationTracker: LedgerMigrationTracker,
     ): ViewModel {
         return WelcomeViewModel(
             shouldShowBack,
@@ -38,6 +40,7 @@ class WelcomeModule {
             addAccountPayload,
             importTypeChooserMixin,
             actionAwaitableMixin,
+            ledgerMigrationTracker,
             updateNotificationsInteractor
         )
     }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -13,7 +13,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField "String", "CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v20/chains_dev.json\""
+        buildConfigField "String", "CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/valentunn-kusama-chopstics/chains/v20/chains_dev.json\""
         buildConfigField "String", "EVM_ASSETS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/assets/evm/v2/assets_dev.json\""
 
         buildConfigField "String", "TEST_CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/tests/chains_for_testBalance.json\""

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
@@ -102,6 +102,10 @@ fun Chain.Additional?.isGenericLedgerAppSupported(): Boolean {
     return this?.supportLedgerGenericApp ?: false
 }
 
+fun Chain.Additional?.isMigrationLedgerAppSupported(): Boolean {
+    return isGenericLedgerAppSupported()
+}
+
 fun ChainId.chainIdHexPrefix16(): String {
     return removeHexPrefix()
         .take(32)

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/metadata/MetadataShortenerService.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/metadata/MetadataShortenerService.kt
@@ -30,6 +30,8 @@ interface MetadataShortenerService {
     suspend fun generateExtrinsicProof(payloadExtrinsic: SignerPayloadExtrinsic): ByteArray
 
     suspend fun generateMetadataProof(chainId: ChainId): MetadataProof
+
+    suspend fun generateDisabledMetadataProof(chainId: ChainId): MetadataProof
 }
 
 private const val MINIMUM_METADATA_VERSION_TO_CALCULATE_HASH = 15
@@ -90,6 +92,15 @@ internal class RealMetadataShortenerService(
                 )
             }
         }
+    }
+
+    override suspend fun generateDisabledMetadataProof(chainId: ChainId): MetadataProof {
+        val runtimeVersion = rpcCalls.getRuntimeVersion(chainId)
+
+        return MetadataProof(
+            checkMetadataHash = CheckMetadataHash.Disabled,
+            usedVersion = runtimeVersion,
+        )
     }
 
     private suspend fun generateMetadataProofOrDisabled(

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/signer/NovaSigner.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/signer/NovaSigner.kt
@@ -7,6 +7,15 @@ import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignerPayloadE
 
 interface NovaSigner : Signer {
 
+    /**
+     * Indicate whether it is possible to include CheckMetadataHash.Enabled into extrinsic
+     * This method will become redundant once Ledger releases both Generic and Migration apps
+     * After that, there wont be a need in additional check and runtime-based check will be enough
+     */
+    suspend fun supportsCheckMetadataHash(chain: Chain): Boolean {
+        return true
+    }
+
     suspend fun signerAccountId(chain: Chain): AccountId
 
     suspend fun modifyPayload(payloadExtrinsic: SignerPayloadExtrinsic): SignerPayloadExtrinsic

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
@@ -138,7 +138,7 @@ data class Chain(
         }
 
         val connectionType = when {
-            unformattedUrl.startsWith("wss://") -> ConnectionType.WSS
+            unformattedUrl.startsWith("wss://") || unformattedUrl.startsWith("ws://") -> ConnectionType.WSS
             unformattedUrl.startsWith("https://") -> ConnectionType.HTTPS
             else -> ConnectionType.UNKNOWN
         }


### PR DESCRIPTION
* Do not show Ledger deprecation warnings of no networks for generic app are available
* Do not add metadata hash to tx if it is legacy ledger account on network that doesnt support generic app yet (Kusama)
* Hide Generic Ledger connection option if no chains with generic support are available

Tested with chopsticks and Kusama v1.2.5