### PR TITLE
Rc/8.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
         // App version
-        versionName = '8.0.0'
-        versionCode = 138
+        versionName = '8.0.1'
+        versionCode = 139
 
         applicationId = "io.novafoundation.nova"
         releaseApplicationSuffix = "market"

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/58_59_AddGloballyUniqueIdToMetaAccounts.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/58_59_AddGloballyUniqueIdToMetaAccounts.kt
@@ -14,7 +14,7 @@ val AddGloballyUniqueIdToMetaAccounts_58_59 = object : Migration(58, 59) {
 
         ids.forEach { id ->
             val uuid = MetaAccountLocal.generateGloballyUniqueId()
-            database.execSQL("UPDATE meta_accounts as m SET globallyUniqueId = '$uuid' WHERE m.id = $id")
+            database.execSQL("UPDATE meta_accounts SET globallyUniqueId = '$uuid' WHERE id = $id")
         }
     }
 


### PR DESCRIPTION
I didnt figured out why exactly does `UPDATE meta_accounts AS m`  trigger  `synatx error near "as"` error on older version of Android (no mentions of something similar in SQLite changelogs) but removing aliasing resolved the issue on my Android 10 emulator