### PR TITLE
Fix/unlock dublications

### DIFF
--- a/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/locks/RealClaimScheduleCalculator.kt
+++ b/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/locks/RealClaimScheduleCalculator.kt
@@ -252,10 +252,14 @@ class RealClaimScheduleCalculator(
         val (claimable, nonClaimable) = chunks.partition { it is UnlockChunk.Claimable }
 
         // fold all claimable chunks to single one
-        val initialClaimable = UnlockChunk.Claimable(amount = Balance.ZERO, actions = emptyList())
-        val claimableChunk = (claimable as List<UnlockChunk.Claimable>).fold(initialClaimable) { acc, unlockChunk ->
-            UnlockChunk.Claimable(acc.amount + unlockChunk.amount, acc.actions + unlockChunk.actions)
+        val initialClaimable = Balance.ZERO to emptyList<ClaimAction>()
+
+        val (claimableAmount, claimableActions) = (claimable as List<UnlockChunk.Claimable>).fold(initialClaimable) { (amount, actions), unlockChunk ->
+            val nextAmount = amount + unlockChunk.amount
+            val nextActions = actions + unlockChunk.actions
+            nextAmount to nextActions
         }
+        val claimableChunk = constructClaimableChunk(claimableAmount, claimableActions)
 
         return buildList {
             if (claimableChunk.amount.isPositive()) {
@@ -264,6 +268,19 @@ class RealClaimScheduleCalculator(
 
             addAll(nonClaimable)
         }
+    }
+
+    private fun constructClaimableChunk(
+        claimableAmount: Balance,
+        claimableActions: List<ClaimAction>
+    ): UnlockChunk.Claimable {
+        return UnlockChunk.Claimable(claimableAmount, claimableActions.dedublicateUnlocks())
+    }
+
+    // We want to avoid doing multiple unlocks for the same track
+    // For that we also need to move unlock() calls to the end
+    private fun List<ClaimAction>.dedublicateUnlocks(): List<ClaimAction> {
+        return distinct().sortedBy { it is Unlock }
     }
 
     private fun OnChainReferendum.maxConvictionEnd(vote: AccountVote): BlockNumber {

--- a/feature-governance-impl/src/test/java/io/novafoundation/nova/feature_governance_api/domain/locks/RealClaimScheduleCalculatorTest.kt
+++ b/feature-governance-impl/src/test/java/io/novafoundation/nova/feature_governance_api/domain/locks/RealClaimScheduleCalculatorTest.kt
@@ -470,10 +470,10 @@ class RealClaimScheduleCalculatorTest {
 
         expect {
             claimable(amount = 10) {
-                removeVote(1, 1)
-                removeVote(1, 2)
+                removeVote(trackId = 1, referendumId = 1)
+                removeVote(trackId = 1, referendumId = 2)
 
-                unlock(1)
+                unlock(trackId = 1)
             }
         }
     }

--- a/feature-governance-impl/src/test/java/io/novafoundation/nova/feature_governance_api/domain/locks/RealClaimScheduleCalculatorTest.kt
+++ b/feature-governance-impl/src/test/java/io/novafoundation/nova/feature_governance_api/domain/locks/RealClaimScheduleCalculatorTest.kt
@@ -152,9 +152,9 @@ class RealClaimScheduleCalculatorTest {
         expect {
             claimable(amount = 2) {
                 removeVote(trackId = 1, referendumId = 1)
-                unlock(trackId = 1)
-
                 removeVote(trackId = 0, referendumId = 0)
+
+                unlock(trackId = 1)
                 unlock(trackId = 0)
             }
         }
@@ -194,12 +194,11 @@ class RealClaimScheduleCalculatorTest {
         expect {
             claimable(amount = 2) {
                 removeVote(trackId = 2, referendumId = 2)
-                unlock(2)
-
                 removeVote(trackId = 1, referendumId = 1)
-                unlock(1)
-
                 removeVote(trackId = 3, referendumId = 3)
+
+                unlock(2)
+                unlock(1)
                 unlock(3)
             }
         }
@@ -451,6 +450,31 @@ class RealClaimScheduleCalculatorTest {
 
             // 1 is delayed indefinitely because of track 1 delegation
             nonClaimable(amount = 1)
+        }
+    }
+
+    @Test
+    fun `should not dublicate unlcock when claiming multiple chunks`() = ClaimScheduleTest {
+        given {
+            currentBlock(1100)
+
+            track(1) {
+                lock(10)
+
+                voting {
+                    vote(amount = 5, unlockAt = 1002, referendumId = 2)
+                    vote(amount = 10, unlockAt = 1001, referendumId = 1)
+                }
+            }
+        }
+
+        expect {
+            claimable(amount = 10) {
+                removeVote(1, 1)
+                removeVote(1, 2)
+
+                unlock(1)
+            }
         }
     }
 }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/connection/autobalance/NodeAutobalancer.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/connection/autobalance/NodeAutobalancer.kt
@@ -35,6 +35,7 @@ class NodeAutobalancer(
                     Log.w(this@NodeAutobalancer.LOG_TAG, "No wss nodes available for chain $chainId")
 
                     emit(null)
+                    return@transform
                 }
 
                 val nodeIterator = strategy.generateNodeSequence(wssNodes).iterator()


### PR DESCRIPTION
We had a cornercase when there were multiple unlocks available for the same track
Current behavior resulted in mutiple unlock() calls
The solution is to de-dublicate unlcocks at the end of calculations