### PR TITLE
Treasury spend support

### DIFF
--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/chains/AssetHubFeePaymentProvider.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/chains/AssetHubFeePaymentProvider.kt
@@ -26,7 +26,7 @@ class AssetHubFeePaymentProvider(
                     paymentAsset = feePaymentCurrency.asset,
                     multiChainRuntimeCallsApi = multiChainRuntimeCallsApi,
                     remoteStorageSource = remoteStorageSource,
-                    multiLocationConverter = multiLocationConverterFactory.default(chain, coroutineScope!!)
+                    multiLocationConverter = multiLocationConverterFactory.defaultAsync(chain, coroutineScope!!)
                 )
             }
 

--- a/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/referendum/details/ReferendumCall.kt
+++ b/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/referendum/details/ReferendumCall.kt
@@ -1,16 +1,22 @@
 package io.novafoundation.nova.feature_governance_api.domain.referendum.details
 
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.runtime.ext.fullId
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.runtime.AccountId
 
 sealed class ReferendumCall {
 
     open fun combineWith(other: ReferendumCall): ReferendumCall = this
 
-    data class TreasuryRequest(val amount: Balance, val beneficiary: AccountId) : ReferendumCall() {
+    data class TreasuryRequest(
+        val amount: Balance,
+        val beneficiary: AccountId,
+        val chainAsset: Chain.Asset,
+    ) : ReferendumCall() {
 
         override fun combineWith(other: ReferendumCall): ReferendumCall {
-            if (other is TreasuryRequest) {
+            if (other is TreasuryRequest && other.chainAsset.fullId == chainAsset.fullId) {
                 return copy(amount = amount + other.amount)
             }
 

--- a/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/tindergov/TinderGovInteractor.kt
+++ b/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/tindergov/TinderGovInteractor.kt
@@ -4,10 +4,10 @@ import io.novafoundation.nova.feature_governance_api.data.model.TinderGovBasketI
 import io.novafoundation.nova.feature_governance_api.data.model.VotingPower
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.ReferendumId
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.VoteType
+import io.novafoundation.nova.feature_governance_api.domain.referendum.details.ReferendumCall
 import io.novafoundation.nova.feature_governance_api.domain.referendum.list.ReferendaState
 import io.novafoundation.nova.feature_governance_api.domain.referendum.list.ReferendumPreview
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
-import java.math.BigInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
@@ -34,7 +34,7 @@ interface TinderGovInteractor {
 
     suspend fun loadReferendumSummary(id: ReferendumId): String?
 
-    suspend fun loadReferendumAmount(referendumPreview: ReferendumPreview): BigInteger?
+    suspend fun loadReferendumAmount(referendumPreview: ReferendumPreview): ReferendumCall.TreasuryRequest?
 
     suspend fun setVotingPower(votingPower: VotingPower)
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/GovernanceFeatureDependencies.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/GovernanceFeatureDependencies.kt
@@ -38,6 +38,8 @@ import io.novafoundation.nova.runtime.di.ExtrinsicSerialization
 import io.novafoundation.nova.runtime.di.REMOTE_STORAGE_SOURCE
 import io.novafoundation.nova.runtime.ethereum.StorageSharedRequestsBuilderFactory
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.MultiLocationConverterFactory
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain.ChainMultiLocationConverterFactory
 import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novafoundation.nova.runtime.repository.TotalIssuanceRepository
 import io.novafoundation.nova.runtime.storage.SampledBlockTimeStorage
@@ -128,4 +130,8 @@ interface GovernanceFeatureDependencies {
     val storageStorageSharedRequestsBuilderFactory: StorageSharedRequestsBuilderFactory
 
     val bannerVisibilityRepository: BannerVisibilityRepository
+
+    val chainMultiLocationConverterFactory: ChainMultiLocationConverterFactory
+
+    val assetMultiLocationConverterFactory: MultiLocationConverterFactory
 }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/modules/screens/ReferendumDetailsModule.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/modules/screens/ReferendumDetailsModule.kt
@@ -40,8 +40,8 @@ class ReferendumDetailsModule {
     @FeatureScope
     @IntoSet
     fun provideTreasurySpendParser(
-       chainLocationConverter: ChainMultiLocationConverterFactory,
-       assetLocationConverter: MultiLocationConverterFactory
+        chainLocationConverter: ChainMultiLocationConverterFactory,
+        assetLocationConverter: MultiLocationConverterFactory
     ): ReferendumCallAdapter = TreasurySpendAdapter(chainLocationConverter, assetLocationConverter)
 
     @Provides

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/modules/screens/ReferendumDetailsModule.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/modules/screens/ReferendumDetailsModule.kt
@@ -20,7 +20,10 @@ import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.batch.BatchAdapter
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.treasury.TreasuryApproveProposalAdapter
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.treasury.TreasurySpendAdapter
+import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.treasury.TreasurySpendLocalAdapter
 import io.novafoundation.nova.runtime.di.ExtrinsicSerialization
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.MultiLocationConverterFactory
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain.ChainMultiLocationConverterFactory
 import io.novafoundation.nova.runtime.repository.ChainStateRepository
 
 @Module
@@ -36,7 +39,15 @@ class ReferendumDetailsModule {
     @Provides
     @FeatureScope
     @IntoSet
-    fun provideTreasurySpendParser(): ReferendumCallAdapter = TreasurySpendAdapter()
+    fun provideTreasurySpendParser(
+       chainLocationConverter: ChainMultiLocationConverterFactory,
+       assetLocationConverter: MultiLocationConverterFactory
+    ): ReferendumCallAdapter = TreasurySpendAdapter(chainLocationConverter, assetLocationConverter)
+
+    @Provides
+    @FeatureScope
+    @IntoSet
+    fun provideTreasurySpendLocalParser(): ReferendumCallAdapter = TreasurySpendLocalAdapter()
 
     @Provides
     @FeatureScope

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/RealReferendumDetailsInteractor.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/RealReferendumDetailsInteractor.kt
@@ -75,7 +75,7 @@ class RealReferendumDetailsInteractor(
     }
 
     override suspend fun detailsFor(preImage: PreImage, chain: Chain): ReferendumCall? {
-        return preImageParser.parse(preImage, chain.id)
+        return preImageParser.parse(preImage, chain)
     }
 
     override suspend fun previewFor(preImage: PreImage): PreimagePreview {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/ReferendumPreImageParser.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/ReferendumPreImageParser.kt
@@ -12,7 +12,7 @@ interface ReferendumPreImageParser {
 
     suspend fun parse(preImage: PreImage, chain: Chain): ReferendumCall?
 
-    suspend fun parsePreimageCall(call: GenericCall.Instance,  chain: Chain): ReferendumCall?
+    suspend fun parsePreimageCall(call: GenericCall.Instance, chain: Chain): ReferendumCall?
 }
 
 interface ReferendumCallAdapter {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/ReferendumPreImageParser.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/ReferendumPreImageParser.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.feature_governance_impl.domain.referendum.details
 
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.PreImage
 import io.novafoundation.nova.feature_governance_api.domain.referendum.details.ReferendumCall
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.extensions.tryFindNonNull
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 import kotlinx.coroutines.Dispatchers
@@ -10,9 +10,9 @@ import kotlinx.coroutines.withContext
 
 interface ReferendumPreImageParser {
 
-    suspend fun parse(preImage: PreImage, chainId: ChainId): ReferendumCall?
+    suspend fun parse(preImage: PreImage, chain: Chain): ReferendumCall?
 
-    suspend fun parsePreimageCall(call: GenericCall.Instance, chainId: ChainId): ReferendumCall?
+    suspend fun parsePreimageCall(call: GenericCall.Instance,  chain: Chain): ReferendumCall?
 }
 
 interface ReferendumCallAdapter {
@@ -22,7 +22,7 @@ interface ReferendumCallAdapter {
 
 interface ReferendumCallParseContext {
 
-    val chainId: ChainId
+    val chain: Chain
 
     /**
      * Can be used to resolve nested calls in compound calls like batch or proxy calls
@@ -35,12 +35,12 @@ class RealReferendumPreImageParser(
     private val knownAdapters: Collection<ReferendumCallAdapter>,
 ) : ReferendumPreImageParser {
 
-    override suspend fun parse(preImage: PreImage, chainId: ChainId): ReferendumCall? {
-        return parsePreimageCall(preImage.call, chainId)
+    override suspend fun parse(preImage: PreImage, chain: Chain): ReferendumCall? {
+        return parsePreimageCall(preImage.call, chain)
     }
 
-    override suspend fun parsePreimageCall(call: GenericCall.Instance, chainId: ChainId): ReferendumCall? {
-        val context = RealReferendumCallParseContext(chainId, knownAdapters)
+    override suspend fun parsePreimageCall(call: GenericCall.Instance, chain: Chain): ReferendumCall? {
+        val context = RealReferendumCallParseContext(chain, knownAdapters)
 
         return withContext(Dispatchers.IO) {
             context.parse(call)
@@ -48,7 +48,7 @@ class RealReferendumPreImageParser(
     }
 
     private inner class RealReferendumCallParseContext(
-        override val chainId: ChainId,
+        override val chain: Chain,
         private val knownAdapters: Collection<ReferendumCallAdapter>,
     ) : ReferendumCallParseContext {
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/treasury/TreasuryApproveProposalAdapter.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/treasury/TreasuryApproveProposalAdapter.kt
@@ -8,6 +8,7 @@ import io.novafoundation.nova.feature_governance_api.data.repository.TreasuryRep
 import io.novafoundation.nova.feature_governance_api.domain.referendum.details.ReferendumCall
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.ReferendumCallAdapter
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.ReferendumCallParseContext
+import io.novafoundation.nova.runtime.ext.utilityAsset
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 
 class TreasuryApproveProposalAdapter(
@@ -19,8 +20,12 @@ class TreasuryApproveProposalAdapter(
 
         val id = bindNumber(call.arguments["proposal_id"])
 
-        val proposal = treasuryRepository.getTreasuryProposal(context.chainId, TreasuryProposal.Id(id)) ?: return null
+        val proposal = treasuryRepository.getTreasuryProposal(context.chain.id, TreasuryProposal.Id(id)) ?: return null
 
-        return ReferendumCall.TreasuryRequest(amount = proposal.amount, beneficiary = proposal.beneficiary)
+        return ReferendumCall.TreasuryRequest(
+            amount = proposal.amount,
+            chainAsset = context.chain.utilityAsset,
+            beneficiary = proposal.beneficiary
+        )
     }
 }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/treasury/TreasurySpendAdapter.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/treasury/TreasurySpendAdapter.kt
@@ -1,26 +1,47 @@
 package io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.treasury
 
-import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdentifier
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNonce
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.instanceOf
 import io.novafoundation.nova.feature_governance_api.domain.referendum.details.ReferendumCall
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.ReferendumCallAdapter
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.ReferendumCallParseContext
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.accountId
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.LocatableMultiAsset
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.bindVersionedLocatableMultiAsset
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.bindVersionedMultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.MultiLocationConverterFactory
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain.ChainMultiLocationConverterFactory
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 
-class TreasurySpendAdapter : ReferendumCallAdapter {
+class TreasurySpendAdapter(
+    private val chainLocationConverterFactory: ChainMultiLocationConverterFactory,
+    private val assetLocationConverterFactory: MultiLocationConverterFactory
+): ReferendumCallAdapter {
 
     override suspend fun fromCall(
         call: GenericCall.Instance,
         context: ReferendumCallParseContext
     ): ReferendumCall? {
-        // TODO: spend call is using MultiLocation now instead of MultiAddress so binding throws an exception
-        if (!call.instanceOf(Modules.TREASURY, "spend_local", "spend")) return null
+        if (!call.instanceOf(Modules.TREASURY, "spend")) return null
 
         val amount = bindNonce(call.arguments["amount"])
-        val beneficiary = bindAccountIdentifier(call.arguments["beneficiary"])
+        val beneficiaryLocation = bindVersionedMultiLocation(call.arguments["beneficiary"])
+        val asset = bindVersionedLocatableMultiAsset(call.arguments["asset_kind"])
 
-        return ReferendumCall.TreasuryRequest(amount, beneficiary)
+        return ReferendumCall.TreasuryRequest(
+            amount = amount,
+            beneficiary = beneficiaryLocation.accountId() ?: return null,
+            chainAsset = resolveChainAsset(asset, context.chain) ?: return null
+        )
+    }
+
+    private suspend fun resolveChainAsset(locatableMultiAsset: LocatableMultiAsset, chain: Chain): Chain.Asset? {
+        val chainLocationConverter = chainLocationConverterFactory.resolveSelfAndChildrenParachains(chain)
+        val resolvedChain = chainLocationConverter.toChain(locatableMultiAsset.location) ?: return null
+
+        val assetLocationConverter = assetLocationConverterFactory.resolveLocalAssets(resolvedChain)
+        return assetLocationConverter.toChainAsset(locatableMultiAsset.assetId.multiLocation)
     }
 }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/treasury/TreasurySpendAdapter.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/treasury/TreasurySpendAdapter.kt
@@ -18,7 +18,7 @@ import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.Gene
 class TreasurySpendAdapter(
     private val chainLocationConverterFactory: ChainMultiLocationConverterFactory,
     private val assetLocationConverterFactory: MultiLocationConverterFactory
-): ReferendumCallAdapter {
+) : ReferendumCallAdapter {
 
     override suspend fun fromCall(
         call: GenericCall.Instance,

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/treasury/TreasurySpendLocalAdapter.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/details/call/treasury/TreasurySpendLocalAdapter.kt
@@ -1,0 +1,30 @@
+package io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.treasury
+
+import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdentifier
+import io.novafoundation.nova.common.data.network.runtime.binding.bindNonce
+import io.novafoundation.nova.common.utils.Modules
+import io.novafoundation.nova.common.utils.instanceOf
+import io.novafoundation.nova.feature_governance_api.domain.referendum.details.ReferendumCall
+import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.ReferendumCallAdapter
+import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.ReferendumCallParseContext
+import io.novafoundation.nova.runtime.ext.utilityAsset
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+
+class TreasurySpendLocalAdapter : ReferendumCallAdapter {
+
+    override suspend fun fromCall(
+        call: GenericCall.Instance,
+        context: ReferendumCallParseContext
+    ): ReferendumCall? {
+        if (!call.instanceOf(Modules.TREASURY, "spend_local")) return null
+
+        val amount = bindNonce(call.arguments["amount"])
+        val beneficiary = bindAccountIdentifier(call.arguments["beneficiary"])
+
+        return ReferendumCall.TreasuryRequest(
+            amount = amount,
+            beneficiary = beneficiary,
+            chainAsset = context.chain.utilityAsset
+        )
+    }
+}

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/tindergov/RealTinderGovInteractor.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/tindergov/RealTinderGovInteractor.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import java.math.BigInteger
 
 class RealTinderGovInteractor(
     private val governanceSharedState: GovernanceSharedState,
@@ -111,7 +110,7 @@ class RealTinderGovInteractor(
         return referendumDetailsRepository.loadSummary(chain, id, summaryApi.url)
     }
 
-    override suspend fun loadReferendumAmount(referendumPreview: ReferendumPreview): BigInteger? {
+    override suspend fun loadReferendumAmount(referendumPreview: ReferendumPreview): ReferendumCall.TreasuryRequest? {
         val selectedGovernanceOption = governanceSharedState.selectedOption()
         val chain = selectedGovernanceOption.assetWithChain.chain
 
@@ -119,11 +118,7 @@ class RealTinderGovInteractor(
         val referendumProposalCall = referendumProposal?.toCallOrNull()
         val referendumCall = referendumProposalCall?.let { preImageParser.parsePreimageCall(it.call, chain) }
 
-        return if (referendumCall is ReferendumCall.TreasuryRequest) {
-            referendumCall.amount
-        } else {
-            null
-        }
+        return referendumCall as? ReferendumCall.TreasuryRequest
     }
 
     override suspend fun setVotingPower(votingPower: VotingPower) {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/tindergov/RealTinderGovInteractor.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/tindergov/RealTinderGovInteractor.kt
@@ -9,35 +9,35 @@ import io.novafoundation.nova.feature_governance_api.data.model.VotingPower
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.ReferendumId
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.VoteType
 import io.novafoundation.nova.feature_governance_api.domain.referendum.details.ReferendumCall
+import io.novafoundation.nova.feature_governance_api.domain.referendum.list.ReferendaState
 import io.novafoundation.nova.feature_governance_api.domain.referendum.list.ReferendumPreview
 import io.novafoundation.nova.feature_governance_api.domain.referendum.list.Voter
 import io.novafoundation.nova.feature_governance_api.domain.referendum.list.toCallOrNull
 import io.novafoundation.nova.feature_governance_api.domain.referendum.list.user
 import io.novafoundation.nova.feature_governance_api.domain.tindergov.TinderGovInteractor
+import io.novafoundation.nova.feature_governance_api.domain.tindergov.VotingPowerState
 import io.novafoundation.nova.feature_governance_impl.data.GovernanceSharedState
 import io.novafoundation.nova.feature_governance_impl.data.repository.tindergov.TinderGovBasketRepository
 import io.novafoundation.nova.feature_governance_impl.data.repository.tindergov.TinderGovVotingPowerRepository
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.ReferendumDetailsRepository
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.details.call.ReferendumPreImageParser
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.list.ReferendaSharedComputation
-import io.novafoundation.nova.feature_governance_api.domain.referendum.list.ReferendaState
-import io.novafoundation.nova.feature_governance_api.domain.tindergov.VotingPowerState
-import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletRepository
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.list.filtering.ReferendaFilteringProvider
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.getCurrentAsset
+import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletRepository
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.domain.model.availableToVote
 import io.novafoundation.nova.runtime.ext.summaryApiOrNull
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.state.chain
 import io.novafoundation.nova.runtime.state.selectedOption
-import java.math.BigInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import java.math.BigInteger
 
 class RealTinderGovInteractor(
     private val governanceSharedState: GovernanceSharedState,
@@ -117,7 +117,7 @@ class RealTinderGovInteractor(
 
         val referendumProposal = referendumPreview.onChainMetadata?.proposal
         val referendumProposalCall = referendumProposal?.toCallOrNull()
-        val referendumCall = referendumProposalCall?.let { preImageParser.parsePreimageCall(it.call, chain.id) }
+        val referendumCall = referendumProposalCall?.let { preImageParser.parsePreimageCall(it.call, chain) }
 
         return if (referendumCall is ReferendumCall.TreasuryRequest) {
             referendumCall.amount

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/common/model/ReferendumCallModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/common/model/ReferendumCallModel.kt
@@ -1,14 +1,8 @@
 package io.novafoundation.nova.feature_governance_impl.presentation.referenda.common.model
 
-import io.novafoundation.nova.common.address.AddressModel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AmountModel
 
 sealed class ReferendumCallModel {
 
-    sealed class GovernanceRequest(val amount: AmountModel) : ReferendumCallModel() {
-
-        class AmountOnly(amount: AmountModel) : GovernanceRequest(amount)
-
-        class Full(amount: AmountModel, val beneficiary: AddressModel) : GovernanceRequest(amount)
-    }
+    class GovernanceRequest(val amount: AmountModel) : ReferendumCallModel()
 }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/details/ReferendumDetailsViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/details/ReferendumDetailsViewModel.kt
@@ -78,6 +78,7 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Ba
 import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
+import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.state.chainAndAsset
 import io.novafoundation.nova.runtime.state.selectedChainFlow
@@ -452,9 +453,9 @@ class ReferendumDetailsViewModel(
     private suspend fun mapReferendumCallToUi(referendumCall: ReferendumCall): ReferendumCallModel {
         return when (referendumCall) {
             is ReferendumCall.TreasuryRequest -> {
-                val token = tokenFlow.first()
+                val token = tokenUseCase.getToken(referendumCall.chainAsset.fullId)
 
-                ReferendumCallModel.GovernanceRequest.AmountOnly(
+                ReferendumCallModel.GovernanceRequest(
                     amount = mapAmountToAmountModel(referendumCall.amount, token)
                 )
             }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/full/ReferendumFullDetailsPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/full/ReferendumFullDetailsPayload.kt
@@ -4,6 +4,9 @@ import android.os.Parcelable
 import io.novafoundation.nova.feature_governance_api.domain.referendum.details.PreimagePreview
 import io.novafoundation.nova.feature_governance_api.domain.referendum.details.ReferendumCall
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
+import io.novafoundation.nova.feature_wallet_api.presentation.model.toAssetPayload
+import io.novafoundation.nova.runtime.ext.fullId
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import kotlinx.android.parcel.Parcelize
 
@@ -24,7 +27,7 @@ class ReferendumFullDetailsPayload(
 sealed class ReferendumCallPayload : Parcelable {
 
     @Parcelize
-    class TreasuryRequest(val amount: Balance, val beneficiary: AccountId) : ReferendumCallPayload()
+    class TreasuryRequest(val amount: Balance, val beneficiary: AccountId, val asset: AssetPayload) : ReferendumCallPayload()
 }
 
 sealed class PreImagePreviewPayload : Parcelable {
@@ -42,8 +45,9 @@ class ReferendumProposerPayload(val accountId: AccountId, val offChainName: Stri
 fun ReferendumCallPayload(referendumCall: ReferendumCall?): ReferendumCallPayload? {
     return when (referendumCall) {
         is ReferendumCall.TreasuryRequest -> ReferendumCallPayload.TreasuryRequest(
-            referendumCall.amount,
-            referendumCall.beneficiary
+            amount = referendumCall.amount,
+            beneficiary = referendumCall.beneficiary,
+            asset = referendumCall.chainAsset.fullId.toAssetPayload()
         )
         null -> null
     }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/full/ReferendumFullDetailsViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/full/ReferendumFullDetailsViewModel.kt
@@ -14,6 +14,7 @@ import io.novafoundation.nova.feature_governance_impl.presentation.referenda.ful
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.Token
+import io.novafoundation.nova.feature_wallet_api.presentation.model.fullChainAssetId
 import io.novafoundation.nova.feature_wallet_api.presentation.model.mapAmountToAmountModel
 import io.novafoundation.nova.runtime.ext.addressOf
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -108,7 +109,8 @@ class ReferendumFullDetailsViewModel(
             referendumCall.beneficiary,
             defaultIdentityProvider
         )
-        val amountModel = mapAmountToAmountModel(referendumCall.amount, getToken())
+        val token = tokenUseCase.getToken(referendumCall.asset.fullChainAssetId)
+        val amountModel = mapAmountToAmountModel(referendumCall.amount, token)
 
         return AddressAndAmountModel(addressModel, amountModel)
     }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/cards/TinderGovCardsFragment.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/cards/TinderGovCardsFragment.kt
@@ -122,6 +122,8 @@ class TinderGovCardsFragment : BaseFragment<TinderGovCardsViewModel>(), TinderGo
                 }
         }
 
+        viewModel.manageVotingPowerAvailable.observe(tinderGovCardsSettings::setVisible)
+
         viewModel.basketModelFlow.observe {
             tinderGovCardsBasketItems.text = it.items.toString()
             tinderGovCardsBasketItems.setTextColorRes(it.textColorRes)

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/cards/TinderGovCardsViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/cards/TinderGovCardsViewModel.kt
@@ -17,7 +17,6 @@ import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.formatTokenAmount
 import io.novafoundation.nova.common.utils.formatting.format
 import io.novafoundation.nova.common.utils.onEachWithPrevious
-import io.novafoundation.nova.common.utils.orFalse
 import io.novafoundation.nova.common.utils.safeSubList
 import io.novafoundation.nova.common.utils.sendEvent
 import io.novafoundation.nova.feature_governance_api.data.model.TinderGovBasketItem
@@ -88,7 +87,7 @@ class TinderGovCardsViewModel(
         cardsSummaryFlow,
         cardsAmountFlow,
         ::mapCards
-    )
+    ).shareInBackground()
 
     val retryReferendumInfoLoadingAction = actionAwaitableMixinFactory.confirmingOrDenyingAction<Unit>()
 
@@ -105,19 +104,21 @@ class TinderGovCardsViewModel(
 
     private val topReferendumWithDetails = combine(topCardIndex, cardsSummaryFlow, cardsAmountFlow) { topCardIndex, cardsSummary, cardsAmount ->
         val referendum = sortedReferendaFlow.value.getOrNull(topCardIndex) ?: return@combine null
-        val cardSummary = cardsSummary[referendum.id]
-        val cardAmount = cardsAmount[referendum.id]
+        val cardSummary = cardsSummary.getOrDefault(referendum.id, ExtendedLoadingState.Loading)
+        val cardAmount = cardsAmount.getOrDefault(referendum.id, ExtendedLoadingState.Loading)
 
         CardWithDetails(referendum, cardSummary, cardAmount)
-    }.filterNotNull()
+    }
         .distinctUntilChanged()
         .shareInBackground()
 
     private var isVotingInProgress = MutableStateFlow(false)
 
-    val isCardDraggingAvailable = combine(isVotingInProgress, topReferendumWithDetails) { isVotingInProgress, cardWithDetails ->
-        val summaryLoaded = cardWithDetails.summary?.isLoaded().orFalse()
-        val amountLoaded = cardWithDetails.summary?.isLoaded().orFalse()
+    val manageVotingPowerAvailable = topReferendumWithDetails.map { it != null }
+
+    val isCardDraggingAvailable = combine(isVotingInProgress, topReferendumWithDetails.filterNotNull()) { isVotingInProgress, cardWithDetails ->
+        val summaryLoaded = cardWithDetails.summary.isLoaded()
+        val amountLoaded = cardWithDetails.summary.isLoaded()
         !isVotingInProgress && summaryLoaded && amountLoaded
     }
 
@@ -131,7 +132,7 @@ class TinderGovCardsViewModel(
 
     val referendumCounterFlow = votingReferendaCounterFlow.map {
         if (it.hasReferendaToVote()) {
-            val currentItemIndex = it.itemsInBasket + 1
+            val currentItemIndex = it.remainingReferendaToVote
             resourceManager.getString(R.string.swipe_gov_cards_counter, currentItemIndex)
         } else {
             resourceManager.getString(R.string.swipe_gov_cards_no_referenda_to_vote)
@@ -199,7 +200,9 @@ class TinderGovCardsViewModel(
     fun editVotingPowerClicked() {
         launch {
             val topReferendum = topReferendumWithDetails.first()
-            tinderGovVoteRequester.openRequest(TinderGovVoteRequester.Request(topReferendum.referendum.id.value))
+            val topReferendumId = topReferendum?.referendum?.id?.value ?: return@launch
+            val request = TinderGovVoteRequester.Request(topReferendumId)
+            tinderGovVoteRequester.openRequest(request)
         }
     }
 
@@ -308,8 +311,9 @@ class TinderGovCardsViewModel(
 
     private fun setupReferendumRetryAction() {
         topReferendumWithDetails
+            .filterNotNull()
             .map {
-                val isLoadingError = it.summary?.isError().orFalse() || it.amount?.isError().orFalse()
+                val isLoadingError = it.summary.isError() || it.amount.isError()
                 it.referendum to isLoadingError
             }
             .distinctUntilChangedBy { (referendum, isLoadingError) -> referendum.id to isLoadingError }
@@ -418,8 +422,8 @@ private class ReferendaWithBasket(
 
 private class CardWithDetails(
     val referendum: ReferendumPreview,
-    val summary: ExtendedLoadingState<String?>?,
-    val amount: ExtendedLoadingState<AmountModel?>?
+    val summary: ExtendedLoadingState<String?>,
+    val amount: ExtendedLoadingState<AmountModel?>
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -434,6 +438,10 @@ private class ReferendaCounterModel(
     val itemsInBasket: Int,
     val referendaSize: Int
 ) {
+
+    val remainingReferendaToVote: Int
+        get() = referendaSize - itemsInBasket
+
     fun hasReferendaToVote(): Boolean {
         return referendaSize > itemsInBasket
     }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/cards/TinderGovCardsViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/cards/TinderGovCardsViewModel.kt
@@ -330,7 +330,7 @@ class TinderGovCardsViewModel(
     }
 
     private fun reloadDetailsForReferendum(referendum: ReferendumPreview) = launch {
-        tinderGovCardDetailsLoader.reloadSummary(referendum, this)
+        tinderGovCardDetailsLoader.reloadSummary(referendum)
         tinderGovCardDetailsLoader.reloadAmount(referendum)
     }
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/cards/di/TinderGovCardsModule.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/cards/di/TinderGovCardsModule.kt
@@ -17,6 +17,7 @@ import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vot
 import io.novafoundation.nova.feature_governance_impl.presentation.tindergov.cards.TinderGovCardsDetailsLoaderFactory
 import io.novafoundation.nova.feature_governance_impl.presentation.tindergov.cards.TinderGovCardsViewModel
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
 
 @Module(includes = [ViewModelModule::class])
 class TinderGovCardsModule {
@@ -24,11 +25,11 @@ class TinderGovCardsModule {
     @Provides
     fun provideTinderGovCardsDataHelper(
         interactor: TinderGovInteractor,
-        assetUseCase: AssetUseCase,
+        tokenUseCase: TokenUseCase,
     ): TinderGovCardsDetailsLoaderFactory {
         return TinderGovCardsDetailsLoaderFactory(
             interactor,
-            assetUseCase
+            tokenUseCase
         )
     }
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
@@ -66,7 +66,7 @@ class AssetConversionExchangeFactory(
 ) : AssetExchange.Factory {
 
     override suspend fun create(chain: Chain, coroutineScope: CoroutineScope): AssetExchange {
-        val converter = multiLocationConverterFactory.default(chain, coroutineScope)
+        val converter = multiLocationConverterFactory.defaultAsync(chain, coroutineScope)
 
         return AssetConversionExchange(
             chain = chain,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/di/common/TokenUseCaseModule.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/di/common/TokenUseCaseModule.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.implementations.SharedStateTokenUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.TokenRepository
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.state.SelectedAssetOptionSharedState
 
 @Module
@@ -16,8 +17,10 @@ class TokenUseCaseModule {
     fun provideTokenUseCase(
         tokenRepository: TokenRepository,
         sharedState: SelectedAssetOptionSharedState<*>,
+        chainRegistry: ChainRegistry
     ): TokenUseCase = SharedStateTokenUseCase(
-        tokenRepository,
-        sharedState
+        tokenRepository = tokenRepository,
+        chainRegistry = chainRegistry,
+        sharedState = sharedState,
     )
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/TokenUseCase.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/TokenUseCase.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_wallet_api.domain
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.Token
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import kotlinx.coroutines.flow.Flow
 
 interface TokenUseCase {
@@ -8,4 +9,6 @@ interface TokenUseCase {
     suspend fun currentToken(): Token
 
     fun currentTokenFlow(): Flow<Token>
+
+    suspend fun getToken(chainAssetId: FullChainAssetId): Token
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/implementations/SharedStateTokenUseCase.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/implementations/SharedStateTokenUseCase.kt
@@ -3,6 +3,9 @@ package io.novafoundation.nova.feature_wallet_api.domain.implementations
 import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.TokenRepository
 import io.novafoundation.nova.feature_wallet_api.domain.model.Token
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.asset
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import io.novafoundation.nova.runtime.state.SelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.chainAsset
 import io.novafoundation.nova.runtime.state.selectedAssetFlow
@@ -11,6 +14,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 
 class SharedStateTokenUseCase(
     private val tokenRepository: TokenRepository,
+    private val chainRegistry: ChainRegistry,
     private val sharedState: SelectedAssetOptionSharedState<*>,
 ) : TokenUseCase {
 
@@ -24,5 +28,9 @@ class SharedStateTokenUseCase(
         return sharedState.selectedAssetFlow().flatMapLatest { chainAsset ->
             tokenRepository.observeToken(chainAsset)
         }
+    }
+
+    override suspend fun getToken(chainAssetId: FullChainAssetId): Token {
+        return tokenRepository.getToken(chainRegistry.asset(chainAssetId))
     }
 }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/realtime/substrate/AssetConversionSwapExtractor.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/realtime/substrate/AssetConversionSwapExtractor.kt
@@ -37,7 +37,7 @@ class AssetConversionSwapExtractor(
         if (!call.isSwap()) return null
 
         val scope = CoroutineScope(coroutineContext)
-        val multiLocationConverter = multiLocationConverterFactory.default(chain, scope)
+        val multiLocationConverter = multiLocationConverterFactory.defaultAsync(chain, scope)
 
         val path = bindList(callArgs["path"], ::bindMultiLocation)
         val assetIn = multiLocationConverter.toChainAsset(path.first()) ?: return null

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/XcmV2.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/XcmV2.kt
@@ -91,6 +91,7 @@ class XcmMultiAsset(
 
     companion object;
 
+    @Deprecated("Deprecated in favour of MultiAssetId and VersionedMultiAssetId as those cover more use-cases")
     sealed class Id {
 
         class Concrete(val multiLocation: MultiLocation) : Id()

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/di/RuntimeApi.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/di/RuntimeApi.kt
@@ -19,9 +19,10 @@ import io.novafoundation.nova.runtime.multiNetwork.connection.ChainConnection
 import io.novafoundation.nova.runtime.multiNetwork.connection.node.connection.NodeConnectionFactory
 import io.novafoundation.nova.runtime.multiNetwork.connection.node.healthState.NodeHealthStateTesterFactory
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.MultiLocationConverterFactory
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain.ChainMultiLocationConverterFactory
 import io.novafoundation.nova.runtime.multiNetwork.qr.MultiChainQrSharingFactory
-import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeProviderPool
 import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeFilesCache
+import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeProviderPool
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.RuntimeVersionsRepository
 import io.novafoundation.nova.runtime.network.rpc.RpcCalls
@@ -94,6 +95,8 @@ interface RuntimeApi {
     val gasPriceProviderFactory: GasPriceProviderFactory
 
     val multiLocationConverterFactory: MultiLocationConverterFactory
+
+    val chainMultiLocationConverterFactory: ChainMultiLocationConverterFactory
 
     val extrinsicWalk: ExtrinsicWalk
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/di/RuntimeModule.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/di/RuntimeModule.kt
@@ -31,6 +31,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.remote.ChainFetcher
 import io.novafoundation.nova.runtime.multiNetwork.connection.ConnectionSecrets
 import io.novafoundation.nova.runtime.multiNetwork.connection.node.connection.NodeConnectionFactory
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.MultiLocationConverterFactory
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain.ChainMultiLocationConverterFactory
 import io.novafoundation.nova.runtime.multiNetwork.qr.MultiChainQrSharingFactory
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.DbRuntimeVersionsRepository
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
@@ -221,6 +222,12 @@ class RuntimeModule {
     @ApplicationScope
     fun provideMultiLocationConverterFactory(chainRegistry: ChainRegistry): MultiLocationConverterFactory {
         return MultiLocationConverterFactory(chainRegistry)
+    }
+
+    @Provides
+    @ApplicationScope
+    fun provideChainMultiLocationConverterFactory(chainRegistry: ChainRegistry): ChainMultiLocationConverterFactory {
+        return ChainMultiLocationConverterFactory(chainRegistry)
     }
 
     @Provides

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/MultiLocation.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/MultiLocation.kt
@@ -82,7 +82,7 @@ fun MultiLocation.Interior.isHere() = this is MultiLocation.Interior.Here
 
 fun MultiLocation.accountId(): AccountId? {
     return interior.junctionList.tryFindNonNull {
-        when(it) {
+        when (it) {
             is MultiLocation.Junction.AccountId32 -> it.accountId
             is MultiLocation.Junction.AccountKey20 -> it.accountId
             else -> null

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/MultiLocation.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/MultiLocation.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.runtime.multiNetwork.multiLocation
 import io.novafoundation.nova.common.data.network.runtime.binding.ParaId
 import io.novafoundation.nova.common.utils.removeHexPrefix
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novasama.substrate_sdk_android.extensions.tryFindNonNull
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import java.math.BigInteger
 
@@ -73,7 +74,21 @@ fun List<MultiLocation.Junction>.toInterior() = when (size) {
     else -> MultiLocation.Interior.Junctions(this)
 }
 
+fun MultiLocation.isHere(): Boolean {
+    return parents == BigInteger.ZERO && interior.isHere()
+}
+
 fun MultiLocation.Interior.isHere() = this is MultiLocation.Interior.Here
+
+fun MultiLocation.accountId(): AccountId? {
+    return interior.junctionList.tryFindNonNull {
+        when(it) {
+            is MultiLocation.Junction.AccountId32 -> it.accountId
+            is MultiLocation.Junction.AccountKey20 -> it.accountId
+            else -> null
+        }
+    }
+}
 
 fun MultiLocation.Interior.paraIdOrNull(): ParaId? {
     if (this !is MultiLocation.Interior.Junctions) return null

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/MultiLocationEncoding.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/MultiLocationEncoding.kt
@@ -27,6 +27,11 @@ fun bindMultiLocation(instance: Any?): MultiLocation {
     )
 }
 
+fun bindVersionedMultiLocation(instance: Any?): MultiLocation {
+    val asDictEnum = instance.castToDictEnum()
+    return bindMultiLocation(asDictEnum.value)
+}
+
 private fun bindInterior(instance: Any?): MultiLocation.Interior {
     val asDictEnum = instance.castToDictEnum()
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/Encoding.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/Encoding.kt
@@ -7,7 +7,7 @@ import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v4.bindLo
 fun bindVersionedLocatableMultiAsset(decoded: Any?): VersionedLocatableMultiAsset {
     val asDictEnum = decoded.castToDictEnum()
 
-    return when(asDictEnum.name) {
+    return when (asDictEnum.name) {
         "V3" -> VersionedLocatableMultiAsset.V3(bindLocatableMultiAssetV3(asDictEnum.value))
         "V4" -> VersionedLocatableMultiAsset.V4(bindLocatableMultiAssetV4(asDictEnum.value))
         else -> error("Unsupported LocatableMultiAsset version: ${asDictEnum.name}")

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/Encoding.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/Encoding.kt
@@ -1,0 +1,15 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset
+
+import io.novafoundation.nova.common.data.network.runtime.binding.castToDictEnum
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v3.bindLocatableMultiAssetV3
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v4.bindLocatableMultiAssetV4
+
+fun bindVersionedLocatableMultiAsset(decoded: Any?): VersionedLocatableMultiAsset {
+    val asDictEnum = decoded.castToDictEnum()
+
+    return when(asDictEnum.name) {
+        "V3" -> VersionedLocatableMultiAsset.V3(bindLocatableMultiAssetV3(asDictEnum.value))
+        "V4" -> VersionedLocatableMultiAsset.V4(bindLocatableMultiAssetV4(asDictEnum.value))
+        else -> error("Unsupported LocatableMultiAsset version: ${asDictEnum.name}")
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/LocatableMultiAsset.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/LocatableMultiAsset.kt
@@ -1,0 +1,19 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset
+
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v3.LocatableMultiAssetV3
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v4.LocatableMultiAssetV4
+
+interface LocatableMultiAsset {
+
+    val location: MultiLocation
+
+    val assetId: MultiAssetId
+}
+
+sealed class VersionedLocatableMultiAsset(multiAssetId: LocatableMultiAsset) : LocatableMultiAsset by multiAssetId {
+
+    class V3(val value: LocatableMultiAssetV3) : VersionedLocatableMultiAsset(value)
+
+    class V4(val value: LocatableMultiAssetV4) : VersionedLocatableMultiAsset(value)
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/MultiAssetId.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/MultiAssetId.kt
@@ -1,0 +1,17 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset
+
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v3.MultiAssetIdV3
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v4.MultiAssetIdV4
+
+interface MultiAssetId {
+
+    val multiLocation: MultiLocation
+}
+
+sealed class VersionedMultiAssetId(multiAssetId: MultiAssetId) : MultiAssetId by multiAssetId {
+
+    class V3(val value: MultiAssetIdV3) : VersionedMultiAssetId(value)
+
+    class V4(val value: MultiAssetIdV4) : VersionedMultiAssetId(value)
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/Encoding.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/Encoding.kt
@@ -1,0 +1,23 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v3
+
+import io.novafoundation.nova.common.data.network.runtime.binding.castToDictEnum
+import io.novafoundation.nova.common.data.network.runtime.binding.castToStruct
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.bindMultiLocation
+
+fun bindMultiAssetIdV3(decoded: Any?): MultiAssetIdV3 {
+    val variant = decoded.castToDictEnum()
+
+    return when(variant.name) {
+        "Concrete" -> MultiAssetIdV3.Concrete(bindMultiLocation(variant.value))
+        else -> error("Asset ids besides Concrete are not supported")
+    }
+}
+
+fun bindLocatableMultiAssetV3(decoded: Any?): LocatableMultiAssetV3 {
+    val asStruct = decoded.castToStruct()
+
+    return LocatableMultiAssetV3(
+        location = bindMultiLocation(asStruct["location"]),
+        assetId = bindMultiAssetIdV3(asStruct["asset_id"])
+    )
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/Encoding.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/Encoding.kt
@@ -7,7 +7,7 @@ import io.novafoundation.nova.runtime.multiNetwork.multiLocation.bindMultiLocati
 fun bindMultiAssetIdV3(decoded: Any?): MultiAssetIdV3 {
     val variant = decoded.castToDictEnum()
 
-    return when(variant.name) {
+    return when (variant.name) {
         "Concrete" -> MultiAssetIdV3.Concrete(bindMultiLocation(variant.value))
         else -> error("Asset ids besides Concrete are not supported")
     }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/LocatableMultiAssetV3.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/LocatableMultiAssetV3.kt
@@ -6,4 +6,4 @@ import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.Locatable
 class LocatableMultiAssetV3(
     override val location: MultiLocation,
     override val assetId: MultiAssetIdV3
-): LocatableMultiAsset
+) : LocatableMultiAsset

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/LocatableMultiAssetV3.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/LocatableMultiAssetV3.kt
@@ -1,0 +1,9 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v3
+
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.LocatableMultiAsset
+
+class LocatableMultiAssetV3(
+    override val location: MultiLocation,
+    override val assetId: MultiAssetIdV3
+): LocatableMultiAsset

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/MultiAssetIdV3.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v3/MultiAssetIdV3.kt
@@ -1,0 +1,9 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v3
+
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.MultiAssetId
+
+sealed class MultiAssetIdV3 : MultiAssetId {
+
+    class Concrete(override val multiLocation: MultiLocation) : MultiAssetIdV3()
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/Encoding.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/Encoding.kt
@@ -1,0 +1,17 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v4
+
+import io.novafoundation.nova.common.data.network.runtime.binding.castToStruct
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.bindMultiLocation
+
+fun bindMultiAssetIdV4(decoded: Any?): MultiAssetIdV4 {
+    return MultiAssetIdV4(bindMultiLocation(decoded))
+}
+
+fun bindLocatableMultiAssetV4(decoded: Any?): LocatableMultiAssetV4 {
+    val asStruct = decoded.castToStruct()
+
+    return LocatableMultiAssetV4(
+        location = bindMultiLocation(asStruct["location"]),
+        assetId = bindMultiAssetIdV4(asStruct["assetId"])
+    )
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/LocatableMultiAssetV4.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/LocatableMultiAssetV4.kt
@@ -1,0 +1,9 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v4
+
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.LocatableMultiAsset
+
+class LocatableMultiAssetV4(
+    override val location: MultiLocation,
+    override val assetId: MultiAssetIdV4
+): LocatableMultiAsset

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/LocatableMultiAssetV4.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/LocatableMultiAssetV4.kt
@@ -6,4 +6,4 @@ import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.Locatable
 class LocatableMultiAssetV4(
     override val location: MultiLocation,
     override val assetId: MultiAssetIdV4
-): LocatableMultiAsset
+) : LocatableMultiAsset

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/MultiAssetIdV4.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/MultiAssetIdV4.kt
@@ -3,4 +3,4 @@ package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v4
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.MultiAssetId
 
-class MultiAssetIdV4(override val multiLocation: MultiLocation): MultiAssetId
+class MultiAssetIdV4(override val multiLocation: MultiLocation) : MultiAssetId

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/MultiAssetIdV4.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/asset/v4/MultiAssetIdV4.kt
@@ -1,0 +1,6 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.v4
+
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.asset.MultiAssetId
+
+class MultiAssetIdV4(override val multiLocation: MultiLocation): MultiAssetId

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/CompoundMultiLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/CompoundMultiLocationConverter.kt
@@ -4,7 +4,7 @@ import io.novafoundation.nova.common.utils.tryFindNonNull
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
 
-class CompoundMultiLocationConverter(
+internal class CompoundMultiLocationConverter(
     private vararg val delegates: MultiLocationConverter
 ) : MultiLocationConverter {
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/ForeignAssetsLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/ForeignAssetsLocationConverter.kt
@@ -23,7 +23,7 @@ private typealias ForeignAssetsMapping = Map<ForeignAssetsMappingKey, Chain.Asse
 
 private const val FOREIGN_ASSETS_PALLET_NAME = "ForeignAssets"
 
-class ForeignAssetsLocationConverter(
+internal class ForeignAssetsLocationConverter(
     private val chain: Chain,
     private val runtime: Deferred<RuntimeSnapshot>
 ) : MultiLocationConverter {

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/LocalAssetsLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/LocalAssetsLocationConverter.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter
 
 import io.novafoundation.nova.common.utils.PalletName
-import io.novafoundation.nova.common.utils.invoke
 import io.novafoundation.nova.runtime.ext.palletNameOrDefault
 import io.novafoundation.nova.runtime.ext.requireStatemine
 import io.novafoundation.nova.runtime.ext.statemineOrNull
@@ -13,9 +12,7 @@ import io.novafoundation.nova.runtime.multiNetwork.multiLocation.Junctions
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation.Junction
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.junctionList
-import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
 import io.novasama.substrate_sdk_android.runtime.metadata.moduleOrNull
-import kotlinx.coroutines.Deferred
 import java.math.BigInteger
 
 private typealias LocalAssetsAssetId = BigInteger
@@ -24,7 +21,7 @@ private typealias LocalAssetsMapping = Map<LocalAssetsMappingKey, Chain.Asset>
 
 class LocalAssetsLocationConverter(
     private val chain: Chain,
-    private val runtime: Deferred<RuntimeSnapshot>
+    private val runtimeSource: RuntimeSource
 ) : MultiLocationConverter {
 
     private val assetIdToAssetMapping by lazy { constructAssetIdToAssetMapping() }
@@ -35,7 +32,7 @@ class LocalAssetsLocationConverter(
         val assetsType = chainAsset.statemineOrNull() ?: return null
         // LocalAssets converter only supports number ids to use as GeneralIndex
         val index = assetsType.id.asNumberOrNull() ?: return null
-        val pallet = runtime().metadata.moduleOrNull(assetsType.palletNameOrDefault()) ?: return null
+        val pallet = runtimeSource.getRuntime().metadata.moduleOrNull(assetsType.palletNameOrDefault()) ?: return null
 
         return MultiLocation(
             parents = BigInteger.ZERO, // For Local Assets chain serves as a reserve
@@ -56,7 +53,7 @@ class LocalAssetsLocationConverter(
         val (maybePalletInstance, maybeGeneralIndex) = junctions
         if (maybePalletInstance !is Junction.PalletInstance || maybeGeneralIndex !is Junction.GeneralIndex) return null
 
-        val pallet = runtime().metadata.moduleOrNull(maybePalletInstance.index.toInt()) ?: return null
+        val pallet = runtimeSource.getRuntime().metadata.moduleOrNull(maybePalletInstance.index.toInt()) ?: return null
         val assetId = maybeGeneralIndex.index
 
         return assetIdToAssetMapping[pallet.name to assetId]

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/NativeAssetLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/NativeAssetLocationConverter.kt
@@ -8,7 +8,7 @@ import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.isHere
 import java.math.BigInteger
 
-class NativeAssetLocationConverter(
+internal class NativeAssetLocationConverter(
     private val chain: Chain,
 ) : MultiLocationConverter {
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/RuntimeSource.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/RuntimeSource.kt
@@ -7,14 +7,14 @@ sealed interface RuntimeSource {
 
     suspend fun getRuntime(): RuntimeSnapshot
 
-    class Sync(private val runtimeSnapshot: RuntimeSnapshot): RuntimeSource {
+    class Sync(private val runtimeSnapshot: RuntimeSnapshot) : RuntimeSource {
 
         override suspend fun getRuntime(): RuntimeSnapshot {
             return runtimeSnapshot
         }
     }
 
-    class Async(private val runtimeSnapshotAsync: Deferred<RuntimeSnapshot>): RuntimeSource {
+    class Async(private val runtimeSnapshotAsync: Deferred<RuntimeSnapshot>) : RuntimeSource {
 
         override suspend fun getRuntime(): RuntimeSnapshot {
             return runtimeSnapshotAsync.await()

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/RuntimeSource.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/RuntimeSource.kt
@@ -1,0 +1,23 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter
+
+import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
+import kotlinx.coroutines.Deferred
+
+sealed interface RuntimeSource {
+
+    suspend fun getRuntime(): RuntimeSnapshot
+
+    class Sync(private val runtimeSnapshot: RuntimeSnapshot): RuntimeSource {
+
+        override suspend fun getRuntime(): RuntimeSnapshot {
+            return runtimeSnapshot
+        }
+    }
+
+    class Async(private val runtimeSnapshotAsync: Deferred<RuntimeSnapshot>): RuntimeSource {
+
+        override suspend fun getRuntime(): RuntimeSnapshot {
+            return runtimeSnapshotAsync.await()
+        }
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/ChainMultiLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/ChainMultiLocationConverter.kt
@@ -1,0 +1,9 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain
+
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+
+interface ChainMultiLocationConverter {
+
+    suspend fun toChain(multiLocation: MultiLocation): Chain?
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/ChainMultiLocationConverterFactory.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/ChainMultiLocationConverterFactory.kt
@@ -1,0 +1,14 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain
+
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+
+class ChainMultiLocationConverterFactory(private val chainRegistry: ChainRegistry) {
+
+    fun resolveSelfAndChildrenParachains(self: Chain): ChainMultiLocationConverter {
+        return CompoundChainLocationConverter(
+            LocalChainMultiLocationConverter(self),
+            ChildParachainLocationConverter(self, chainRegistry)
+        )
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/ChildParachainLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/ChildParachainLocationConverter.kt
@@ -1,0 +1,41 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain
+
+import io.novafoundation.nova.runtime.ext.Geneses
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.multiNetwork.getChainOrNull
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation.Junction.ParachainId
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.junctionList
+import java.math.BigInteger
+
+internal class ChildParachainLocationConverter(
+    private val relayChain: Chain,
+    private val chainRegistry: ChainRegistry
+): ChainMultiLocationConverter {
+
+    private val parachainIdToChainIdByRelay = mapOf(
+        Chain.Geneses.POLKADOT to mapOf(
+            1000 to Chain.Geneses.POLKADOT_ASSET_HUB
+        )
+    )
+
+    override suspend fun toChain(multiLocation: MultiLocation): Chain? {
+        // This is not a child parachain from relay point
+        if (multiLocation.parents != BigInteger.ZERO) return null
+
+        val junctions = multiLocation.interior.junctionList
+        // Child parachain has only 1 ParachainId junction
+        if (junctions.size != 1) return null
+        val parachainId = junctions.single() as? ParachainId ?: return null
+
+        val parachainChainId = getParachainChainId(parachainId.id) ?: return null
+
+        return chainRegistry.getChainOrNull(parachainChainId)
+    }
+
+    private fun getParachainChainId(parachainId: BigInteger): ChainId? {
+        return parachainIdToChainIdByRelay[relayChain.id]?.get(parachainId.toInt())
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/ChildParachainLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/ChildParachainLocationConverter.kt
@@ -13,7 +13,7 @@ import java.math.BigInteger
 internal class ChildParachainLocationConverter(
     private val relayChain: Chain,
     private val chainRegistry: ChainRegistry
-): ChainMultiLocationConverter {
+) : ChainMultiLocationConverter {
 
     private val parachainIdToChainIdByRelay = mapOf(
         Chain.Geneses.POLKADOT to mapOf(

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/CompoundChainLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/CompoundChainLocationConverter.kt
@@ -1,0 +1,14 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain
+
+import io.novafoundation.nova.common.utils.tryFindNonNull
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+
+internal class CompoundChainLocationConverter(
+    private vararg val delegates: ChainMultiLocationConverter
+) : ChainMultiLocationConverter {
+
+    override suspend fun toChain(multiLocation: MultiLocation): Chain? {
+        return delegates.tryFindNonNull { it.toChain(multiLocation) }
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/LocalChainMultiLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/LocalChainMultiLocationConverter.kt
@@ -6,9 +6,9 @@ import io.novafoundation.nova.runtime.multiNetwork.multiLocation.isHere
 
 internal class LocalChainMultiLocationConverter(
     val chain: Chain
-): ChainMultiLocationConverter {
+) : ChainMultiLocationConverter {
 
     override suspend fun toChain(multiLocation: MultiLocation): Chain? {
-       return chain.takeIf { multiLocation.isHere() }
+        return chain.takeIf { multiLocation.isHere() }
     }
 }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/LocalChainMultiLocationConverter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/converter/chain/LocalChainMultiLocationConverter.kt
@@ -1,0 +1,14 @@
+package io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.chain
+
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.MultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.multiLocation.isHere
+
+internal class LocalChainMultiLocationConverter(
+    val chain: Chain
+): ChainMultiLocationConverter {
+
+    override suspend fun toChain(multiLocation: MultiLocation): Chain? {
+       return chain.takeIf { multiLocation.isHere() }
+    }
+}


### PR DESCRIPTION
Support treasury.spend and resolve native and all local assets on AssetHub
Foreign assets (like DED) in theory could be supported with no changes in `ForeignAssetsLocationConverter` but there is not active referenda to test it

![image](https://github.com/user-attachments/assets/0e86e3c0-c73a-4d52-ae04-ae40d4ad876d)
![image](https://github.com/user-attachments/assets/0aa4ff8b-25b6-4190-8c40-367e4de0238e)

