### PR TITLE
Ledger external signing

### DIFF
--- a/app/src/androidTest/java/io/novafoundation/nova/MetadataShortenerTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/MetadataShortenerTest.kt
@@ -70,7 +70,7 @@ class MetadataShortenerTest : BaseIntegrationTest() {
         extrinsicBuilder.nativeTransfer(accountId = signer.accountId, amount = BigInteger.ONE)
         extrinsicBuilder.systemRemark(remark = byteArrayOf(1, 2, 3))
 
-        extrinsicBuilder.build()
+        extrinsicBuilder.buildExtrinsic()
     }
 
     @Test

--- a/app/src/androidTest/java/io/novafoundation/nova/MoonbaseSendIntagrationTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/MoonbaseSendIntagrationTest.kt
@@ -89,7 +89,7 @@ class MoonbaseSendIntagrationTest {
 
         val extrinsic = extrinsicBuilderFactory.create(chain, signer, accountId)
             .nativeTransfer(accountId, chain.utilityAsset.planksFromAmount(BigDecimal.ONE), keepAlive = true)
-            .build()
+            .buildExtrinsic().extrinsicHex
 
         val hash = rpcCalls.submitExtrinsic(chain.id, extrinsic)
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ buildscript {
 
         web3jVersion = '4.9.5'
 
-        substrateSdkVersion = '2.1.4'
+        substrateSdkVersion = '2.2.0'
 
         gifVersion = '1.2.19'
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/extrinsic/RealExtrinsicService.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/extrinsic/RealExtrinsicService.kt
@@ -37,12 +37,12 @@ import io.novafoundation.nova.runtime.network.rpc.RpcCalls
 import io.novasama.substrate_sdk_android.runtime.definitions.types.fromHex
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.Extrinsic
 import io.novasama.substrate_sdk_android.runtime.extrinsic.ExtrinsicBuilder
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import java.math.BigInteger
-import kotlinx.coroutines.CoroutineScope
 
 class RealExtrinsicService(
     private val rpcCalls: RpcCalls,
@@ -107,7 +107,8 @@ class RealExtrinsicService(
     ): FeeResponse {
         val extrinsic = extrinsicBuilderFactory.createForFee(getFeeSigner(chain, origin), chain)
             .also { it.formExtrinsic() }
-            .build(submissionOptions.batchMode)
+            .buildExtrinsic(submissionOptions.batchMode)
+            .extrinsicHex
 
         return rpcCalls.getExtrinsicFee(chain, extrinsic)
     }
@@ -121,7 +122,7 @@ class RealExtrinsicService(
         val signer = getFeeSigner(chain, origin)
         val extrinsicBuilder = extrinsicBuilderFactory.createForFee(signer, chain)
         extrinsicBuilder.formExtrinsic()
-        val extrinsic = extrinsicBuilder.build(submissionOptions.batchMode)
+        val extrinsic = extrinsicBuilder.buildExtrinsic(submissionOptions.batchMode).extrinsicHex
 
         return estimateFee(chain, extrinsic, signer, submissionOptions)
     }
@@ -227,7 +228,7 @@ class RealExtrinsicService(
 
             feePayment.modifyExtrinsic(extrinsicBuilder)
 
-            extrinsicBuilder.build(submissionOptions.batchMode)
+            extrinsicBuilder.buildExtrinsic(submissionOptions.batchMode).extrinsicHex
         }
 
         extrinsicsToSubmit
@@ -254,7 +255,7 @@ class RealExtrinsicService(
 
         feePayment.modifyExtrinsic(extrinsicBuilder)
 
-        val extrinsic = extrinsicBuilder.build(submissionOptions.batchMode)
+        val extrinsic = extrinsicBuilder.buildExtrinsic(submissionOptions.batchMode).extrinsicHex
 
         return SubmissionRaw(extrinsic, submissionOrigin)
     }

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/DAppBrowserViewModel.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/DAppBrowserViewModel.kt
@@ -137,7 +137,7 @@ class DAppBrowserViewModel(
 
         return when (response) {
             is ExternalSignCommunicator.Response.Rejected -> ConfirmTxResponse.Rejected(response.requestId)
-            is ExternalSignCommunicator.Response.Signed -> ConfirmTxResponse.Signed(response.requestId, response.signature)
+            is ExternalSignCommunicator.Response.Signed -> ConfirmTxResponse.Signed(response.requestId, response.signature, response.modifiedTransaction)
             is ExternalSignCommunicator.Response.SigningFailed -> ConfirmTxResponse.SigningFailed(response.requestId, response.shouldPresent)
             is ExternalSignCommunicator.Response.Sent -> ConfirmTxResponse.Sent(response.requestId, response.txHash)
         }

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/polkadotJs/model/SignerPayload.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/polkadotJs/model/SignerPayload.kt
@@ -18,6 +18,8 @@ sealed class SignerPayload {
         val specVersion: String,
         val tip: String,
         val transactionVersion: String,
+        val metadataHash: String?,
+        val withSignedTransaction: Boolean?,
         val signedExtensions: List<String>,
         val version: Int
     ) : SignerPayload()
@@ -60,12 +62,14 @@ fun mapPolkadotJsSignerPayloadToPolkadotPayload(signerPayload: SignerPayload): P
                 blockNumber = blockNumber,
                 era = era,
                 genesisHash = genesisHash,
+                metadataHash = metadataHash,
                 method = method,
                 nonce = nonce,
                 specVersion = specVersion,
                 tip = tip,
                 transactionVersion = transactionVersion,
                 signedExtensions = signedExtensions,
+                withSignedTransaction = withSignedTransaction,
                 version = version
             )
         }

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/polkadotJs/states/DefaultPolkadotJsState.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/polkadotJs/states/DefaultPolkadotJsState.kt
@@ -7,7 +7,6 @@ import io.novafoundation.nova.feature_dapp_impl.R
 import io.novafoundation.nova.feature_dapp_impl.domain.DappInteractor
 import io.novafoundation.nova.feature_dapp_impl.domain.browser.polkadotJs.PolkadotJsExtensionInteractor
 import io.novafoundation.nova.feature_dapp_impl.web3.polkadotJs.PolkadotJsTransportRequest
-import io.novafoundation.nova.feature_external_sign_api.model.signPayload.polkadot.PolkadotSignerResult
 import io.novafoundation.nova.feature_dapp_impl.web3.polkadotJs.model.mapPolkadotJsSignerPayloadToPolkadotPayload
 import io.novafoundation.nova.feature_dapp_impl.web3.session.Web3Session
 import io.novafoundation.nova.feature_dapp_impl.web3.states.BaseState
@@ -17,6 +16,7 @@ import io.novafoundation.nova.feature_dapp_impl.web3.states.Web3StateMachineHost
 import io.novafoundation.nova.feature_dapp_impl.web3.states.Web3StateMachineHost.NotAuthorizedException
 import io.novafoundation.nova.feature_dapp_impl.web3.states.hostApi.ConfirmTxResponse
 import io.novafoundation.nova.feature_external_sign_api.model.signPayload.ExternalSignRequest
+import io.novafoundation.nova.feature_external_sign_api.model.signPayload.polkadot.PolkadotSignerResult
 import kotlinx.coroutines.flow.flowOf
 
 class DefaultPolkadotJsState(
@@ -75,7 +75,7 @@ class DefaultPolkadotJsState(
         when (val response = hostApi.confirmTx(signRequest)) {
             is ConfirmTxResponse.Rejected -> request.reject(NotAuthorizedException)
             is ConfirmTxResponse.Sent -> throw IllegalStateException("Unexpected 'Sent' response for PolkadotJs extension")
-            is ConfirmTxResponse.Signed -> request.accept(PolkadotSignerResult(response.requestId, response.signature))
+            is ConfirmTxResponse.Signed -> request.accept(PolkadotSignerResult(response.requestId, response.signature, response.modifiedTransaction))
             is ConfirmTxResponse.SigningFailed -> {
                 if (response.shouldPresent) hostApi.showError(resourceManager.getString(R.string.dapp_sign_extrinsic_failed))
 

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/states/hostApi/ConfirmTxResponse.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/web3/states/hostApi/ConfirmTxResponse.kt
@@ -11,7 +11,7 @@ sealed class ConfirmTxResponse : Parcelable {
     class Rejected(override val requestId: String) : ConfirmTxResponse()
 
     @Parcelize
-    class Signed(override val requestId: String, val signature: String) : ConfirmTxResponse()
+    class Signed(override val requestId: String, val signature: String, val modifiedTransaction: String?) : ConfirmTxResponse()
 
     @Parcelize
     class Sent(override val requestId: String, val txHash: String) : ConfirmTxResponse()

--- a/feature-external-sign-api/src/main/java/io/novafoundation/nova/feature_external_sign_api/model/ExternalSignCommunicator.kt
+++ b/feature-external-sign-api/src/main/java/io/novafoundation/nova/feature_external_sign_api/model/ExternalSignCommunicator.kt
@@ -23,7 +23,7 @@ interface ExternalSignCommunicator : ExternalSignRequester, ExternalSignResponde
         class Rejected(override val requestId: String) : Response()
 
         @Parcelize
-        class Signed(override val requestId: String, val signature: String) : Response()
+        class Signed(override val requestId: String, val signature: String, val modifiedTransaction: String? = null) : Response()
 
         @Parcelize
         class Sent(override val requestId: String, val txHash: String) : Response()

--- a/feature-external-sign-api/src/main/java/io/novafoundation/nova/feature_external_sign_api/model/signPayload/polkadot/PolkadotSignPayload.kt
+++ b/feature-external-sign-api/src/main/java/io/novafoundation/nova/feature_external_sign_api/model/signPayload/polkadot/PolkadotSignPayload.kt
@@ -19,6 +19,8 @@ sealed class PolkadotSignPayload : Parcelable {
         val specVersion: String,
         val tip: String,
         val transactionVersion: String,
+        val metadataHash: String?,
+        val withSignedTransaction: Boolean?,
         val signedExtensions: List<String>,
         val version: Int
     ) : PolkadotSignPayload()

--- a/feature-external-sign-api/src/main/java/io/novafoundation/nova/feature_external_sign_api/model/signPayload/polkadot/PolkadotSignerResult.kt
+++ b/feature-external-sign-api/src/main/java/io/novafoundation/nova/feature_external_sign_api/model/signPayload/polkadot/PolkadotSignerResult.kt
@@ -1,3 +1,3 @@
 package io.novafoundation.nova.feature_external_sign_api.model.signPayload.polkadot
 
-class PolkadotSignerResult(val id: String, val signature: String)
+class PolkadotSignerResult(val id: String, val signature: String, val signedTransaction: String?)

--- a/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/di/ExternalSignFeatureDependencies.kt
+++ b/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/di/ExternalSignFeatureDependencies.kt
@@ -18,6 +18,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletReposit
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.runtime.di.ExtrinsicSerialization
 import io.novafoundation.nova.runtime.ethereum.gas.GasPriceProviderFactory
+import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerService
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.network.rpc.RpcCalls
 import okhttp3.OkHttpClient
@@ -64,4 +65,6 @@ interface ExternalSignFeatureDependencies {
     val gasPriceProviderFactory: GasPriceProviderFactory
 
     val rpcCalls: RpcCalls
+
+    val metadataShortenerService: MetadataShortenerService
 }

--- a/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/di/modules/sign/PolkadotSignModule.kt
+++ b/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/di/modules/sign/PolkadotSignModule.kt
@@ -11,6 +11,7 @@ import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepos
 import io.novafoundation.nova.feature_external_sign_impl.domain.sign.polkadot.PolkadotSignInteractorFactory
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.TokenRepository
 import io.novafoundation.nova.runtime.di.ExtrinsicSerialization
+import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerService
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 
 @Module
@@ -25,7 +26,8 @@ class PolkadotSignModule {
         tokenRepository: TokenRepository,
         @ExtrinsicSerialization extrinsicGson: Gson,
         addressIconGenerator: AddressIconGenerator,
-        signerProvider: SignerProvider
+        signerProvider: SignerProvider,
+        metadataShortenerService: MetadataShortenerService
     ) = PolkadotSignInteractorFactory(
         extrinsicService = extrinsicService,
         chainRegistry = chainRegistry,
@@ -33,6 +35,7 @@ class PolkadotSignModule {
         tokenRepository = tokenRepository,
         extrinsicGson = extrinsicGson,
         addressIconGenerator = addressIconGenerator,
-        signerProvider = signerProvider
+        signerProvider = signerProvider,
+        metadataShortenerService = metadataShortenerService
     )
 }

--- a/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/domain/sign/polkadot/DAppParsedExtrinsic.kt
+++ b/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/domain/sign/polkadot/DAppParsedExtrinsic.kt
@@ -4,7 +4,7 @@ import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.Era
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.Extrinsic
 import java.math.BigInteger
 
-class DAppParsedExtrinsic(
+data class DAppParsedExtrinsic(
     val address: String,
     val nonce: BigInteger,
     val specVersion: Int,
@@ -13,5 +13,6 @@ class DAppParsedExtrinsic(
     val era: Era,
     val blockHash: ByteArray,
     val tip: BigInteger,
+    val metadataHash: ByteArray?,
     val call: Extrinsic.EncodingInstance.CallRepresentation
 )

--- a/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/domain/sign/polkadot/PolkadotExternalSignInteractor.kt
+++ b/feature-external-sign-impl/src/main/java/io/novafoundation/nova/feature_external_sign_impl/domain/sign/polkadot/PolkadotExternalSignInteractor.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.common.address.createAddressModel
 import io.novafoundation.nova.common.utils.asHexString
 import io.novafoundation.nova.common.utils.bigIntegerFromHex
 import io.novafoundation.nova.common.utils.intFromHex
+import io.novafoundation.nova.common.utils.singleReplaySharedFlow
 import io.novafoundation.nova.common.validation.EmptyValidationSystem
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_account_api.data.mappers.mapChainToUi
@@ -28,8 +29,10 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.Token
 import io.novafoundation.nova.runtime.ext.accountIdOf
 import io.novafoundation.nova.runtime.ext.utilityAsset
 import io.novafoundation.nova.runtime.extrinsic.CustomSignedExtensions
+import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerService
 import io.novafoundation.nova.runtime.extrinsic.signer.FeeSigner
 import io.novafoundation.nova.runtime.extrinsic.signer.NovaSigner
+import io.novafoundation.nova.runtime.extrinsic.signer.generateMetadataProofWithSignerRestrictions
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.getChainOrNull
@@ -40,8 +43,10 @@ import io.novasama.substrate_sdk_android.runtime.definitions.types.fromHex
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.EraType
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.Extrinsic.EncodingInstance.CallRepresentation
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+import io.novasama.substrate_sdk_android.runtime.extrinsic.CheckMetadataHash
 import io.novasama.substrate_sdk_android.runtime.extrinsic.ExtrinsicBuilder
 import io.novasama.substrate_sdk_android.runtime.extrinsic.Nonce
+import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SendableExtrinsic
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignerPayloadRaw
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.fromHex
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.fromUtf8
@@ -50,6 +55,7 @@ import io.novasama.substrate_sdk_android.wsrpc.request.runtime.chain.RuntimeVers
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 
@@ -60,6 +66,7 @@ class PolkadotSignInteractorFactory(
     private val tokenRepository: TokenRepository,
     private val extrinsicGson: Gson,
     private val addressIconGenerator: AddressIconGenerator,
+    private val metadataShortenerService: MetadataShortenerService,
     private val signerProvider: SignerProvider,
 ) {
 
@@ -72,7 +79,8 @@ class PolkadotSignInteractorFactory(
         addressIconGenerator = addressIconGenerator,
         request = request,
         wallet = wallet,
-        signerProvider = signerProvider
+        signerProvider = signerProvider,
+        metadataShortenerService = metadataShortenerService
     )
 }
 
@@ -84,11 +92,14 @@ class PolkadotExternalSignInteractor(
     private val addressIconGenerator: AddressIconGenerator,
     private val request: ExternalSignRequest.Polkadot,
     private val signerProvider: SignerProvider,
+    private val metadataShortenerService: MetadataShortenerService,
     wallet: ExternalSignWallet,
     accountRepository: AccountRepository
 ) : BaseExternalSignInteractor(accountRepository, wallet, signerProvider) {
 
     private val signPayload = request.payload
+
+    private val actualParsedExtrinsic = singleReplaySharedFlow<DAppParsedExtrinsic>()
 
     override val validationSystem: ConfirmDAppOperationValidationSystem = EmptyValidationSystem()
 
@@ -126,8 +137,8 @@ class PolkadotExternalSignInteractor(
                 is PolkadotSignPayload.Raw -> signBytes(signPayload)
             }
         }.fold(
-            onSuccess = { signature ->
-                ExternalSignCommunicator.Response.Signed(request.id, signature)
+            onSuccess = { signedResult ->
+                ExternalSignCommunicator.Response.Signed(request.id, signedResult.signature, signedResult.modifiedTransaction)
             },
             onFailure = { error ->
                 error.failedSigningIfNotCancelled(request.id)
@@ -137,7 +148,7 @@ class PolkadotExternalSignInteractor(
 
     override suspend fun readableOperationContent(): String = withContext(Dispatchers.Default) {
         when (signPayload) {
-            is PolkadotSignPayload.Json -> readableExtrinsicContent(signPayload)
+            is PolkadotSignPayload.Json -> readableExtrinsicContent()
             is PolkadotSignPayload.Raw -> readableBytesContent(signPayload)
         }
     }
@@ -148,29 +159,22 @@ class PolkadotExternalSignInteractor(
         val chain = signPayload.chainOrNull() ?: return@withContext null
 
         val signer = signPayload.feeSigner()
-        val extrinsicBuilder = signPayload.toExtrinsicBuilderWithoutCall(signer)
-        val runtime = chainRegistry.getRuntime(chain.id)
+        val (extrinsic, _, parsedExtrinsic) = signPayload.analyzeAndSign(signer)
 
-        val extrinsic = when (val callRepresentation = signPayload.callRepresentation(runtime)) {
-            is CallRepresentation.Instance -> extrinsicBuilder.call(callRepresentation.call).build()
-            is CallRepresentation.Bytes -> extrinsicBuilder.build(rawCallBytes = callRepresentation.bytes)
-        }
+        actualParsedExtrinsic.emit(parsedExtrinsic)
 
-        extrinsicService.estimateFee(chain, extrinsic, signer)
+        extrinsicService.estimateFee(chain, extrinsic.extrinsicHex, signer)
     }
 
     private fun readableBytesContent(signBytesPayload: PolkadotSignPayload.Raw): String {
         return signBytesPayload.data
     }
 
-    private suspend fun readableExtrinsicContent(extrinsicPayload: PolkadotSignPayload.Json): String {
-        val runtime = chainRegistry.getRuntime(extrinsicPayload.chain().id)
-        val parsedExtrinsic = parseDAppExtrinsic(runtime, extrinsicPayload)
-
-        return extrinsicGson.toJson(parsedExtrinsic)
+    private suspend fun readableExtrinsicContent(): String {
+        return extrinsicGson.toJson(actualParsedExtrinsic.first())
     }
 
-    private suspend fun signBytes(signBytesPayload: PolkadotSignPayload.Raw): String {
+    private suspend fun signBytes(signBytesPayload: PolkadotSignPayload.Raw): SignedResult {
         // assumption - only substrate dApps
         val substrateAccountId = signBytesPayload.address.toAccountId()
 
@@ -181,18 +185,17 @@ class PolkadotExternalSignInteractor(
             SignerPayloadRaw.fromUtf8(signBytesPayload.data, substrateAccountId)
         }
 
-        return signer.signRaw(payload).asHexString()
+        val signature = signer.signRaw(payload).asHexString()
+        return SignedResult(signature, modifiedTransaction = null)
     }
 
-    private suspend fun signExtrinsic(extrinsicPayload: PolkadotSignPayload.Json): String {
-        val runtime = chainRegistry.getRuntime(extrinsicPayload.chain().id)
+    private suspend fun signExtrinsic(extrinsicPayload: PolkadotSignPayload.Json): SignedResult {
         val signer = resolveWalletSigner()
-        val extrinsicBuilder = extrinsicPayload.toExtrinsicBuilderWithoutCall(signer)
+        val (extrinsic, modifiedOriginal) = extrinsicPayload.analyzeAndSign(signer)
 
-        return when (val callRepresentation = extrinsicPayload.callRepresentation(runtime)) {
-            is CallRepresentation.Instance -> extrinsicBuilder.call(callRepresentation.call).buildSignature()
-            is CallRepresentation.Bytes -> extrinsicBuilder.buildSignature(rawCallBytes = callRepresentation.bytes)
-        }
+        val modifiedTx = if (modifiedOriginal) extrinsic.extrinsicHex else null
+
+        return SignedResult(extrinsic.signatureHex, modifiedTx)
     }
 
     private suspend fun PolkadotSignPayload.Json.feeSigner(): FeeSigner {
@@ -201,14 +204,16 @@ class PolkadotExternalSignInteractor(
         return signerProvider.feeSigner(resolveMetaAccount(), chain)
     }
 
-    private suspend fun PolkadotSignPayload.Json.toExtrinsicBuilderWithoutCall(signer: NovaSigner): ExtrinsicBuilder {
+    private suspend fun PolkadotSignPayload.Json.analyzeAndSign(signer: NovaSigner): ActualExtrinsic {
         val chain = chain()
         val runtime = chainRegistry.getRuntime(genesisHash)
         val parsedExtrinsic = parseDAppExtrinsic(runtime, this)
 
         val accountId = chain.accountIdOf(address)
 
-        return with(parsedExtrinsic) {
+        val actualMetadataHash = actualMetadataHash(chain, signer)
+
+        val builder = with(parsedExtrinsic) {
             ExtrinsicBuilder(
                 runtime = runtime,
                 nonce = Nonce.singleTx(nonce),
@@ -219,12 +224,44 @@ class PolkadotExternalSignInteractor(
                 signer = signer,
                 accountId = accountId,
                 genesisHash = genesisHash,
+                checkMetadataHash = actualMetadataHash.checkMetadataHash,
                 customSignedExtensions = CustomSignedExtensions.extensionsWithValues(),
                 blockHash = blockHash,
                 era = era,
                 tip = tip
             )
         }
+
+        val extrinsic = when (val callRepresentation = callRepresentation(runtime)) {
+            is CallRepresentation.Instance -> builder.call(callRepresentation.call).buildExtrinsic()
+            is CallRepresentation.Bytes -> builder.buildExtrinsic(rawCallBytes = callRepresentation.bytes)
+        }
+
+        val actualParsedExtrinsic = parsedExtrinsic.copy(
+            metadataHash = actualMetadataHash.checkMetadataHash.metadataHash
+        )
+
+        return ActualExtrinsic(
+            signedExtrinsic = extrinsic,
+            modifiedOriginal = actualMetadataHash.modifiedOriginal,
+            actualParsedExtrinsic = actualParsedExtrinsic
+        )
+    }
+
+    private suspend fun PolkadotSignPayload.Json.actualMetadataHash(chain: Chain, signer: NovaSigner): ActualMetadataHash {
+        // If a dapp haven't declared a permission to modify extrinsic - return whatever metadataHash present in payload
+        if (withSignedTransaction != true) {
+            return ActualMetadataHash(modifiedOriginal = false, hexHash = metadataHash)
+        }
+
+        // If a dapp have specified metadata hash explicitly - use it
+        if (metadataHash != null) {
+            return ActualMetadataHash(modifiedOriginal = false, hexHash = metadataHash)
+        }
+
+        // Else generate and use our own proof
+        val metadataProof = metadataShortenerService.generateMetadataProofWithSignerRestrictions(chain, signer)
+        return ActualMetadataHash(modifiedOriginal = true, checkMetadataHash = metadataProof.checkMetadataHash)
     }
 
     private fun PolkadotSignPayload.Json.callRepresentation(runtime: RuntimeSnapshot): CallRepresentation = runCatching {
@@ -250,8 +287,35 @@ class PolkadotExternalSignInteractor(
                 blockHash = blockHash.fromHex(),
                 era = EraType.fromHex(runtime, era),
                 tip = tip.bigIntegerFromHex(),
-                call = callRepresentation(runtime)
+                call = callRepresentation(runtime),
+                metadataHash = metadataHash?.fromHex()
             )
         }
     }
+
+    private class ActualMetadataHash(val modifiedOriginal: Boolean, val checkMetadataHash: CheckMetadataHash) {
+
+        constructor(modifiedOriginal: Boolean, hash: ByteArray?) : this(modifiedOriginal, CheckMetadataHash(hash))
+
+        constructor(modifiedOriginal: Boolean, hexHash: String?) : this(modifiedOriginal, hexHash?.fromHex())
+    }
+
+    private data class ActualExtrinsic(
+        val signedExtrinsic: SendableExtrinsic,
+        val modifiedOriginal: Boolean,
+        val actualParsedExtrinsic: DAppParsedExtrinsic
+    )
+
+    private data class SignedResult(val signature: String, val modifiedTransaction: String?)
 }
+
+private fun CheckMetadataHash(hash: ByteArray?): CheckMetadataHash {
+    return if (hash != null) {
+        CheckMetadataHash.Enabled(hash)
+    } else {
+        CheckMetadataHash.Disabled
+    }
+}
+
+private val CheckMetadataHash.metadataHash: ByteArray?
+    get() = if (this is CheckMetadataHash.Enabled) hash else null

--- a/feature-wallet-connect-impl/src/main/java/io/novafoundation/nova/feature_wallet_connect_impl/domain/session/requests/polkadot/PolkadotSignRequest.kt
+++ b/feature-wallet-connect-impl/src/main/java/io/novafoundation/nova/feature_wallet_connect_impl/domain/session/requests/polkadot/PolkadotSignRequest.kt
@@ -18,7 +18,7 @@ class PolkadotSignRequest(
 ) : SignWalletConnectRequest(sessionRequest, context) {
 
     override suspend fun signedResponse(response: ExternalSignCommunicator.Response.Signed): Wallet.Params.SessionRequestResponse {
-        val responseData = PolkadotSignerResult(id, response.signature)
+        val responseData = PolkadotSignerResult(id, signature = response.signature, response.modifiedTransaction)
         val responseJson = gson.toJson(responseData)
 
         return sessionRequest.approved(responseJson)

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/ExtrinsicBuilderFactory.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/ExtrinsicBuilderFactory.kt
@@ -3,9 +3,9 @@ package io.novafoundation.nova.runtime.extrinsic
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.runtime.ext.addressOf
 import io.novafoundation.nova.runtime.ext.requireGenesisHash
-import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataProof
 import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerService
 import io.novafoundation.nova.runtime.extrinsic.signer.NovaSigner
+import io.novafoundation.nova.runtime.extrinsic.signer.generateMetadataProofWithSignerRestrictions
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.getRuntime
@@ -85,17 +85,6 @@ class ExtrinsicBuilderFactory(
             nonceOffset++
 
             newElement
-        }
-    }
-
-    private suspend fun MetadataShortenerService.generateMetadataProofWithSignerRestrictions(
-        chain: Chain,
-        signer: NovaSigner,
-    ): MetadataProof {
-        return if (signer.supportsCheckMetadataHash(chain)) {
-            generateMetadataProof(chain.id)
-        } else {
-            generateDisabledMetadataProof(chain.id)
         }
     }
 }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/multi/ExtrinsicSplitter.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/multi/ExtrinsicSplitter.kt
@@ -108,6 +108,7 @@ internal class RealExtrinsicSplitter(
             accountId = signer.signerAccountId(chain)
         )
             .call(call)
-            .build()
+            .buildExtrinsic()
+            .extrinsicHex
     }
 }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/signer/MetadataHashSigning.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/signer/MetadataHashSigning.kt
@@ -1,0 +1,16 @@
+package io.novafoundation.nova.runtime.extrinsic.signer
+
+import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataProof
+import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerService
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+
+suspend fun MetadataShortenerService.generateMetadataProofWithSignerRestrictions(
+    chain: Chain,
+    signer: NovaSigner,
+): MetadataProof {
+    return if (signer.supportsCheckMetadataHash(chain)) {
+        generateMetadataProof(chain.id)
+    } else {
+        generateDisabledMetadataProof(chain.id)
+    }
+}


### PR DESCRIPTION
Support Generic Ledger signing in Dapp Browser and Wallet Connect

Protocol is described at https://github.com/polkadot-js/api/pull/5920

Requires https://github.com/novasamatech/substrate-sdk-android/pull/96

Basic logic for determining what to use as a metadata hash

* If SignerPayloadJson doesnt contain `withSignedTransaction=true` use whatever is present in `SignerPayloadJson.metadaHash`
* If `SignerPayloadJson.metadaHash != null` use `SignerPayloadJson.metadaHash`
* Otherwise, generate `metadata hash` using on the same logic done in `ExtrinsicBuilderFactory` (thus accountring for restrictions regarding chain, signer type e.t.c.)

