### PR TITLE
Remove Multidex declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ buildscript {
         jUnitDep = "junit:junit:$junitVersion"
         mockitoDep = "org.mockito:mockito-inline:$mockitoVersion"
         robolectricDep = "org.robolectric:robolectric:$robolectricVersion"
-        robolectricMultidexDep = "org.robolectric:shadows-multidex:$robolectricVersion"
         archCoreTestDep = "androidx.arch.core:core-testing:$architectureComponentVersion"
 
         progressButtonDep = "com.github.razir.progressbutton:progressbutton:$progressButtonsVersion"


### PR DESCRIPTION
Since the min SDK is 24, it is no longer necessary to use the Multidex library.
The Robolectric-specific dependency is actually no longer used, but still declared in Gradle.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l