### PR TITLE
Fix/dapp navigation

### DIFF
--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/AccountNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/AccountNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.account.PolkadotVaultVariantSignCommunicatorImpl

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/AccountNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/AccountNavigationModule.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.account.PolkadotVaultVariantSignCommunicatorImpl
@@ -30,7 +31,7 @@ class AccountNavigationModule {
     @Provides
     @ApplicationScope
     fun providePinCodeTwoFactorVerificationCommunicator(
-        navigationHolder: SplitScreenNavigationHolder
+        navigationHolder: RootNavigationHolder
     ): PinCodeTwoFactorVerificationCommunicator = PinCodeTwoFactorVerificationCommunicatorImpl(navigationHolder)
 
     @Provides

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/AccountNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/AccountNavigationModule.kt
@@ -4,6 +4,7 @@ import dagger.Module
 import dagger.Provides
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.account.PolkadotVaultVariantSignCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.account.SelectAddressCommunicatorImpl
@@ -31,34 +32,34 @@ class AccountNavigationModule {
     @Provides
     @ApplicationScope
     fun providePinCodeTwoFactorVerificationCommunicator(
-        navigationHolder: RootNavigationHolder
-    ): PinCodeTwoFactorVerificationCommunicator = PinCodeTwoFactorVerificationCommunicatorImpl(navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): PinCodeTwoFactorVerificationCommunicator = PinCodeTwoFactorVerificationCommunicatorImpl(navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope
     fun provideSelectWalletCommunicator(
-        navigationHolder: SplitScreenNavigationHolder
-    ): SelectWalletCommunicator = SelectWalletCommunicatorImpl(navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): SelectWalletCommunicator = SelectWalletCommunicatorImpl(navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope
     fun provideParitySignerCommunicator(
-        navigationHolder: SplitScreenNavigationHolder
-    ): PolkadotVaultVariantSignCommunicator = PolkadotVaultVariantSignCommunicatorImpl(navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): PolkadotVaultVariantSignCommunicator = PolkadotVaultVariantSignCommunicatorImpl(navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope
     fun provideSelectAddressCommunicator(
         router: AssetsRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): SelectAddressCommunicator = SelectAddressCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): SelectAddressCommunicator = SelectAddressCommunicatorImpl(router, navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope
     fun provideSelectMultipleWalletsCommunicator(
         router: AssetsRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): SelectMultipleWalletsCommunicator = SelectMultipleWalletsCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): SelectMultipleWalletsCommunicator = SelectMultipleWalletsCommunicatorImpl(router, navigationHoldersRegistry)
 
     @ApplicationScope
     @Provides
@@ -68,20 +69,20 @@ class AccountNavigationModule {
     @ApplicationScope
     fun providePushGovernanceSettingsCommunicator(
         router: AccountRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): SyncWalletsBackupPasswordCommunicator = SyncWalletsBackupPasswordCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): SyncWalletsBackupPasswordCommunicator = SyncWalletsBackupPasswordCommunicatorImpl(router, navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope
     fun provideChangeBackupPasswordCommunicator(
         router: AccountRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): ChangeBackupPasswordCommunicator = ChangeBackupPasswordCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): ChangeBackupPasswordCommunicator = ChangeBackupPasswordCommunicatorImpl(router, navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope
     fun provideRestoreBackupPasswordCommunicator(
         router: AccountRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): RestoreBackupPasswordCommunicator = RestoreBackupPasswordCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): RestoreBackupPasswordCommunicator = RestoreBackupPasswordCommunicatorImpl(router, navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/AccountNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/AccountNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.account.PolkadotVaultVariantSignCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.account.SelectAddressCommunicatorImpl
@@ -30,33 +30,33 @@ class AccountNavigationModule {
     @Provides
     @ApplicationScope
     fun providePinCodeTwoFactorVerificationCommunicator(
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): PinCodeTwoFactorVerificationCommunicator = PinCodeTwoFactorVerificationCommunicatorImpl(navigationHolder)
 
     @Provides
     @ApplicationScope
     fun provideSelectWalletCommunicator(
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): SelectWalletCommunicator = SelectWalletCommunicatorImpl(navigationHolder)
 
     @Provides
     @ApplicationScope
     fun provideParitySignerCommunicator(
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): PolkadotVaultVariantSignCommunicator = PolkadotVaultVariantSignCommunicatorImpl(navigationHolder)
 
     @Provides
     @ApplicationScope
     fun provideSelectAddressCommunicator(
         router: AssetsRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): SelectAddressCommunicator = SelectAddressCommunicatorImpl(router, navigationHolder)
 
     @Provides
     @ApplicationScope
     fun provideSelectMultipleWalletsCommunicator(
         router: AssetsRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): SelectMultipleWalletsCommunicator = SelectMultipleWalletsCommunicatorImpl(router, navigationHolder)
 
     @ApplicationScope
@@ -67,20 +67,20 @@ class AccountNavigationModule {
     @ApplicationScope
     fun providePushGovernanceSettingsCommunicator(
         router: AccountRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): SyncWalletsBackupPasswordCommunicator = SyncWalletsBackupPasswordCommunicatorImpl(router, navigationHolder)
 
     @Provides
     @ApplicationScope
     fun provideChangeBackupPasswordCommunicator(
         router: AccountRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): ChangeBackupPasswordCommunicator = ChangeBackupPasswordCommunicatorImpl(router, navigationHolder)
 
     @Provides
     @ApplicationScope
     fun provideRestoreBackupPasswordCommunicator(
         router: AccountRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): RestoreBackupPasswordCommunicator = RestoreBackupPasswordCommunicatorImpl(router, navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/BuyNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/BuyNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.buy.BuyNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/BuyNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/BuyNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.buy.BuyNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.feature_buy_impl.presentation.BuyRouter
@@ -12,5 +12,5 @@ class BuyNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: MainNavigationHolder): BuyRouter = BuyNavigator(navigationHolder)
+    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): BuyRouter = BuyNavigator(navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/BuyNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/BuyNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.buy.BuyNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.feature_buy_impl.presentation.BuyRouter
@@ -12,5 +14,6 @@ class BuyNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): BuyRouter = BuyNavigator(navigationHolder)
+    fun provideRouter(navigationHoldersRegistry: NavigationHoldersRegistry): BuyRouter =
+        BuyNavigator(navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CloudBackupNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CloudBackupNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.cloudBackup.CloudBackupNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CloudBackupNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CloudBackupNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.cloudBackup.CloudBackupNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.feature_cloud_backup_impl.presentation.CloudBackupRouter
@@ -12,5 +14,6 @@ class CloudBackupNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): CloudBackupRouter = CloudBackupNavigator(navigationHolder)
+    fun provideRouter(navigationHoldersRegistry: NavigationHoldersRegistry): CloudBackupRouter =
+        CloudBackupNavigator(navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CloudBackupNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CloudBackupNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.cloudBackup.CloudBackupNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.feature_cloud_backup_impl.presentation.CloudBackupRouter
@@ -12,5 +12,5 @@ class CloudBackupNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: MainNavigationHolder): CloudBackupRouter = CloudBackupNavigator(navigationHolder)
+    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): CloudBackupRouter = CloudBackupNavigator(navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CurrencyNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CurrencyNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.wallet.CurrencyNavigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -15,6 +17,6 @@ class CurrencyNavigationModule {
     @Provides
     fun provideRouter(
         rootRouter: RootRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): CurrencyRouter = CurrencyNavigator(rootRouter, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry,
+    ): CurrencyRouter = CurrencyNavigator(rootRouter, navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CurrencyNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CurrencyNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.wallet.CurrencyNavigator
 import io.novafoundation.nova.app.root.presentation.RootRouter

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CurrencyNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/CurrencyNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.wallet.CurrencyNavigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -15,6 +15,6 @@ class CurrencyNavigationModule {
     @Provides
     fun provideRouter(
         rootRouter: RootRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): CurrencyRouter = CurrencyNavigator(rootRouter, navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DAppNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DAppNavigationModule.kt
@@ -23,7 +23,7 @@ class DAppNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideSearchDappCommunicator(navigationHolder: RootNavigationHolder): DAppSearchCommunicator {
-        return DAppSearchCommunicatorImpl(navigationHolder)
+    fun provideSearchDappCommunicator(navigationHoldersRegistry: NavigationHoldersRegistry): DAppSearchCommunicator {
+        return DAppSearchCommunicatorImpl(navigationHoldersRegistry)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DAppNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DAppNavigationModule.kt
@@ -4,9 +4,11 @@ import dagger.Module
 import dagger.Provides
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.dApp.DAppNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.dApp.DAppSearchCommunicatorImpl
 import io.novafoundation.nova.common.di.scope.ApplicationScope
+import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DAppSearchCommunicator
 
@@ -15,8 +17,9 @@ class DAppNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(rootNavigationHolder: RootNavigationHolder, splitScreenNavigationHolder: SplitScreenNavigationHolder): DAppRouter =
-        DAppNavigator(rootNavigationHolder, splitScreenNavigationHolder)
+    fun provideRouter(
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): DAppRouter = DAppNavigator(navigationHoldersRegistry)
 
     @ApplicationScope
     @Provides

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DAppNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DAppNavigationModule.kt
@@ -2,13 +2,10 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.dApp.DAppNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.dApp.DAppSearchCommunicatorImpl
 import io.novafoundation.nova.common.di.scope.ApplicationScope
-import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DAppSearchCommunicator
 

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DAppNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DAppNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.dApp.DAppNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.dApp.DAppSearchCommunicatorImpl
@@ -15,8 +15,8 @@ class DAppNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(rootNavigationHolder: RootNavigationHolder, mainNavigationHolder: MainNavigationHolder): DAppRouter =
-        DAppNavigator(rootNavigationHolder, mainNavigationHolder)
+    fun provideRouter(rootNavigationHolder: RootNavigationHolder, splitScreenNavigationHolder: SplitScreenNavigationHolder): DAppRouter =
+        DAppNavigator(rootNavigationHolder, splitScreenNavigationHolder)
 
     @ApplicationScope
     @Provides

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DeepLinkingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/DeepLinkingNavigationModule.kt
@@ -2,13 +2,13 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.deepLinking.DeepLinkingNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
 import io.novafoundation.nova.feature_deep_linking.presentation.handling.DeepLinkingRouter
-import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
 
 @Module
 class DeepLinkingNavigationModule {
@@ -16,14 +16,14 @@ class DeepLinkingNavigationModule {
     @ApplicationScope
     @Provides
     fun provideRouter(
+        navigationHoldersRegistry: NavigationHoldersRegistry,
         accountRouter: AccountRouter,
         assetsRouter: AssetsRouter,
-        dAppRouter: DAppRouter,
-        governanceRouter: GovernanceRouter
+        dAppRouter: DAppRouter
     ): DeepLinkingRouter = DeepLinkingNavigator(
+        navigationHoldersRegistry = navigationHoldersRegistry,
         accountRouter = accountRouter,
         assetsRouter = assetsRouter,
-        dAppRouter = dAppRouter,
-        governanceRouter = governanceRouter
+        dAppRouter = dAppRouter
     )
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/ExternalSignNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/ExternalSignNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.externalSign.ExternalSignCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.externalSign.ExternalSignNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -15,7 +17,8 @@ class ExternalSignNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): ExternalSignRouter = ExternalSignNavigator(navigationHolder)
+    fun provideRouter(navigationHoldersRegistry: NavigationHoldersRegistry): ExternalSignRouter =
+        ExternalSignNavigator(navigationHoldersRegistry)
 
     @ApplicationScope
     @Provides

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/ExternalSignNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/ExternalSignNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.externalSign.ExternalSignCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.externalSign.ExternalSignNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -15,12 +15,12 @@ class ExternalSignNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: MainNavigationHolder): ExternalSignRouter = ExternalSignNavigator(navigationHolder)
+    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): ExternalSignRouter = ExternalSignNavigator(navigationHolder)
 
     @ApplicationScope
     @Provides
     fun provideSignExtrinsicCommunicator(
-        navigationHolder: MainNavigationHolder,
+        navigationHolder: SplitScreenNavigationHolder,
         automaticInteractionGate: AutomaticInteractionGate,
     ): ExternalSignCommunicator {
         return ExternalSignCommunicatorImpl(navigationHolder, automaticInteractionGate)

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/ExternalSignNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/ExternalSignNavigationModule.kt
@@ -3,7 +3,6 @@ package io.novafoundation.nova.app.di.app.navigation
 import dagger.Module
 import dagger.Provides
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.externalSign.ExternalSignCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.externalSign.ExternalSignNavigator

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/ExternalSignNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/ExternalSignNavigationModule.kt
@@ -23,7 +23,7 @@ class ExternalSignNavigationModule {
     @ApplicationScope
     @Provides
     fun provideSignExtrinsicCommunicator(
-        navigationHolder: SplitScreenNavigationHolder,
+        navigationHolder: RootNavigationHolder,
         automaticInteractionGate: AutomaticInteractionGate,
     ): ExternalSignCommunicator {
         return ExternalSignCommunicatorImpl(navigationHolder, automaticInteractionGate)

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/GovernanceNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/GovernanceNavigationModule.kt
@@ -30,13 +30,13 @@ class GovernanceNavigationModule {
     @ApplicationScope
     fun provideSelectTracksCommunicator(
         router: GovernanceRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): SelectTracksCommunicator = SelectTracksCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): SelectTracksCommunicator = SelectTracksCommunicatorImpl(router, navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope
     fun provideTinderGovVoteCommunicator(
         router: GovernanceRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): TinderGovVoteCommunicator = TinderGovVoteCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): TinderGovVoteCommunicator = TinderGovVoteCommunicatorImpl(router, navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/GovernanceNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/GovernanceNavigationModule.kt
@@ -2,12 +2,15 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.governance.GovernanceNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.governance.SelectTracksCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.governance.TinderGovVoteCommunicatorImpl
 import io.novafoundation.nova.common.di.scope.ApplicationScope
+import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksCommunicator
 import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.setup.tindergov.TinderGovVoteCommunicator
@@ -18,9 +21,10 @@ class GovernanceNavigationModule {
     @ApplicationScope
     @Provides
     fun provideRouter(
-        navigationHolder: SplitScreenNavigationHolder,
+        navigationHoldersRegistry: NavigationHoldersRegistry,
         commonNavigator: Navigator,
-    ): GovernanceRouter = GovernanceNavigator(navigationHolder, commonNavigator)
+        contextManager: ContextManager
+    ): GovernanceRouter = GovernanceNavigator(navigationHoldersRegistry, commonNavigator, contextManager)
 
     @Provides
     @ApplicationScope

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/GovernanceNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/GovernanceNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.governance.GovernanceNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.governance.SelectTracksCommunicatorImpl
@@ -18,7 +18,7 @@ class GovernanceNavigationModule {
     @ApplicationScope
     @Provides
     fun provideRouter(
-        navigationHolder: MainNavigationHolder,
+        navigationHolder: SplitScreenNavigationHolder,
         commonNavigator: Navigator,
     ): GovernanceRouter = GovernanceNavigator(navigationHolder, commonNavigator)
 
@@ -26,13 +26,13 @@ class GovernanceNavigationModule {
     @ApplicationScope
     fun provideSelectTracksCommunicator(
         router: GovernanceRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): SelectTracksCommunicator = SelectTracksCommunicatorImpl(router, navigationHolder)
 
     @Provides
     @ApplicationScope
     fun provideTinderGovVoteCommunicator(
         router: GovernanceRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): TinderGovVoteCommunicator = TinderGovVoteCommunicatorImpl(router, navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/GovernanceNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/GovernanceNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.governance.GovernanceNavigator

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/LedgerNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/LedgerNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.ledger.LedgerNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.ledger.LedgerSignCommunicatorImpl

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/LedgerNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/LedgerNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.ledger.LedgerNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.ledger.LedgerSignCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.ledger.SelectLedgerAddressCommunicatorImpl
@@ -17,17 +17,17 @@ class LedgerNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideSelectLedgerAddressCommunicator(navigationHolder: MainNavigationHolder): SelectLedgerAddressInterScreenCommunicator {
+    fun provideSelectLedgerAddressCommunicator(navigationHolder: SplitScreenNavigationHolder): SelectLedgerAddressInterScreenCommunicator {
         return SelectLedgerAddressCommunicatorImpl(navigationHolder)
     }
 
     @Provides
     @ApplicationScope
     fun provideLedgerSignerCommunicator(
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): LedgerSignCommunicator = LedgerSignCommunicatorImpl(navigationHolder)
 
     @ApplicationScope
     @Provides
-    fun provideRouter(router: AccountRouter, navigationHolder: MainNavigationHolder): LedgerRouter = LedgerNavigator(router, navigationHolder)
+    fun provideRouter(router: AccountRouter, navigationHolder: SplitScreenNavigationHolder): LedgerRouter = LedgerNavigator(router, navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/LedgerNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/LedgerNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.ledger.LedgerNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.ledger.LedgerSignCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.ledger.SelectLedgerAddressCommunicatorImpl
@@ -17,17 +19,18 @@ class LedgerNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideSelectLedgerAddressCommunicator(navigationHolder: SplitScreenNavigationHolder): SelectLedgerAddressInterScreenCommunicator {
-        return SelectLedgerAddressCommunicatorImpl(navigationHolder)
+    fun provideSelectLedgerAddressCommunicator(splitScreenNavigationHolder: SplitScreenNavigationHolder): SelectLedgerAddressInterScreenCommunicator {
+        return SelectLedgerAddressCommunicatorImpl(splitScreenNavigationHolder)
     }
 
     @Provides
     @ApplicationScope
     fun provideLedgerSignerCommunicator(
-        navigationHolder: SplitScreenNavigationHolder
-    ): LedgerSignCommunicator = LedgerSignCommunicatorImpl(navigationHolder)
+        splitScreenNavigationHolder: SplitScreenNavigationHolder
+    ): LedgerSignCommunicator = LedgerSignCommunicatorImpl(splitScreenNavigationHolder)
 
     @ApplicationScope
     @Provides
-    fun provideRouter(router: AccountRouter, navigationHolder: SplitScreenNavigationHolder): LedgerRouter = LedgerNavigator(router, navigationHolder)
+    fun provideRouter(router: AccountRouter, navigationHoldersRegistry: NavigationHoldersRegistry): LedgerRouter =
+        LedgerNavigator(router, navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/LedgerNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/LedgerNavigationModule.kt
@@ -19,15 +19,15 @@ class LedgerNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideSelectLedgerAddressCommunicator(splitScreenNavigationHolder: SplitScreenNavigationHolder): SelectLedgerAddressInterScreenCommunicator {
-        return SelectLedgerAddressCommunicatorImpl(splitScreenNavigationHolder)
+    fun provideSelectLedgerAddressCommunicator(navigationHoldersRegistry: NavigationHoldersRegistry): SelectLedgerAddressInterScreenCommunicator {
+        return SelectLedgerAddressCommunicatorImpl(navigationHoldersRegistry)
     }
 
     @Provides
     @ApplicationScope
     fun provideLedgerSignerCommunicator(
-        splitScreenNavigationHolder: SplitScreenNavigationHolder
-    ): LedgerSignCommunicator = LedgerSignCommunicatorImpl(splitScreenNavigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): LedgerSignCommunicator = LedgerSignCommunicatorImpl(navigationHoldersRegistry)
 
     @ApplicationScope
     @Provides

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NavigationModule.kt
@@ -11,7 +11,6 @@ import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.common.navigation.DelayedNavigationRouter
 import io.novafoundation.nova.common.resources.ContextManager
-import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
 import io.novafoundation.nova.feature_crowdloan_impl.presentation.CrowdloanRouter
 import io.novafoundation.nova.feature_onboarding_impl.OnboardingRouter
@@ -94,5 +93,4 @@ class NavigationModule {
     @ApplicationScope
     @Provides
     fun provideDelayedNavigationRouter(navigator: Navigator): DelayedNavigationRouter = navigator
-
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NavigationModule.kt
@@ -4,7 +4,7 @@ import dagger.Module
 import dagger.Provides
 import io.novafoundation.nova.app.di.app.navigation.staking.StakingNavigationModule
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -43,7 +43,7 @@ class NavigationModule {
     @Provides
     fun provideMainNavigatorHolder(
         contextManager: ContextManager
-    ): MainNavigationHolder = MainNavigationHolder(contextManager)
+    ): SplitScreenNavigationHolder = SplitScreenNavigationHolder(contextManager)
 
     @ApplicationScope
     @Provides
@@ -55,7 +55,7 @@ class NavigationModule {
     @Provides
     fun provideNavigator(
         rootNavigatorHolder: RootNavigationHolder,
-        mainNavigatorHolder: MainNavigationHolder,
+        mainNavigatorHolder: SplitScreenNavigationHolder,
         walletConnectRouter: WalletConnectRouter,
         stakingDashboardRouter: StakingDashboardRouter,
     ): Navigator = Navigator(rootNavigatorHolder, mainNavigatorHolder, walletConnectRouter, stakingDashboardRouter)

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NavigationModule.kt
@@ -9,7 +9,9 @@ import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRe
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.di.scope.ApplicationScope
+import io.novafoundation.nova.common.navigation.DelayedNavigationRouter
 import io.novafoundation.nova.common.resources.ContextManager
+import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
 import io.novafoundation.nova.feature_crowdloan_impl.presentation.CrowdloanRouter
 import io.novafoundation.nova.feature_onboarding_impl.OnboardingRouter
@@ -88,4 +90,9 @@ class NavigationModule {
     @ApplicationScope
     @Provides
     fun provideCrowdloanRouter(navigator: Navigator): CrowdloanRouter = navigator
+
+    @ApplicationScope
+    @Provides
+    fun provideDelayedNavigationRouter(navigator: Navigator): DelayedNavigationRouter = navigator
+
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NavigationModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import io.novafoundation.nova.app.di.app.navigation.staking.StakingNavigationModule
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -53,12 +54,20 @@ class NavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideNavigator(
+    fun provideNavigationHoldersRegistry(
         rootNavigatorHolder: RootNavigationHolder,
-        mainNavigatorHolder: SplitScreenNavigationHolder,
+        splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    ): NavigationHoldersRegistry {
+        return NavigationHoldersRegistry(splitScreenNavigationHolder, rootNavigatorHolder)
+    }
+
+    @ApplicationScope
+    @Provides
+    fun provideNavigator(
+        navigationHoldersRegistry: NavigationHoldersRegistry,
         walletConnectRouter: WalletConnectRouter,
         stakingDashboardRouter: StakingDashboardRouter,
-    ): Navigator = Navigator(rootNavigatorHolder, mainNavigatorHolder, walletConnectRouter, stakingDashboardRouter)
+    ): Navigator = Navigator(navigationHoldersRegistry, walletConnectRouter, stakingDashboardRouter)
 
     @Provides
     @ApplicationScope

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NftNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NftNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.nft.NftNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.feature_nft_impl.NftRouter
@@ -12,5 +14,6 @@ class NftNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): NftRouter = NftNavigator(navigationHolder)
+    fun provideRouter(navigationHoldersRegistry: NavigationHoldersRegistry): NftRouter =
+        NftNavigator(navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NftNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NftNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.nft.NftNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
 import io.novafoundation.nova.feature_nft_impl.NftRouter
@@ -12,5 +12,5 @@ class NftNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: MainNavigationHolder): NftRouter = NftNavigator(navigationHolder)
+    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): NftRouter = NftNavigator(navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NftNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/NftNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.nft.NftNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/PushNotificationsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/PushNotificationsNavigationModule.kt
@@ -25,13 +25,13 @@ class PushNotificationsNavigationModule {
     @ApplicationScope
     fun providePushGovernanceSettingsCommunicator(
         router: PushNotificationsRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): PushGovernanceSettingsCommunicator = PushGovernanceSettingsCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): PushGovernanceSettingsCommunicator = PushGovernanceSettingsCommunicatorImpl(router, navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope
     fun providePushStakingSettingsCommunicator(
         router: PushNotificationsRouter,
-        navigationHolder: SplitScreenNavigationHolder
-    ): PushStakingSettingsCommunicator = PushStakingSettingsCommunicatorImpl(router, navigationHolder)
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): PushStakingSettingsCommunicator = PushStakingSettingsCommunicatorImpl(router, navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/PushNotificationsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/PushNotificationsNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.push.PushGovernanceSettingsCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.push.PushNotificationsNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.push.PushStakingSettingsCommunicatorImpl
@@ -16,7 +18,8 @@ class PushNotificationsNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): PushNotificationsRouter = PushNotificationsNavigator(navigationHolder)
+    fun provideRouter(navigationHoldersRegistry: NavigationHoldersRegistry): PushNotificationsRouter =
+        PushNotificationsNavigator(navigationHoldersRegistry)
 
     @Provides
     @ApplicationScope

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/PushNotificationsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/PushNotificationsNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.push.PushGovernanceSettingsCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.push.PushNotificationsNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.push.PushStakingSettingsCommunicatorImpl
@@ -16,19 +16,19 @@ class PushNotificationsNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: MainNavigationHolder): PushNotificationsRouter = PushNotificationsNavigator(navigationHolder)
+    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): PushNotificationsRouter = PushNotificationsNavigator(navigationHolder)
 
     @Provides
     @ApplicationScope
     fun providePushGovernanceSettingsCommunicator(
         router: PushNotificationsRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): PushGovernanceSettingsCommunicator = PushGovernanceSettingsCommunicatorImpl(router, navigationHolder)
 
     @Provides
     @ApplicationScope
     fun providePushStakingSettingsCommunicator(
         router: PushNotificationsRouter,
-        navigationHolder: MainNavigationHolder
+        navigationHolder: SplitScreenNavigationHolder
     ): PushStakingSettingsCommunicator = PushStakingSettingsCommunicatorImpl(router, navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/PushNotificationsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/PushNotificationsNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.push.PushGovernanceSettingsCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.push.PushNotificationsNavigator

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SettingsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SettingsNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.settings.SettingsNavigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
@@ -17,7 +17,7 @@ class SettingsNavigationModule {
     @Provides
     fun provideRouter(
         rootRouter: RootRouter,
-        navigationHolder: MainNavigationHolder,
+        navigationHolder: SplitScreenNavigationHolder,
         walletConnectRouter: WalletConnectRouter,
         navigator: Navigator,
     ): SettingsRouter = SettingsNavigator(navigationHolder, rootRouter, walletConnectRouter, navigator)

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SettingsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SettingsNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.settings.SettingsNavigator

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SettingsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SettingsNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.settings.SettingsNavigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
@@ -17,8 +19,8 @@ class SettingsNavigationModule {
     @Provides
     fun provideRouter(
         rootRouter: RootRouter,
-        navigationHolder: SplitScreenNavigationHolder,
+        navigationHoldersRegistry: NavigationHoldersRegistry,
         walletConnectRouter: WalletConnectRouter,
         navigator: Navigator,
-    ): SettingsRouter = SettingsNavigator(navigationHolder, rootRouter, walletConnectRouter, navigator)
+    ): SettingsRouter = SettingsNavigator(navigationHoldersRegistry, rootRouter, walletConnectRouter, navigator)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SwapNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SwapNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.swap.SwapNavigator

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SwapNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SwapNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.swap.SwapNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -14,7 +16,7 @@ class SwapNavigationModule {
     @ApplicationScope
     @Provides
     fun provideRouter(
-        navigationHolder: SplitScreenNavigationHolder,
+        navigationHoldersRegistry: NavigationHoldersRegistry,
         commonDelegate: Navigator
-    ): SwapRouter = SwapNavigator(navigationHolder, commonDelegate)
+    ): SwapRouter = SwapNavigator(navigationHoldersRegistry, commonDelegate)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SwapNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/SwapNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.swap.SwapNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -14,7 +14,7 @@ class SwapNavigationModule {
     @ApplicationScope
     @Provides
     fun provideRouter(
-        navigationHolder: MainNavigationHolder,
+        navigationHolder: SplitScreenNavigationHolder,
         commonDelegate: Navigator
     ): SwapRouter = SwapNavigator(navigationHolder, commonDelegate)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/VersionsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/VersionsNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.versions.VersionsNavigator
 import io.novafoundation.nova.common.data.network.AppLinksProvider

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/VersionsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/VersionsNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.versions.VersionsNavigator
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -14,7 +14,7 @@ class VersionsNavigationModule {
     @Provides
     @ApplicationScope
     fun provideRouter(
-        navigationHolder: MainNavigationHolder,
+        navigationHolder: SplitScreenNavigationHolder,
         appLinksProvider: AppLinksProvider
     ): VersionsRouter = VersionsNavigator(navigationHolder, appLinksProvider.storeUrl)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/VersionsNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/VersionsNavigationModule.kt
@@ -2,10 +2,13 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.versions.VersionsNavigator
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.di.scope.ApplicationScope
+import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.feature_versions_api.presentation.VersionsRouter
 
 @Module
@@ -14,7 +17,8 @@ class VersionsNavigationModule {
     @Provides
     @ApplicationScope
     fun provideRouter(
-        navigationHolder: SplitScreenNavigationHolder,
+        navigationHoldersRegistry: NavigationHoldersRegistry,
+        contextManager: ContextManager,
         appLinksProvider: AppLinksProvider
-    ): VersionsRouter = VersionsNavigator(navigationHolder, appLinksProvider.storeUrl)
+    ): VersionsRouter = VersionsNavigator(navigationHoldersRegistry, contextManager, appLinksProvider.storeUrl)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/WalletConnectNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/WalletConnectNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.walletConnect.ApproveSessionCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.walletConnect.WalletConnectNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -16,11 +16,11 @@ class WalletConnectNavigationModule {
     @Provides
     @ApplicationScope
     fun provideApproveSessionCommunicator(
-        navigationHolder: MainNavigationHolder,
+        navigationHolder: SplitScreenNavigationHolder,
         automaticInteractionGate: AutomaticInteractionGate,
     ): ApproveSessionCommunicator = ApproveSessionCommunicatorImpl(navigationHolder, automaticInteractionGate)
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: MainNavigationHolder): WalletConnectRouter = WalletConnectNavigator(navigationHolder)
+    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): WalletConnectRouter = WalletConnectNavigator(navigationHolder)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/WalletConnectNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/WalletConnectNavigationModule.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.walletConnect.ApproveSessionCommunicatorImpl

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/WalletConnectNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/WalletConnectNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.walletConnect.ApproveSessionCommunicatorImpl
 import io.novafoundation.nova.app.root.navigation.navigators.walletConnect.WalletConnectNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -22,5 +24,6 @@ class WalletConnectNavigationModule {
 
     @ApplicationScope
     @Provides
-    fun provideRouter(navigationHolder: SplitScreenNavigationHolder): WalletConnectRouter = WalletConnectNavigator(navigationHolder)
+    fun provideRouter(navigationHoldersRegistry: NavigationHoldersRegistry): WalletConnectRouter =
+        WalletConnectNavigator(navigationHoldersRegistry)
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/NominationPoolsStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/NominationPoolsStakingNavigationModule.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.nominationPools.NominationPoolsStakingNavigator

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/NominationPoolsStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/NominationPoolsStakingNavigationModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.nominationPools.NominationPoolsStakingNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -13,7 +15,7 @@ class NominationPoolsStakingNavigationModule {
 
     @Provides
     @ApplicationScope
-    fun provideRouter(navigationHolder: SplitScreenNavigationHolder, navigator: Navigator): NominationPoolsRouter {
-        return NominationPoolsStakingNavigator(navigationHolder, navigator)
+    fun provideRouter(navigationHoldersRegistry: NavigationHoldersRegistry, navigator: Navigator): NominationPoolsRouter {
+        return NominationPoolsStakingNavigator(navigationHoldersRegistry, navigator)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/NominationPoolsStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/NominationPoolsStakingNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.nominationPools.NominationPoolsStakingNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -13,7 +13,7 @@ class NominationPoolsStakingNavigationModule {
 
     @Provides
     @ApplicationScope
-    fun provideRouter(navigationHolder: MainNavigationHolder, navigator: Navigator): NominationPoolsRouter {
+    fun provideRouter(navigationHolder: SplitScreenNavigationHolder, navigator: Navigator): NominationPoolsRouter {
         return NominationPoolsStakingNavigator(navigationHolder, navigator)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/ParachainStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/ParachainStakingNavigationModule.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.parachain.ParachainStakingNavigator

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/ParachainStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/ParachainStakingNavigationModule.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 import dagger.Module
 import dagger.Provides
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.parachain.ParachainStakingNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.parachain.SelectCollatorInterScreenCommunicatorImpl
@@ -17,8 +18,11 @@ class ParachainStakingNavigationModule {
 
     @Provides
     @ApplicationScope
-    fun provideParachainStakingRouter(navigationHolder: SplitScreenNavigationHolder, navigator: Navigator): ParachainStakingRouter {
-        return ParachainStakingNavigator(navigationHolder, navigator)
+    fun provideParachainStakingRouter(
+        navigationHoldersRegistry: NavigationHoldersRegistry,
+        navigator: Navigator
+    ): ParachainStakingRouter {
+        return ParachainStakingNavigator(navigationHoldersRegistry, navigator)
     }
 
     @Provides

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/ParachainStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/ParachainStakingNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.parachain.ParachainStakingNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.parachain.SelectCollatorInterScreenCommunicatorImpl
@@ -17,19 +17,19 @@ class ParachainStakingNavigationModule {
 
     @Provides
     @ApplicationScope
-    fun provideParachainStakingRouter(navigationHolder: MainNavigationHolder, navigator: Navigator): ParachainStakingRouter {
+    fun provideParachainStakingRouter(navigationHolder: SplitScreenNavigationHolder, navigator: Navigator): ParachainStakingRouter {
         return ParachainStakingNavigator(navigationHolder, navigator)
     }
 
     @Provides
     @ApplicationScope
-    fun provideSelectCollatorCommunicator(navigationHolder: MainNavigationHolder): SelectCollatorInterScreenCommunicator {
+    fun provideSelectCollatorCommunicator(navigationHolder: SplitScreenNavigationHolder): SelectCollatorInterScreenCommunicator {
         return SelectCollatorInterScreenCommunicatorImpl(navigationHolder)
     }
 
     @Provides
     @ApplicationScope
-    fun provideSelectCollatorSettingsCommunicator(navigationHolder: MainNavigationHolder): SelectCollatorSettingsInterScreenCommunicator {
+    fun provideSelectCollatorSettingsCommunicator(navigationHolder: SplitScreenNavigationHolder): SelectCollatorSettingsInterScreenCommunicator {
         return SelectCollatorSettingsInterScreenCommunicatorImpl(navigationHolder)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/ParachainStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/ParachainStakingNavigationModule.kt
@@ -27,13 +27,13 @@ class ParachainStakingNavigationModule {
 
     @Provides
     @ApplicationScope
-    fun provideSelectCollatorCommunicator(navigationHolder: SplitScreenNavigationHolder): SelectCollatorInterScreenCommunicator {
-        return SelectCollatorInterScreenCommunicatorImpl(navigationHolder)
+    fun provideSelectCollatorCommunicator(navigationHoldersRegistry: NavigationHoldersRegistry): SelectCollatorInterScreenCommunicator {
+        return SelectCollatorInterScreenCommunicatorImpl(navigationHoldersRegistry)
     }
 
     @Provides
     @ApplicationScope
-    fun provideSelectCollatorSettingsCommunicator(navigationHolder: SplitScreenNavigationHolder): SelectCollatorSettingsInterScreenCommunicator {
-        return SelectCollatorSettingsInterScreenCommunicatorImpl(navigationHolder)
+    fun provideSelectCollatorSettingsCommunicator(navigationHoldersRegistry: NavigationHoldersRegistry): SelectCollatorSettingsInterScreenCommunicator {
+        return SelectCollatorSettingsInterScreenCommunicatorImpl(navigationHoldersRegistry)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/RelayStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/RelayStakingNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.relaychain.RelayStakingNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -15,7 +15,7 @@ class RelayStakingNavigationModule {
     @Provides
     @ApplicationScope
     fun provideRelayStakingRouter(
-        navigationHolder: MainNavigationHolder,
+        navigationHolder: SplitScreenNavigationHolder,
         navigator: Navigator,
         dashboardRouter: StakingDashboardRouter
     ): StakingRouter {

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/RelayStakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/RelayStakingNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.relaychain.RelayStakingNavigator
 import io.novafoundation.nova.common.di.scope.ApplicationScope
@@ -15,10 +15,10 @@ class RelayStakingNavigationModule {
     @Provides
     @ApplicationScope
     fun provideRelayStakingRouter(
-        navigationHolder: SplitScreenNavigationHolder,
+        navigationHoldersRegistry: NavigationHoldersRegistry,
         navigator: Navigator,
         dashboardRouter: StakingDashboardRouter
     ): StakingRouter {
-        return RelayStakingNavigator(navigationHolder, navigator, dashboardRouter)
+        return RelayStakingNavigator(navigationHoldersRegistry, navigator, dashboardRouter)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/StakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/StakingNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.StakingDashboardNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.StartMultiStakingNavigator
@@ -21,8 +21,10 @@ class StakingNavigationModule {
 
     @Provides
     @ApplicationScope
-    fun provideStakingDashboardNavigator(navigationHolder: SplitScreenNavigationHolder): StakingDashboardNavigator {
-        return StakingDashboardNavigator(navigationHolder)
+    fun provideStakingDashboardNavigator(
+        navigationHoldersRegistry: NavigationHoldersRegistry
+    ): StakingDashboardNavigator {
+        return StakingDashboardNavigator(navigationHoldersRegistry)
     }
 
     @Provides
@@ -32,10 +34,10 @@ class StakingNavigationModule {
     @Provides
     @ApplicationScope
     fun provideStartMultiStakingRouter(
-        navigationHolder: SplitScreenNavigationHolder,
+        navigationHoldersRegistry: NavigationHoldersRegistry,
         dashboardRouter: StakingDashboardRouter,
         commonNavigator: Navigator
     ): StartMultiStakingRouter {
-        return StartMultiStakingNavigator(navigationHolder, dashboardRouter, commonNavigator)
+        return StartMultiStakingNavigator(navigationHoldersRegistry, dashboardRouter, commonNavigator)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/StakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/StakingNavigationModule.kt
@@ -21,10 +21,8 @@ class StakingNavigationModule {
 
     @Provides
     @ApplicationScope
-    fun provideStakingDashboardNavigator(
-        navigationHoldersRegistry: NavigationHoldersRegistry
-    ): StakingDashboardNavigator {
-        return StakingDashboardNavigator(navigationHoldersRegistry)
+    fun provideStakingDashboardNavigator(): StakingDashboardNavigator {
+        return StakingDashboardNavigator()
     }
 
     @Provides

--- a/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/StakingNavigationModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/di/app/navigation/staking/StakingNavigationModule.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.di.app.navigation.staking
 
 import dagger.Module
 import dagger.Provides
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.StakingDashboardNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.StartMultiStakingNavigator
@@ -21,7 +21,7 @@ class StakingNavigationModule {
 
     @Provides
     @ApplicationScope
-    fun provideStakingDashboardNavigator(navigationHolder: MainNavigationHolder): StakingDashboardNavigator {
+    fun provideStakingDashboardNavigator(navigationHolder: SplitScreenNavigationHolder): StakingDashboardNavigator {
         return StakingDashboardNavigator(navigationHolder)
     }
 
@@ -32,7 +32,7 @@ class StakingNavigationModule {
     @Provides
     @ApplicationScope
     fun provideStartMultiStakingRouter(
-        navigationHolder: MainNavigationHolder,
+        navigationHolder: SplitScreenNavigationHolder,
         dashboardRouter: StakingDashboardRouter,
         commonNavigator: Navigator
     ): StartMultiStakingRouter {

--- a/app/src/main/java/io/novafoundation/nova/app/root/di/RootComponent.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/di/RootComponent.kt
@@ -11,6 +11,7 @@ import io.novafoundation.nova.app.root.presentation.main.di.MainFragmentComponen
 import io.novafoundation.nova.app.root.presentation.splitScreen.di.SplitScreenFragmentComponent
 import io.novafoundation.nova.common.di.CommonApi
 import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.common.navigation.DelayedNavigationRouter
 import io.novafoundation.nova.core_db.di.DbApi
 import io.novafoundation.nova.feature_account_api.di.AccountFeatureApi
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
@@ -60,6 +61,7 @@ interface RootComponent {
             @BindsInstance assetsRouter: AssetsRouter,
             @BindsInstance accountRouter: AccountRouter,
             @BindsInstance stakingDashboardNavigator: StakingDashboardNavigator,
+            @BindsInstance delayedNavigationRouter: DelayedNavigationRouter,
             deps: RootDependencies
         ): RootComponent
     }

--- a/app/src/main/java/io/novafoundation/nova/app/root/di/RootComponent.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/di/RootComponent.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.app.root.di
 import dagger.BindsInstance
 import dagger.Component
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.staking.StakingDashboardNavigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.app.root.presentation.di.RootActivityComponent
@@ -52,7 +52,7 @@ interface RootComponent {
     interface Factory {
 
         fun create(
-            @BindsInstance mainNavigationHolder: MainNavigationHolder,
+            @BindsInstance splitScreenNavigationHolder: SplitScreenNavigationHolder,
             @BindsInstance rootNavigationHolder: RootNavigationHolder,
             @BindsInstance rootRouter: RootRouter,
             @BindsInstance governanceRouter: GovernanceRouter,

--- a/app/src/main/java/io/novafoundation/nova/app/root/di/RootFeatureHolder.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/di/RootFeatureHolder.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.app.root.di
 
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.navigation.navigators.staking.StakingDashboardNavigator
 import io.novafoundation.nova.common.di.FeatureApiHolder
@@ -30,7 +30,7 @@ import javax.inject.Inject
 
 @ApplicationScope
 class RootFeatureHolder @Inject constructor(
-    private val mainNavigationHolder: MainNavigationHolder,
+    private val splitScreenNavigationHolder: SplitScreenNavigationHolder,
     private val rootNavigationHolder: RootNavigationHolder,
     private val navigator: Navigator,
     private val governanceRouter: GovernanceRouter,
@@ -63,7 +63,7 @@ class RootFeatureHolder @Inject constructor(
 
         return DaggerRootComponent.factory()
             .create(
-                mainNavigationHolder,
+                splitScreenNavigationHolder,
                 rootNavigationHolder,
                 navigator,
                 governanceRouter,

--- a/app/src/main/java/io/novafoundation/nova/app/root/di/RootFeatureHolder.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/di/RootFeatureHolder.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.app.root.navigation.navigators.staking.StakingDash
 import io.novafoundation.nova.common.di.FeatureApiHolder
 import io.novafoundation.nova.common.di.FeatureContainer
 import io.novafoundation.nova.common.di.scope.ApplicationScope
+import io.novafoundation.nova.common.navigation.DelayedNavigationRouter
 import io.novafoundation.nova.core_db.di.DbApi
 import io.novafoundation.nova.feature_account_api.di.AccountFeatureApi
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
@@ -38,6 +39,7 @@ class RootFeatureHolder @Inject constructor(
     private val accountRouter: AccountRouter,
     private val assetsRouter: AssetsRouter,
     private val stakingDashboardNavigator: StakingDashboardNavigator,
+    private val delayedNavRouter: DelayedNavigationRouter,
     featureContainer: FeatureContainer
 ) : FeatureApiHolder(featureContainer) {
 
@@ -71,6 +73,7 @@ class RootFeatureHolder @Inject constructor(
                 assetsRouter,
                 accountRouter,
                 stakingDashboardNavigator,
+                delayedNavRouter,
                 rootFeatureDependencies
             )
     }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/Ext.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/Ext.kt
@@ -1,10 +1,16 @@
 package io.novafoundation.nova.app.root.navigation
 
 import android.annotation.SuppressLint
+import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph
+import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.delayedNavigation.NavComponentDelayedNavigation
+import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
+import io.novafoundation.nova.app.root.presentation.splitScreen.SplitScreenFragment
+import io.novafoundation.nova.app.root.presentation.splitScreen.SplitScreenPayload
 
 @SuppressLint("RestrictedApi")
 fun NavController.getBackStackEntryBefore(@IdRes id: Int): NavBackStackEntry {
@@ -21,4 +27,13 @@ fun NavController.getBackStackEntryBefore(@IdRes id: Int): NavBackStackEntry {
     }
 
     return backStack[previousIndex]
+}
+
+fun BaseNavigator.openSplitScreenWithInstantAction(actionId: Int, nestedActionExtras: Bundle? = null) {
+    val delayedNavigation = NavComponentDelayedNavigation(actionId, nestedActionExtras)
+
+    val splitScreenPayload = SplitScreenPayload.InstantNavigationOnAttach(delayedNavigation)
+    navigationBuilder(R.id.action_open_split_screen)
+        .setArgs(SplitScreenFragment.createPayload(splitScreenPayload))
+        .performInRoot()
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/Ext.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/Ext.kt
@@ -35,5 +35,5 @@ fun BaseNavigator.openSplitScreenWithInstantAction(actionId: Int, nestedActionEx
     val splitScreenPayload = SplitScreenPayload.InstantNavigationOnAttach(delayedNavigation)
     navigationBuilder(R.id.action_open_split_screen)
         .setArgs(SplitScreenFragment.createPayload(splitScreenPayload))
-        .performInRoot()
+        .navigateInRoot()
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/NavStackInterScreenCommunicator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/NavStackInterScreenCommunicator.kt
@@ -71,7 +71,7 @@ abstract class NavStackInterScreenCommunicator<I : Parcelable, O : Parcelable>(
             .asFlow()
     }
 
-    fun navigationBuilder(destination: Int? = null): NavigationBuilder {
+    protected fun navigationBuilder(destination: Int? = null): NavigationBuilder {
         return NavigationBuilder(navigationHoldersRegistry, destination)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/NavStackInterScreenCommunicator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/NavStackInterScreenCommunicator.kt
@@ -6,19 +6,21 @@ import androidx.lifecycle.asFlow
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationBuilder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.common.navigation.InterScreenCommunicator
 import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 abstract class NavStackInterScreenCommunicator<I : Parcelable, O : Parcelable>(
-    private val navigationHolder: NavigationHolder,
+    private val navigationHoldersRegistry: NavigationHoldersRegistry
 ) : InterScreenCommunicator<I, O> {
 
     private val responseKey = UUID.randomUUID().toString()
     private val requestKey = UUID.randomUUID().toString()
 
     protected val navController: NavController
-        get() = navigationHolder.navController!!
+        get() = navigationHoldersRegistry.firstAttachedNavController!!
 
     // from requester - retrieve from current entry
     override val latestResponse: O?
@@ -68,5 +70,9 @@ abstract class NavStackInterScreenCommunicator<I : Parcelable, O : Parcelable>(
         return navController.currentBackStackEntry!!.savedStateHandle
             .getLiveData<O>(responseKey)
             .asFlow()
+    }
+
+    fun navigationBuilder(destination: Int? = null): NavigationBuilder {
+        return NavigationBuilder(navigationHoldersRegistry, destination)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/NavStackInterScreenCommunicator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/NavStackInterScreenCommunicator.kt
@@ -5,7 +5,6 @@ import androidx.annotation.CallSuper
 import androidx.lifecycle.asFlow
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
-import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationBuilder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.common.navigation.InterScreenCommunicator

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/holders/NavigationHolder.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/holders/NavigationHolder.kt
@@ -16,6 +16,18 @@ abstract class NavigationHolder(val contextManager: ContextManager) {
         this.navController = navController
     }
 
+    /**
+     * Detaches the current navController only if it matches the one provided.
+     * This check ensures that if a new screen with a navController is attached,
+     * it doesn't lose its navController when the previous screen calls detach.
+     * By verifying equality, we prevent unintended detachment.
+     */
+    fun detachNavController(navController: NavController) {
+        if (this.navController == navController) {
+            this.navController = null
+        }
+    }
+
     fun detach() {
         navController = null
     }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/holders/SplitScreenNavigationHolder.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/holders/SplitScreenNavigationHolder.kt
@@ -2,4 +2,4 @@ package io.novafoundation.nova.app.root.navigation.holders
 
 import io.novafoundation.nova.common.resources.ContextManager
 
-class MainNavigationHolder(contextManager: ContextManager) : NavigationHolder(contextManager)
+class SplitScreenNavigationHolder(contextManager: ContextManager) : NavigationHolder(contextManager)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
@@ -67,7 +67,7 @@ class NavigationBuilder(private val navigationHolder: NavigationHolder, private 
         return this
     }
 
-    fun setExtras(extras: FragmentNavigator.Extras): NavigationBuilder {
+    fun setExtras(extras: FragmentNavigator.Extras?): NavigationBuilder {
         this.extras = extras
         return this
     }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
@@ -23,6 +23,10 @@ abstract class BaseNavigator(
         navigationHolder.executeBack()
     }
 
+    fun finishApp() {
+        navigationHolder.finishApp()
+    }
+
     fun navigationBuilder(destination: Int? = null): NavigationBuilder {
         return NavigationBuilder(navigationHolder, destination)
     }
@@ -53,7 +57,7 @@ class NavigationBuilder(private val navigationHolder: NavigationHolder, private 
         return this
     }
 
-    fun setArgs(args: Bundle): NavigationBuilder {
+    fun setArgs(args: Bundle?): NavigationBuilder {
         this.args = args
         return this
     }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
@@ -26,7 +26,7 @@ abstract class BaseNavigator(
         navigationHoldersRegistry.firstAttachedHolder.finishApp()
     }
 
-    fun navigationBuilder(destination: Int? = null): NavigationBuilder {
+    protected fun navigationBuilder(destination: Int? = null): NavigationBuilder {
         return NavigationBuilder(navigationHoldersRegistry, destination)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
@@ -1,10 +1,5 @@
 package io.novafoundation.nova.app.root.navigation.navigators
 
-import android.os.Bundle
-import androidx.navigation.NavDestination
-import androidx.navigation.NavOptions
-import androidx.navigation.fragment.FragmentNavigator
-import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
 import io.novafoundation.nova.common.navigation.ReturnableRouter
 
 abstract class BaseNavigator(
@@ -33,90 +28,5 @@ abstract class BaseNavigator(
 
     fun navigationBuilder(destination: Int? = null): NavigationBuilder {
         return NavigationBuilder(navigationHoldersRegistry, destination)
-    }
-}
-
-/**
- * Builder for navigation
- * @param navigationHoldersRegistry
- * @param actionId - action to perform or fallback when cases not found
- */
-class NavigationBuilder(
-    private val navigationHoldersRegistry: NavigationHoldersRegistry,
-    private val actionId: Int?
-) {
-
-    class Case(val destination: Int, val actionId: Int)
-
-    private val cases = mutableListOf<Case>()
-    private var fallbackCaseActionId: Int? = null
-    private var navOptions: NavOptions? = null
-    private var args: Bundle? = null
-    private var extras: FragmentNavigator.Extras? = null
-
-    fun addCase(currentDestination: Int, actionId: Int): NavigationBuilder {
-        cases.add(Case(currentDestination, actionId))
-        return this
-    }
-
-    fun setFallbackCase(actionId: Int): NavigationBuilder {
-        fallbackCaseActionId = actionId
-        return this
-    }
-
-    fun setArgs(args: Bundle?): NavigationBuilder {
-        this.args = args
-        return this
-    }
-
-    fun setNavOptions(navOptions: NavOptions): NavigationBuilder {
-        this.navOptions = navOptions
-        return this
-    }
-
-    fun setExtras(extras: FragmentNavigator.Extras?): NavigationBuilder {
-        this.extras = extras
-        return this
-    }
-
-    fun perform() {
-        performInternal(navigationHoldersRegistry.firstAttachedHolder)
-    }
-
-    fun performInRoot() {
-        performInternal(navigationHoldersRegistry.rootNavigationHolder)
-    }
-
-    private fun performInternal(navigationHolder: NavigationHolder) {
-        if (actionId == null) {
-            performCases(navigationHolder)
-        } else {
-            performAction(navigationHolder, actionId)
-        }
-    }
-
-    private fun performCases(navigationHolder: NavigationHolder) {
-        val navController = navigationHolder.navController ?: return
-        val currentDestination = navController.currentDestination ?: return
-
-        val caseActionId = cases.find { case -> case.destination == currentDestination.id }
-            ?.actionId
-            ?: fallbackCaseActionId
-            ?: throw IllegalArgumentException("Unknown case for ${currentDestination.label}")
-
-        performAction(navigationHolder, caseActionId)
-    }
-
-    private fun performAction(navigationHolder: NavigationHolder, actionId: Int) {
-        val navController = navigationHolder.navController ?: return
-        val currentDestination = navController.currentDestination ?: return
-
-        if (currentDestination.hasAction(actionId)) {
-            navigationHolder.navController?.navigate(actionId, args, navOptions, extras)
-        }
-    }
-
-    private fun NavDestination.hasAction(actionId: Int): Boolean {
-        return this.getAction(actionId) != null
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
@@ -1,49 +1,103 @@
 package io.novafoundation.nova.app.root.navigation.navigators
 
 import android.os.Bundle
-import androidx.annotation.IdRes
-import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.FragmentNavigator
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.common.navigation.ReturnableRouter
 
 abstract class BaseNavigator(
-    private val navigationHolder: NavigationHolder
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder
 ) : ReturnableRouter {
+
+    private val holders = listOf(splitScreenNavigationHolder, rootNavigationHolder)
+
+    private val navigationHolder: NavigationHolder
+        get() = holders.first { it.isAttached() }
 
     override fun back() {
         navigationHolder.executeBack()
     }
 
-    /**
-     * Performs conditional navigation based on current destination
-     * @param cases - array of pairs (currentDestination, navigationAction)
-     */
-    fun performNavigation(
-        cases: Array<Pair<Int, Int>>,
-        args: Bundle? = null
-    ) {
-        val navController = navigationHolder.navController
+    fun navigationBuilder(destination: Int? = null): NavigationBuilder {
+        return NavigationBuilder(navigationHolder, destination)
+    }
+}
 
-        navController?.currentDestination?.let { currentDestination ->
-            val (_, case) = cases.find { (startDestination, _) -> startDestination == currentDestination.id }
-                ?: throw IllegalArgumentException("Unknown case for ${currentDestination.label}")
+/**
+ * Builder for navigation
+ * @param navigationHolder
+ * @param actionId - action to perform or fallback when cases not found
+ */
+class NavigationBuilder(private val navigationHolder: NavigationHolder, private val actionId: Int?) {
 
-            currentDestination.getAction(case)?.let {
-                navController.navigate(case, args)
-            }
+    class Case(val destination: Int, val actionId: Int)
+
+    private val cases = mutableListOf<Case>()
+    private var fallbackCaseActionId: Int? = null
+    private var navOptions: NavOptions? = null
+    private var args: Bundle? = null
+    private var extras: FragmentNavigator.Extras? = null
+
+    fun addCase(currentDestination: Int, actionId: Int): NavigationBuilder {
+        cases.add(Case(currentDestination, actionId))
+        return this
+    }
+
+    fun setFallbackCase(actionId: Int): NavigationBuilder {
+        fallbackCaseActionId = actionId
+        return this
+    }
+
+    fun setArgs(args: Bundle): NavigationBuilder {
+        this.args = args
+        return this
+    }
+
+    fun setNavOptions(navOptions: NavOptions): NavigationBuilder {
+        this.navOptions = navOptions
+        return this
+    }
+
+    fun setExtras(extras: FragmentNavigator.Extras): NavigationBuilder {
+        this.extras = extras
+        return this
+    }
+
+    fun perform() {
+        if (actionId == null) {
+            performCases()
+        } else {
+            performAction(actionId)
         }
     }
 
-    protected fun performNavigation(@IdRes actionId: Int, args: Bundle? = null, extras: FragmentNavigator.Extras? = null) {
-        val navController = navigationHolder.navController
+    private fun performCases() {
+        val navController = navigationHolder.navController ?: return
+        val currentDestination = navController.currentDestination ?: return
 
-        navController?.performNavigation(actionId, args, extras)
+        val caseActionId = cases.find { case -> case.destination == currentDestination.id }
+            ?.actionId
+            ?: fallbackCaseActionId
+            ?: throw IllegalArgumentException("Unknown case for ${currentDestination.label}")
+
+        performAction(caseActionId)
     }
 
-    protected fun NavController.performNavigation(@IdRes actionId: Int, args: Bundle? = null, extras: FragmentNavigator.Extras? = null) {
-        currentDestination?.getAction(actionId)?.let {
-            navigate(actionId, args, null, extras)
+    private fun performAction(actionId: Int) {
+        val navController = navigationHolder.navController ?: return
+        val currentDestination = navController.currentDestination ?: return
+
+        if (currentDestination.hasAction(actionId)) {
+            navigationHolder.navController?.navigate(actionId, args, navOptions, extras)
         }
+    }
+
+    private fun NavDestination.hasAction(actionId: Int): Boolean {
+        return this.getAction(actionId) != null
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/BaseNavigator.kt
@@ -26,7 +26,7 @@ abstract class BaseNavigator(
         navigationHoldersRegistry.firstAttachedHolder.finishApp()
     }
 
-    protected fun navigationBuilder(destination: Int? = null): NavigationBuilder {
+    fun navigationBuilder(destination: Int? = null): NavigationBuilder {
         return NavigationBuilder(navigationHoldersRegistry, destination)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/NavigationBuilder.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/NavigationBuilder.kt
@@ -25,11 +25,15 @@ class NavigationBuilder(
     private var extras: FragmentNavigator.Extras? = null
 
     fun addCase(currentDestination: Int, actionId: Int): NavigationBuilder {
+        require(this.actionId == null)
+
         cases.add(Case(currentDestination, actionId))
         return this
     }
 
     fun setFallbackCase(actionId: Int): NavigationBuilder {
+        require(this.actionId == null)
+
         fallbackCaseActionId = actionId
         return this
     }
@@ -49,11 +53,11 @@ class NavigationBuilder(
         return this
     }
 
-    fun perform() {
+    fun navigateInFirstAttachedContext() {
         performInternal(navigationHoldersRegistry.firstAttachedHolder)
     }
 
-    fun performInRoot() {
+    fun navigateInRoot() {
         performInternal(navigationHoldersRegistry.rootNavigationHolder)
     }
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/NavigationBuilder.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/NavigationBuilder.kt
@@ -1,0 +1,92 @@
+package io.novafoundation.nova.app.root.navigation.navigators
+
+import android.os.Bundle
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.FragmentNavigator
+import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+
+/**
+ * Builder for navigation
+ * @param navigationHoldersRegistry
+ * @param actionId - action to perform or fallback when cases not found
+ */
+class NavigationBuilder(
+    private val navigationHoldersRegistry: NavigationHoldersRegistry,
+    private val actionId: Int?
+) {
+
+    class Case(val destination: Int, val actionId: Int)
+
+    private val cases = mutableListOf<Case>()
+    private var fallbackCaseActionId: Int? = null
+    private var navOptions: NavOptions? = null
+    private var args: Bundle? = null
+    private var extras: FragmentNavigator.Extras? = null
+
+    fun addCase(currentDestination: Int, actionId: Int): NavigationBuilder {
+        cases.add(Case(currentDestination, actionId))
+        return this
+    }
+
+    fun setFallbackCase(actionId: Int): NavigationBuilder {
+        fallbackCaseActionId = actionId
+        return this
+    }
+
+    fun setArgs(args: Bundle?): NavigationBuilder {
+        this.args = args
+        return this
+    }
+
+    fun setNavOptions(navOptions: NavOptions): NavigationBuilder {
+        this.navOptions = navOptions
+        return this
+    }
+
+    fun setExtras(extras: FragmentNavigator.Extras?): NavigationBuilder {
+        this.extras = extras
+        return this
+    }
+
+    fun perform() {
+        performInternal(navigationHoldersRegistry.firstAttachedHolder)
+    }
+
+    fun performInRoot() {
+        performInternal(navigationHoldersRegistry.rootNavigationHolder)
+    }
+
+    private fun performInternal(navigationHolder: NavigationHolder) {
+        if (actionId == null) {
+            performCases(navigationHolder)
+        } else {
+            performAction(navigationHolder, actionId)
+        }
+    }
+
+    private fun performCases(navigationHolder: NavigationHolder) {
+        val navController = navigationHolder.navController ?: return
+        val currentDestination = navController.currentDestination ?: return
+
+        val caseActionId = cases.find { case -> case.destination == currentDestination.id }
+            ?.actionId
+            ?: fallbackCaseActionId
+            ?: throw IllegalArgumentException("Unknown case for ${currentDestination.label}")
+
+        performAction(navigationHolder, caseActionId)
+    }
+
+    private fun performAction(navigationHolder: NavigationHolder, actionId: Int) {
+        val navController = navigationHolder.navController ?: return
+        val currentDestination = navController.currentDestination ?: return
+
+        if (currentDestination.hasAction(actionId)) {
+            navigationHolder.navController?.navigate(actionId, args, navOptions, extras)
+        }
+    }
+
+    private fun NavDestination.hasAction(actionId: Int): Boolean {
+        return this.getAction(actionId) != null
+    }
+}

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/NavigationHoldersRegistry.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/NavigationHoldersRegistry.kt
@@ -13,7 +13,7 @@ class NavigationHoldersRegistry(
     private val holders = listOf(splitScreenNavigationHolder, rootNavigationHolder)
 
     val firstAttachedHolder: NavigationHolder
-        get() = holders.first { it.isAttached() }
+        get() = holders.first { it.isControllerAttached() }
 
     val firstAttachedNavController: NavController?
         get() = firstAttachedHolder.navController

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/NavigationHoldersRegistry.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/NavigationHoldersRegistry.kt
@@ -1,0 +1,20 @@
+package io.novafoundation.nova.app.root.navigation.navigators
+
+import androidx.navigation.NavController
+import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+
+class NavigationHoldersRegistry(
+    val splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    val rootNavigationHolder: RootNavigationHolder
+) {
+
+    private val holders = listOf(splitScreenNavigationHolder, rootNavigationHolder)
+
+    val firstAttachedHolder: NavigationHolder
+        get() = holders.first { it.isAttached() }
+
+    val firstAttachedNavController: NavController?
+        get() = firstAttachedHolder.navController
+}

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
@@ -8,6 +8,7 @@ import io.novafoundation.nova.app.root.navigation.delayedNavigation.BackDelayedN
 import io.novafoundation.nova.app.root.navigation.delayedNavigation.NavComponentDelayedNavigation
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.navigation.DelayedNavigation
+import io.novafoundation.nova.common.navigation.DelayedNavigationRouter
 import io.novafoundation.nova.common.utils.getParcelableCompat
 import io.novafoundation.nova.common.utils.postToUiThread
 import io.novafoundation.nova.feature_account_api.domain.model.PolkadotVaultVariant
@@ -105,7 +106,8 @@ class Navigator(
     AccountRouter,
     AssetsRouter,
     RootRouter,
-    CrowdloanRouter {
+    CrowdloanRouter,
+    DelayedNavigationRouter {
 
     override fun openWelcomeScreen() {
         navigationBuilder()
@@ -545,7 +547,6 @@ class Navigator(
             .addCase(R.id.mainFragment, R.id.action_mainFragment_to_balanceDetailFragment)
             .addCase(R.id.assetSearchFragment, R.id.action_assetSearchFragment_to_balanceDetailFragment)
             .addCase(R.id.confirmTransferFragment, R.id.action_confirmTransferFragment_to_balanceDetailFragment)
-            .setFallbackCase(R.id.action_root_to_balanceDetailFragment)
             .setArgs(bundle)
             .perform()
     }
@@ -782,5 +783,16 @@ class Navigator(
         val delayedNavigation = NavComponentDelayedNavigation(R.id.action_open_split_screen)
         val action = PinCodeAction.Create(delayedNavigation)
         return PincodeFragment.getPinCodeBundle(action)
+    }
+
+    override fun runDelayedNavigation(delayedNavigation: DelayedNavigation) {
+        when (delayedNavigation) {
+            BackDelayedNavigation -> back()
+            is NavComponentDelayedNavigation -> {
+                navigationBuilder(delayedNavigation.globalActionId)
+                    .setArgs(delayedNavigation.extras)
+                    .perform()
+            }
+        }
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.app.root.navigation.navigators
 import android.os.Bundle
 import androidx.lifecycle.asFlow
 import androidx.navigation.NavOptions
+import androidx.navigation.fragment.FragmentNavigator
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.delayedNavigation.BackDelayedNavigation
 import io.novafoundation.nova.app.root.navigation.delayedNavigation.NavComponentDelayedNavigation
@@ -111,14 +112,6 @@ class Navigator(
     CrowdloanRouter {
 
     override fun openWelcomeScreen() {
-        /*
-        Was:
-        when (rootNavController?.currentDestination?.id) {
-            R.id.accountsFragment -> rootNavController?.navigate(R.id.action_walletManagment_to_welcome, WelcomeFragment.bundle(false))
-            R.id.splashFragment -> rootNavController?.navigate(R.id.action_splash_to_onboarding, WelcomeFragment.bundle(false))
-        }
-        */
-        // Now:
         navigationBuilder()
             .addCase(R.id.accountsFragment, R.id.action_walletManagment_to_welcome)
             .addCase(R.id.splashFragment, R.id.action_splash_to_onboarding)
@@ -129,24 +122,20 @@ class Navigator(
     override fun openInitialCheckPincode() {
         val action = PinCodeAction.Check(NavComponentDelayedNavigation(R.id.action_open_split_screen), ToolbarConfiguration())
 
-        /* Was:
-        rootNavController?.navigate(R.id.action_splash_to_pin, PincodeFragment.getPinCodeBundle(action))
-        */
-        // Now:
         navigationBuilder(R.id.action_splash_to_pin)
             .setArgs(PincodeFragment.getPinCodeBundle(action))
             .perform()
     }
 
     override fun openCreateFirstWallet() {
-        rootNavController?.navigate(
-            R.id.action_welcomeFragment_to_startCreateWallet,
-            StartCreateWalletFragment.bundle(StartCreateWalletPayload(FlowType.FIRST_WALLET))
-        )
+        navigationBuilder(R.id.action_welcomeFragment_to_startCreateWallet)
+            .setArgs(StartCreateWalletFragment.bundle(StartCreateWalletPayload(FlowType.FIRST_WALLET)))
+            .perform()
     }
 
     override fun openMain() {
-        rootNavController?.navigate(R.id.action_open_split_screen)
+        navigationBuilder(R.id.action_open_split_screen)
+            .perform()
     }
 
     override fun openAfterPinCode(delayedNavigation: DelayedNavigation) {
@@ -160,78 +149,72 @@ class Navigator(
                     .setPopExitAnim(R.anim.fragment_close_exit)
                     .build()
 
-                // TODO: need to pass a controller
-                rootNavController?.navigate(delayedNavigation.globalActionId, delayedNavigation.extras, navOptions)
+                navigationBuilder(delayedNavigation.globalActionId)
+                    .setArgs(delayedNavigation.extras)
+                    .setNavOptions(navOptions)
+                    .perform()
             }
 
-            is BackDelayedNavigation -> {
-                // TODO: need to pass a controller
-                rootNavController?.popBackStack()
-            }
+            is BackDelayedNavigation -> back()
         }
     }
 
     override fun openCreatePincode() {
-        val bundle = buildCreatePinBundle()
+        val args = buildCreatePinBundle()
 
-        when (rootNavController?.currentDestination?.id) {
-            R.id.splashFragment -> rootNavController?.navigate(R.id.action_splash_to_pin, bundle)
-            R.id.importAccountFragment -> rootNavController?.navigate(R.id.action_importAccountFragment_to_pincodeFragment, bundle)
-            R.id.confirmMnemonicFragment -> rootNavController?.navigate(R.id.action_confirmMnemonicFragment_to_pincodeFragment, bundle)
-            R.id.createWatchWalletFragment -> rootNavController?.navigate(R.id.action_watchWalletFragment_to_pincodeFragment, bundle)
-            R.id.finishImportParitySignerFragment -> rootNavController?.navigate(R.id.action_finishImportParitySignerFragment_to_pincodeFragment, bundle)
-            R.id.finishImportLedgerFragment -> rootNavController?.navigate(R.id.action_finishImportLedgerFragment_to_pincodeFragment, bundle)
-            R.id.createCloudBackupPasswordFragment -> rootNavController?.navigate(R.id.action_createCloudBackupPasswordFragment_to_pincodeFragment, bundle)
-            R.id.restoreCloudBackupFragment -> rootNavController?.navigate(R.id.action_restoreCloudBackupFragment_to_pincodeFragment, bundle)
-            R.id.finishImportGenericLedgerFragment -> rootNavController?.navigate(R.id.action_finishImportGenericLedgerFragment_to_pincodeFragment, bundle)
-        }
+        navigationBuilder()
+            .addCase(R.id.splashFragment, R.id.action_splash_to_pin)
+            .addCase(R.id.importAccountFragment, R.id.action_importAccountFragment_to_pincodeFragment)
+            .addCase(R.id.confirmMnemonicFragment, R.id.action_confirmMnemonicFragment_to_pincodeFragment)
+            .addCase(R.id.createWatchWalletFragment, R.id.action_watchWalletFragment_to_pincodeFragment)
+            .addCase(R.id.finishImportParitySignerFragment, R.id.action_finishImportParitySignerFragment_to_pincodeFragment)
+            .addCase(R.id.finishImportLedgerFragment, R.id.action_finishImportLedgerFragment_to_pincodeFragment)
+            .addCase(R.id.createCloudBackupPasswordFragment, R.id.action_createCloudBackupPasswordFragment_to_pincodeFragment)
+            .addCase(R.id.restoreCloudBackupFragment, R.id.action_restoreCloudBackupFragment_to_pincodeFragment)
+            .addCase(R.id.finishImportGenericLedgerFragment, R.id.action_finishImportGenericLedgerFragment_to_pincodeFragment)
+            .setArgs(args)
+            .perform()
     }
 
     override fun openAdvancedSettings(payload: AdvancedEncryptionModePayload) {
-        mainNavController?.navigate(R.id.action_open_advancedEncryptionFragment, AdvancedEncryptionFragment.getBundle(payload))
+        navigationBuilder(R.id.action_open_advancedEncryptionFragment)
+            .setArgs(AdvancedEncryptionFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openConfirmMnemonicOnCreate(confirmMnemonicPayload: ConfirmMnemonicPayload) {
-        val bundle = ConfirmMnemonicFragment.getBundle(confirmMnemonicPayload)
-
-        rootNavController?.navigate(
-            R.id.action_backupMnemonicFragment_to_confirmMnemonicFragment,
-            bundle
-        )
+        navigationBuilder(R.id.action_backupMnemonicFragment_to_confirmMnemonicFragment)
+            .setArgs(ConfirmMnemonicFragment.getBundle(confirmMnemonicPayload))
+            .perform()
     }
 
     override fun openImportAccountScreen(payload: ImportAccountPayload) {
-        val currentDestination = mainNavController?.currentDestination ?: return
-        val actionId = when (currentDestination.id) {
-            // Wee need the splash fragment case to close app if we use back navigation in import mnemonic screen
-            R.id.splashFragment -> R.id.action_splashFragment_to_import_nav_graph
-            else -> R.id.action_import_nav_graph
-        }
-        rootNavController?.navigate(actionId, ImportAccountFragment.getBundle(payload))
+        navigationBuilder()
+            .addCase(R.id.splashFragment, R.id.action_splashFragment_to_import_nav_graph)
+            .setFallbackCase(R.id.action_import_nav_graph)
+            .setArgs(ImportAccountFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openMnemonicScreen(accountName: String?, addAccountPayload: AddAccountPayload) {
-        val destination = when (val currentDestinationId = mainNavController?.currentDestination?.id) {
-            R.id.welcomeFragment -> R.id.action_welcomeFragment_to_mnemonic_nav_graph
-            R.id.startCreateWalletFragment -> R.id.action_startCreateWalletFragment_to_mnemonic_nav_graph
-            R.id.walletDetailsFragment -> R.id.action_accountDetailsFragment_to_mnemonic_nav_graph
-            else -> throw IllegalArgumentException("Unknown current destination to open mnemonic screen: $currentDestinationId")
-        }
-
         val payload = BackupMnemonicPayload.Create(accountName, addAccountPayload)
-        rootNavController?.navigate(destination, BackupMnemonicFragment.getBundle(payload))
+
+        navigationBuilder()
+            .addCase(R.id.welcomeFragment, R.id.action_welcomeFragment_to_mnemonic_nav_graph)
+            .addCase(R.id.startCreateWalletFragment, R.id.action_startCreateWalletFragment_to_mnemonic_nav_graph)
+            .addCase(R.id.walletDetailsFragment, R.id.action_accountDetailsFragment_to_mnemonic_nav_graph)
+            .setArgs(BackupMnemonicFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openContribute(payload: ContributePayload) {
         val bundle = CrowdloanContributeFragment.getBundle(payload)
 
-        when (mainNavController?.currentDestination?.id) {
-            R.id.mainFragment -> mainNavController?.navigate(R.id.action_mainFragment_to_crowdloanContributeFragment, bundle)
-            R.id.moonbeamCrowdloanTermsFragment -> mainNavController?.navigate(
-                R.id.action_moonbeamCrowdloanTermsFragment_to_crowdloanContributeFragment,
-                bundle
-            )
-        }
+        navigationBuilder()
+            .addCase(R.id.mainFragment, R.id.action_mainFragment_to_crowdloanContributeFragment)
+            .addCase(R.id.moonbeamCrowdloanTermsFragment, R.id.action_moonbeamCrowdloanTermsFragment_to_crowdloanContributeFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override val customBonusFlow: Flow<BonusPayload?>
@@ -244,7 +227,9 @@ class Navigator(
             .get(CrowdloanContributeFragment.KEY_BONUS_LIVE_DATA)
 
     override fun openCustomContribute(payload: CustomContributePayload) {
-        mainNavController?.navigate(R.id.action_crowdloanContributeFragment_to_customContributeFragment, CustomContributeFragment.getBundle(payload))
+        navigationBuilder(R.id.action_crowdloanContributeFragment_to_customContributeFragment)
+            .setArgs(CustomContributeFragment.getBundle(payload))
+            .perform()
     }
 
     override fun setCustomBonus(payload: BonusPayload) {
@@ -252,148 +237,178 @@ class Navigator(
     }
 
     override fun openConfirmContribute(payload: ConfirmContributePayload) {
-        mainNavController?.navigate(R.id.action_crowdloanContributeFragment_to_confirmContributeFragment, ConfirmContributeFragment.getBundle(payload))
-    }
-
-    /*
-    When we open some screen in root host then main navigation controller is detaching from its holder
-    So in this case we must execute back for root controller
-    */
-    override fun back() {
-        if (mainNavigationHolder.isAttached()) {
-            mainNavigationHolder.executeBack()
-        } else {
-            rootNavigationHolder.executeBack()
-        }
+        navigationBuilder(R.id.action_crowdloanContributeFragment_to_confirmContributeFragment)
+            .setArgs(ConfirmContributeFragment.getBundle(payload))
+            .perform()
     }
 
     override fun returnToMain() {
-        mainNavController?.navigate(R.id.back_to_main)
+        navigationBuilder(R.id.back_to_main)
+            .perform()
     }
 
     override fun openMoonbeamFlow(payload: ContributePayload) {
-        mainNavController?.navigate(R.id.action_mainFragment_to_moonbeamCrowdloanTermsFragment, MoonbeamCrowdloanTermsFragment.getBundle(payload))
+        navigationBuilder(R.id.action_mainFragment_to_moonbeamCrowdloanTermsFragment)
+            .setArgs(MoonbeamCrowdloanTermsFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openAddAccount(payload: AddAccountPayload) {
-        mainNavController?.navigate(R.id.action_open_onboarding, WelcomeFragment.bundle(payload))
+        navigationBuilder(R.id.action_open_onboarding)
+            .setArgs(WelcomeFragment.bundle(payload))
+            .perform()
     }
 
-    override fun openFilter(payload: TransactionHistoryFilterPayload) = performNavigation(
-        actionId = R.id.action_mainFragment_to_filterFragment,
-        args = TransactionHistoryFilterFragment.getBundle(payload)
-    )
+    override fun openFilter(payload: TransactionHistoryFilterPayload) {
+        navigationBuilder(R.id.action_mainFragment_to_filterFragment)
+            .setArgs(TransactionHistoryFilterFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openSend(payload: SendPayload, initialRecipientAddress: String?) {
         val extras = SelectSendFragment.getBundle(payload, initialRecipientAddress)
 
-        mainNavController?.navigate(R.id.action_open_send, extras)
+        navigationBuilder(R.id.action_open_send)
+            .setArgs(extras)
+            .perform()
     }
 
     override fun openConfirmTransfer(transferDraft: TransferDraft) {
         val bundle = ConfirmSendFragment.getBundle(transferDraft)
 
-        mainNavController?.navigate(R.id.action_chooseAmountFragment_to_confirmTransferFragment, bundle)
+        navigationBuilder(R.id.action_chooseAmountFragment_to_confirmTransferFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openTransferDetail(transaction: OperationParcelizeModel.Transfer) {
         val bundle = TransferDetailFragment.getBundle(transaction)
 
-        mainNavController?.navigate(R.id.open_transfer_detail, bundle)
+        navigationBuilder(R.id.open_transfer_detail)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openRewardDetail(reward: OperationParcelizeModel.Reward) {
         val bundle = RewardDetailFragment.getBundle(reward)
 
-        mainNavController?.navigate(R.id.open_reward_detail, bundle)
+        navigationBuilder(R.id.open_reward_detail)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openPoolRewardDetail(reward: OperationParcelizeModel.PoolReward) {
         val bundle = PoolRewardDetailFragment.getBundle(reward)
 
-        mainNavController?.navigate(R.id.open_pool_reward_detail, bundle)
+        navigationBuilder(R.id.open_pool_reward_detail)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openSwapDetail(swap: OperationParcelizeModel.Swap) {
         val bundle = SwapDetailFragment.getBundle(swap)
 
-        mainNavController?.navigate(R.id.open_swap_detail, bundle)
+        navigationBuilder(R.id.open_swap_detail)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openExtrinsicDetail(extrinsic: OperationParcelizeModel.Extrinsic) {
-        val bundle = ExtrinsicDetailFragment.getBundle(extrinsic)
-
-        mainNavController?.navigate(R.id.open_extrinsic_detail, bundle)
+        navigationBuilder(R.id.open_extrinsic_detail)
+            .setArgs(ExtrinsicDetailFragment.getBundle(extrinsic))
+            .perform()
     }
 
     override fun openWallets() {
-        mainNavController?.navigate(R.id.action_open_accounts)
+        navigationBuilder(R.id.action_open_accounts)
+            .perform()
     }
 
     override fun openSwitchWallet() {
-        mainNavController?.navigate(R.id.action_open_switch_wallet)
+        navigationBuilder(R.id.action_open_switch_wallet)
+            .perform()
     }
 
     override fun openDelegatedAccountsUpdates() {
-        mainNavController?.navigate(R.id.action_switchWalletFragment_to_delegatedAccountUpdates)
+        navigationBuilder(R.id.action_switchWalletFragment_to_delegatedAccountUpdates)
+            .perform()
     }
 
     override fun openSelectAddress(arguments: Bundle) {
-        mainNavController?.navigate(R.id.action_open_select_address, arguments)
+        navigationBuilder(R.id.action_open_select_address)
+            .setArgs(arguments)
+            .perform()
     }
 
     override fun openSelectMultipleWallets(arguments: Bundle) {
-        mainNavController?.navigate(R.id.action_open_select_multiple_wallets, arguments)
+        navigationBuilder(R.id.action_open_select_multiple_wallets)
+            .setArgs(arguments)
+            .perform()
     }
 
     override fun openNodes() {
-        mainNavController?.navigate(R.id.action_mainFragment_to_nodesFragment)
+        navigationBuilder(R.id.action_mainFragment_to_nodesFragment)
+            .perform()
     }
 
     override fun openReceive(assetPayload: AssetPayload) {
-        mainNavController?.navigate(R.id.action_open_receive, ReceiveFragment.getBundle(assetPayload))
+        navigationBuilder(R.id.action_open_receive)
+            .setArgs(ReceiveFragment.getBundle(assetPayload))
+            .perform()
     }
 
     override fun openAssetSearch() {
-        mainNavController?.navigate(R.id.action_mainFragment_to_assetSearchFragment)
+        navigationBuilder(R.id.action_mainFragment_to_assetSearchFragment)
+            .perform()
     }
 
     override fun openManageTokens() {
-        mainNavController?.navigate(R.id.action_mainFragment_to_manageTokensGraph)
+        navigationBuilder(R.id.action_mainFragment_to_manageTokensGraph)
+            .perform()
     }
 
     override fun openManageChainTokens(payload: ManageChainTokensPayload) {
         val args = ManageChainTokensFragment.getBundle(payload)
-        mainNavController?.navigate(R.id.action_manageTokensFragment_to_manageChainTokensFragment, args)
+        navigationBuilder(R.id.action_manageTokensFragment_to_manageChainTokensFragment)
+            .setArgs(args)
+            .perform()
     }
 
     override fun openAddTokenSelectChain() {
-        mainNavController?.navigate(R.id.action_manageTokensFragment_to_addTokenSelectChainFragment)
+        navigationBuilder(R.id.action_manageTokensFragment_to_addTokenSelectChainFragment)
+            .perform()
     }
 
     override fun openSendFlow() {
-        mainNavController?.navigate(R.id.action_mainFragment_to_sendFlow)
+        navigationBuilder(R.id.action_mainFragment_to_sendFlow)
+            .perform()
     }
 
     override fun openReceiveFlow() {
-        mainNavController?.navigate(R.id.action_mainFragment_to_receiveFlow)
+        navigationBuilder(R.id.action_mainFragment_to_receiveFlow)
+            .perform()
     }
 
     override fun openBuyFlow() {
-        mainNavController?.navigate(R.id.action_mainFragment_to_buyFlow)
+        navigationBuilder(R.id.action_mainFragment_to_buyFlow)
+            .perform()
     }
 
     override fun openBuyFlowFromSendFlow() {
-        mainNavController?.navigate(R.id.action_sendFlow_to_buyFlow)
+        navigationBuilder(R.id.action_sendFlow_to_buyFlow)
+            .perform()
     }
 
     override fun openAddTokenEnterInfo(payload: AddTokenEnterInfoPayload) {
         val args = AddTokenEnterInfoFragment.getBundle(payload)
-        mainNavController?.navigate(R.id.action_addTokenSelectChainFragment_to_addTokenEnterInfoFragment, args)
+        navigationBuilder(R.id.action_addTokenSelectChainFragment_to_addTokenEnterInfoFragment)
+            .setArgs(args)
+            .perform()
     }
 
     override fun finishAddTokenFlow() {
-        mainNavController?.navigate(R.id.finish_add_token_flow)
+        navigationBuilder(R.id.finish_add_token_flow)
+            .perform()
     }
 
     override fun openWalletConnectSessions(metaId: Long) {
@@ -411,40 +426,55 @@ class Navigator(
     }
 
     override fun closeSendFlow() {
-        mainNavController?.navigate(R.id.action_close_send_flow)
+        navigationBuilder(R.id.action_close_send_flow)
+            .perform()
     }
 
     override fun openSendNetworks(payload: NetworkFlowPayload) {
-        mainNavController?.navigate(R.id.action_sendFlow_to_sendFlowNetwork, NetworkFlowFragment.createPayload(payload))
+        navigationBuilder(R.id.action_sendFlow_to_sendFlowNetwork)
+            .setArgs(NetworkFlowFragment.createPayload(payload))
+            .perform()
     }
 
     override fun openReceiveNetworks(payload: NetworkFlowPayload) {
-        mainNavController?.navigate(R.id.action_receiveFlow_to_receiveFlowNetwork, NetworkFlowFragment.createPayload(payload))
+        navigationBuilder(R.id.action_receiveFlow_to_receiveFlowNetwork)
+            .setArgs(NetworkFlowFragment.createPayload(payload))
+            .perform()
     }
 
     override fun openSwapNetworks(payload: NetworkSwapFlowPayload) {
-        mainNavController?.navigate(R.id.action_selectAssetSwapFlowFragment_to_swapFlowNetworkFragment, NetworkSwapFlowFragment.createPayload(payload))
+        navigationBuilder(R.id.action_selectAssetSwapFlowFragment_to_swapFlowNetworkFragment)
+            .setArgs(NetworkSwapFlowFragment.createPayload(payload))
+            .perform()
     }
 
     override fun openBuyNetworks(payload: NetworkFlowPayload) {
-        mainNavController?.navigate(R.id.action_buyFlow_to_buyFlowNetwork, NetworkFlowFragment.createPayload(payload))
+        navigationBuilder(R.id.action_buyFlow_to_buyFlowNetwork)
+            .setArgs(NetworkFlowFragment.createPayload(payload))
+            .perform()
     }
 
     override fun returnToMainSwapScreen() {
-        mainNavController?.navigate(R.id.action_return_to_swap_settings)
+        navigationBuilder(R.id.action_return_to_swap_settings)
+            .perform()
     }
 
     override fun openSwapFlow() {
         val payload = SwapFlowPayload.InitialSelecting
-        mainNavController?.navigate(R.id.action_mainFragment_to_swapFlow, AssetSwapFlowFragment.getBundle(payload))
+        navigationBuilder(R.id.action_mainFragment_to_swapFlow)
+            .setArgs(AssetSwapFlowFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openSwapSetupAmount(swapSettingsPayload: SwapSettingsPayload) {
-        mainNavController?.navigate(R.id.action_open_swapSetupAmount, SwapMainSettingsFragment.getBundle(swapSettingsPayload))
+        navigationBuilder(R.id.action_open_swapSetupAmount)
+            .setArgs(SwapMainSettingsFragment.getBundle(swapSettingsPayload))
+            .perform()
     }
 
     override fun openNfts() {
-        mainNavController?.navigate(R.id.action_mainFragment_to_nfts_nav_graph)
+        navigationBuilder(R.id.action_mainFragment_to_nfts_nav_graph)
+            .perform()
     }
 
     override fun nonCancellableVerify() {
@@ -469,63 +499,76 @@ class Navigator(
     }
 
     override fun openUpdateNotifications() {
-        mainNavController?.navigate(R.id.action_open_update_notifications)
+        navigationBuilder(R.id.action_open_update_notifications)
+            .perform()
     }
 
     override fun openPushWelcome() {
-        performNavigation(R.id.action_open_pushNotificationsWelcome)
+        navigationBuilder(R.id.action_open_pushNotificationsWelcome)
+            .perform()
     }
 
     override fun openCloudBackupSettings() {
-        performNavigation(R.id.action_open_cloudBackupSettings)
+        navigationBuilder(R.id.action_open_cloudBackupSettings)
+            .perform()
     }
 
     override fun returnToWallet() {
         // to achieve smooth animation
         postToUiThread {
-            mainNavController?.navigate(R.id.action_return_to_wallet)
+            navigationBuilder(R.id.action_return_to_wallet)
+                .perform()
         }
     }
 
     override fun openWalletDetails(metaId: Long) {
         val extras = WalletDetailsFragment.getBundle(metaId)
-
-        mainNavController?.navigate(R.id.action_open_account_details, extras)
+        navigationBuilder(R.id.action_open_account_details)
+            .setArgs(extras)
+            .perform()
     }
 
     override fun openNodeDetails(nodeId: Int) {
-        mainNavController?.navigate(R.id.action_nodesFragment_to_nodeDetailsFragment, NodeDetailsFragment.getBundle(nodeId))
+        val extras = NodeDetailsFragment.getBundle(nodeId)
+        navigationBuilder(R.id.action_nodesFragment_to_nodeDetailsFragment)
+            .setArgs(extras)
+            .perform()
     }
 
     override fun openAssetDetails(assetPayload: AssetPayload) {
         val bundle = BalanceDetailFragment.getBundle(assetPayload)
 
-        val action = when (mainNavController?.currentDestination?.id) {
-            R.id.mainFragment -> R.id.action_mainFragment_to_balanceDetailFragment
-            R.id.assetSearchFragment -> R.id.action_assetSearchFragment_to_balanceDetailFragment
-            R.id.confirmTransferFragment -> R.id.action_confirmTransferFragment_to_balanceDetailFragment
-            else -> R.id.action_root_to_balanceDetailFragment
-        }
-
-        mainNavController?.navigate(action, bundle)
+        navigationBuilder()
+            .addCase(R.id.mainFragment, R.id.action_mainFragment_to_balanceDetailFragment)
+            .addCase(R.id.assetSearchFragment, R.id.action_assetSearchFragment_to_balanceDetailFragment)
+            .addCase(R.id.confirmTransferFragment, R.id.action_confirmTransferFragment_to_balanceDetailFragment)
+            .setFallbackCase(R.id.action_root_to_balanceDetailFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openAddNode() {
-        mainNavController?.navigate(R.id.action_nodesFragment_to_addNodeFragment)
+        navigationBuilder(R.id.action_nodesFragment_to_addNodeFragment)
+            .perform()
     }
 
     override fun openChangeWatchAccount(payload: AddAccountPayload.ChainAccount) {
         val bundle = ChangeWatchAccountFragment.getBundle(payload)
 
-        mainNavController?.navigate(R.id.action_accountDetailsFragment_to_changeWatchAccountFragment, bundle)
+        navigationBuilder(R.id.action_accountDetailsFragment_to_changeWatchAccountFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openCreateWallet(payload: StartCreateWalletPayload) {
-        mainNavController?.navigate(R.id.action_open_create_new_wallet, StartCreateWalletFragment.bundle(payload))
+        navigationBuilder(R.id.action_open_create_new_wallet)
+            .setArgs(StartCreateWalletFragment.bundle(payload))
+            .perform()
     }
 
     override fun openUserContributions() {
-        mainNavController?.navigate(R.id.action_mainFragment_to_userContributionsFragment)
+        navigationBuilder(R.id.action_mainFragment_to_userContributionsFragment)
+            .perform()
     }
 
     override fun getExportMnemonicDelayedNavigation(exportPayload: ExportPayload.ChainAccount): DelayedNavigation {
@@ -550,82 +593,102 @@ class Navigator(
     override fun exportJsonAction(exportPayload: ExportPayload) {
         val extras = ExportJsonFragment.getBundle(exportPayload)
 
-        mainNavController?.navigate(R.id.action_export_json, extras)
+        navigationBuilder(R.id.action_export_json)
+            .setArgs(extras)
+            .perform()
     }
 
     override fun finishExportFlow() {
-        mainNavController?.navigate(R.id.finish_export_flow)
+        navigationBuilder(R.id.finish_export_flow)
+            .perform()
     }
 
     override fun openScanImportParitySigner(payload: ParitySignerStartPayload) {
         val args = ScanImportParitySignerFragment.getBundle(payload)
-        mainNavController?.navigate(R.id.action_startImportParitySignerFragment_to_scanImportParitySignerFragment, args)
+
+        navigationBuilder(R.id.action_startImportParitySignerFragment_to_scanImportParitySignerFragment)
+            .setArgs(args)
+            .perform()
     }
 
     override fun openPreviewImportParitySigner(payload: ParitySignerAccountPayload) {
         val bundle = PreviewImportParitySignerFragment.getBundle(payload)
 
-        mainNavController?.navigate(R.id.action_scanImportParitySignerFragment_to_previewImportParitySignerFragment, bundle)
+        navigationBuilder(R.id.action_scanImportParitySignerFragment_to_previewImportParitySignerFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openFinishImportParitySigner(payload: ParitySignerAccountPayload) {
         val bundle = FinishImportParitySignerFragment.getBundle(payload)
 
-        mainNavController?.navigate(R.id.action_previewImportParitySignerFragment_to_finishImportParitySignerFragment, bundle)
+        navigationBuilder(R.id.action_previewImportParitySignerFragment_to_finishImportParitySignerFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openScanParitySignerSignature(payload: ScanSignParitySignerPayload) {
         val bundle = ScanSignParitySignerFragment.getBundle(payload)
 
-        mainNavController?.navigate(R.id.action_showSignParitySignerFragment_to_scanSignParitySignerFragment, bundle)
+        navigationBuilder(R.id.action_showSignParitySignerFragment_to_scanSignParitySignerFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun finishParitySignerFlow() {
-        mainNavController?.navigate(R.id.action_finish_parity_signer_flow)
+        navigationBuilder(R.id.action_finish_parity_signer_flow)
+            .perform()
     }
 
     override fun openAddLedgerChainAccountFlow(payload: AddAccountPayload.ChainAccount) {
         val bundle = AddChainAccountSelectLedgerFragment.getBundle(payload)
 
-        mainNavController?.navigate(R.id.action_accountDetailsFragment_to_addLedgerAccountGraph, bundle)
-    }
-
-    override fun finishApp() {
-        mainNavigationHolder.finishApp()
+        navigationBuilder(R.id.action_accountDetailsFragment_to_addLedgerAccountGraph)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openCreateCloudBackupPassword(walletName: String) {
         val bundle = CreateWalletBackupPasswordFragment.getBundle(CreateBackupPasswordPayload(walletName))
 
-        mainNavController?.navigate(R.id.action_startCreateWalletFragment_to_createCloudBackupPasswordFragment, bundle)
+        navigationBuilder(R.id.action_startCreateWalletFragment_to_createCloudBackupPasswordFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun restoreCloudBackup() {
-        when (mainNavController?.currentDestination?.id) {
-            R.id.importWalletOptionsFragment -> mainNavController?.navigate(R.id.action_importWalletOptionsFragment_to_restoreCloudBackup)
-            R.id.startCreateWalletFragment -> mainNavController?.navigate(R.id.action_startCreateWalletFragment_to_resotreCloudBackupFragment)
-        }
+        navigationBuilder()
+            .addCase(R.id.importWalletOptionsFragment, R.id.action_importWalletOptionsFragment_to_restoreCloudBackup)
+            .addCase(R.id.startCreateWalletFragment, R.id.action_startCreateWalletFragment_to_resotreCloudBackupFragment)
+            .perform()
     }
 
     override fun openSyncWalletsBackupPassword() {
-        performNavigation(R.id.action_cloudBackupSettings_to_syncWalletsBackupPasswordFragment)
+        navigationBuilder(R.id.action_cloudBackupSettings_to_syncWalletsBackupPasswordFragment)
+            .perform()
     }
 
     override fun openChangeBackupPasswordFlow() {
-        performNavigation(R.id.action_cloudBackupSettings_to_checkCloudBackupPasswordFragment)
+        navigationBuilder(R.id.action_cloudBackupSettings_to_checkCloudBackupPasswordFragment)
+            .perform()
     }
 
     override fun openRestoreBackupPassword() {
-        performNavigation(R.id.action_cloudBackupSettings_to_restoreCloudBackupPasswordFragment)
+        navigationBuilder(R.id.action_cloudBackupSettings_to_restoreCloudBackupPasswordFragment)
+            .perform()
     }
 
     override fun openChangeBackupPassword() {
-        performNavigation(R.id.action_checkCloudBackupPasswordFragment_to_changeBackupPasswordFragment)
+        navigationBuilder(R.id.action_checkCloudBackupPasswordFragment_to_changeBackupPasswordFragment)
+            .perform()
     }
 
     override fun openManualBackupSelectAccount(metaId: Long) {
         val bundle = ManualBackupSelectAccountFragment.bundle(ManualBackupSelectAccountPayload(metaId))
-        performNavigation(R.id.action_manualBackupSelectWalletFragment_to_manualBackupSelectAccountFragment, bundle)
+
+        navigationBuilder(R.id.action_manualBackupSelectWalletFragment_to_manualBackupSelectAccountFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openManualBackupConditions(payload: ManualBackupCommonPayload) {
@@ -637,27 +700,30 @@ class Navigator(
         )
         val pinCodeBundle = PincodeFragment.getPinCodeBundle(pinCodePayload)
 
-        performNavigation(
-            cases = arrayOf(
-                R.id.manualBackupSelectWallet to R.id.action_manualBackupSelectWallet_to_pincode_check,
-                R.id.manualBackupSelectAccount to R.id.action_manualBackupSelectAccount_to_pincode_check
-            ),
-            args = pinCodeBundle
-        )
+        navigationBuilder()
+            .addCase(R.id.manualBackupSelectWallet, R.id.action_manualBackupSelectWallet_to_pincode_check)
+            .addCase(R.id.manualBackupSelectAccount, R.id.action_manualBackupSelectAccount_to_pincode_check)
+            .setArgs(pinCodeBundle)
+            .perform()
     }
 
     override fun openManualBackupSecrets(payload: ManualBackupCommonPayload) {
         val bundle = ManualBackupSecretsFragment.bundle(payload)
-        performNavigation(R.id.action_manualBackupWarning_to_manualBackupSecrets, bundle)
+        navigationBuilder(R.id.action_manualBackupWarning_to_manualBackupSecrets)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openManualBackupAdvancedSecrets(payload: ManualBackupCommonPayload) {
         val bundle = ManualBackupAdvancedSecretsFragment.bundle(payload)
-        performNavigation(R.id.action_manualBackupSecrets_to_manualBackupAdvancedSecrets, bundle)
+        navigationBuilder(R.id.action_manualBackupSecrets_to_manualBackupAdvancedSecrets)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openCreateWatchWallet() {
-        rootNavController?.navigate(R.id.action_importWalletOptionsFragment_to_createWatchWalletFragment)
+        navigationBuilder(R.id.action_importWalletOptionsFragment_to_createWatchWalletFragment)
+            .perform()
     }
 
     override fun openStartImportParitySigner() {
@@ -669,18 +735,20 @@ class Navigator(
     }
 
     override fun openImportOptionsScreen() {
-        when (rootNavController?.currentDestination?.id) {
-            R.id.welcomeFragment -> rootNavController?.navigate(R.id.action_welcomeFragment_to_importWalletOptionsFragment)
-            else -> rootNavController?.navigate(R.id.action_importWalletOptionsFragment)
-        }
+        navigationBuilder()
+            .addCase(R.id.welcomeFragment, R.id.action_welcomeFragment_to_importWalletOptionsFragment)
+            .setFallbackCase(R.id.action_importWalletOptionsFragment)
+            .perform()
     }
 
     override fun openStartImportLegacyLedger() {
-        mainNavController?.navigate(R.id.action_importWalletOptionsFragment_to_import_legacy_ledger_graph)
+        navigationBuilder(R.id.action_importWalletOptionsFragment_to_import_legacy_ledger_graph)
+            .perform()
     }
 
     override fun openStartImportGenericLedger() {
-        mainNavController?.navigate(R.id.action_importWalletOptionsFragment_to_import_generic_ledger_graph)
+        navigationBuilder(R.id.action_importWalletOptionsFragment_to_import_generic_ledger_graph)
+            .perform()
     }
 
     override fun withPinCodeCheckRequired(
@@ -694,14 +762,17 @@ class Navigator(
             PinCodeAction.Check(delayedNavigation, ToolbarConfiguration(pinCodeTitleRes, true))
         }
 
-        val extras = PincodeFragment.getPinCodeBundle(action)
-
-        rootNavController?.navigate(R.id.open_pincode_check, extras)
+        navigationBuilder(R.id.open_pincode_check)
+            .setArgs(PincodeFragment.getPinCodeBundle(action))
+            .perform()
     }
 
     private fun openStartImportPolkadotVault(variant: PolkadotVaultVariant) {
         val args = StartImportParitySignerFragment.getBundle(ParitySignerStartPayload(variant))
-        mainNavController?.navigate(R.id.action_importWalletOptionsFragment_to_import_parity_signer_graph, args)
+
+        navigationBuilder(R.id.action_importWalletOptionsFragment_to_import_parity_signer_graph)
+            .setArgs(args)
+            .perform()
     }
 
     private fun buildCreatePinBundle(): Bundle {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
@@ -3,7 +3,6 @@ package io.novafoundation.nova.app.root.navigation.navigators
 import android.os.Bundle
 import androidx.lifecycle.asFlow
 import androidx.navigation.NavOptions
-import androidx.navigation.fragment.FragmentNavigator
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.delayedNavigation.BackDelayedNavigation
 import io.novafoundation.nova.app.root.navigation.delayedNavigation.NavComponentDelayedNavigation

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
@@ -114,7 +114,7 @@ class Navigator(
             .addCase(R.id.accountsFragment, R.id.action_walletManagment_to_welcome)
             .addCase(R.id.splashFragment, R.id.action_splash_to_onboarding)
             .setArgs(WelcomeFragment.bundle(false))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openInitialCheckPincode() {
@@ -122,18 +122,18 @@ class Navigator(
 
         navigationBuilder(R.id.action_splash_to_pin)
             .setArgs(PincodeFragment.getPinCodeBundle(action))
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun openCreateFirstWallet() {
         navigationBuilder(R.id.action_welcomeFragment_to_startCreateWallet)
             .setArgs(StartCreateWalletFragment.bundle(StartCreateWalletPayload(FlowType.FIRST_WALLET)))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openMain() {
         navigationBuilder(R.id.action_open_split_screen)
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun openAfterPinCode(delayedNavigation: DelayedNavigation) {
@@ -150,7 +150,7 @@ class Navigator(
                 navigationBuilder(delayedNavigation.globalActionId)
                     .setArgs(delayedNavigation.extras)
                     .setNavOptions(navOptions)
-                    .perform()
+                    .navigateInFirstAttachedContext()
             }
 
             is BackDelayedNavigation -> back()
@@ -171,19 +171,19 @@ class Navigator(
             .addCase(R.id.restoreCloudBackupFragment, R.id.action_restoreCloudBackupFragment_to_pincodeFragment)
             .addCase(R.id.finishImportGenericLedgerFragment, R.id.action_finishImportGenericLedgerFragment_to_pincodeFragment)
             .setArgs(args)
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun openAdvancedSettings(payload: AdvancedEncryptionModePayload) {
         navigationBuilder(R.id.action_open_advancedEncryptionFragment)
             .setArgs(AdvancedEncryptionFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmMnemonicOnCreate(confirmMnemonicPayload: ConfirmMnemonicPayload) {
         navigationBuilder(R.id.action_backupMnemonicFragment_to_confirmMnemonicFragment)
             .setArgs(ConfirmMnemonicFragment.getBundle(confirmMnemonicPayload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openImportAccountScreen(payload: ImportAccountPayload) {
@@ -191,7 +191,7 @@ class Navigator(
             .addCase(R.id.splashFragment, R.id.action_splashFragment_to_import_nav_graph)
             .setFallbackCase(R.id.action_import_nav_graph)
             .setArgs(ImportAccountFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openMnemonicScreen(accountName: String?, addAccountPayload: AddAccountPayload) {
@@ -202,7 +202,7 @@ class Navigator(
             .addCase(R.id.startCreateWalletFragment, R.id.action_startCreateWalletFragment_to_mnemonic_nav_graph)
             .addCase(R.id.walletDetailsFragment, R.id.action_accountDetailsFragment_to_mnemonic_nav_graph)
             .setArgs(BackupMnemonicFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openContribute(payload: ContributePayload) {
@@ -212,7 +212,7 @@ class Navigator(
             .addCase(R.id.mainFragment, R.id.action_mainFragment_to_crowdloanContributeFragment)
             .addCase(R.id.moonbeamCrowdloanTermsFragment, R.id.action_moonbeamCrowdloanTermsFragment_to_crowdloanContributeFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     @Deprecated("TODO: Use communicator api instead")
@@ -229,7 +229,7 @@ class Navigator(
     override fun openCustomContribute(payload: CustomContributePayload) {
         navigationBuilder(R.id.action_crowdloanContributeFragment_to_customContributeFragment)
             .setArgs(CustomContributeFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     @Deprecated("TODO: Use communicator api instead")
@@ -240,30 +240,30 @@ class Navigator(
     override fun openConfirmContribute(payload: ConfirmContributePayload) {
         navigationBuilder(R.id.action_crowdloanContributeFragment_to_confirmContributeFragment)
             .setArgs(ConfirmContributeFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun returnToMain() {
         navigationBuilder(R.id.back_to_main)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openMoonbeamFlow(payload: ContributePayload) {
         navigationBuilder(R.id.action_mainFragment_to_moonbeamCrowdloanTermsFragment)
             .setArgs(MoonbeamCrowdloanTermsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAddAccount(payload: AddAccountPayload) {
         navigationBuilder(R.id.action_open_onboarding)
             .setArgs(WelcomeFragment.bundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openFilter(payload: TransactionHistoryFilterPayload) {
         navigationBuilder(R.id.action_mainFragment_to_filterFragment)
             .setArgs(TransactionHistoryFilterFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSend(payload: SendPayload, initialRecipientAddress: String?) {
@@ -271,7 +271,7 @@ class Navigator(
 
         navigationBuilder(R.id.action_open_send)
             .setArgs(extras)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmTransfer(transferDraft: TransferDraft) {
@@ -279,7 +279,7 @@ class Navigator(
 
         navigationBuilder(R.id.action_chooseAmountFragment_to_confirmTransferFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openTransferDetail(transaction: OperationParcelizeModel.Transfer) {
@@ -287,7 +287,7 @@ class Navigator(
 
         navigationBuilder(R.id.open_transfer_detail)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRewardDetail(reward: OperationParcelizeModel.Reward) {
@@ -295,7 +295,7 @@ class Navigator(
 
         navigationBuilder(R.id.open_reward_detail)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openPoolRewardDetail(reward: OperationParcelizeModel.PoolReward) {
@@ -303,7 +303,7 @@ class Navigator(
 
         navigationBuilder(R.id.open_pool_reward_detail)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSwapDetail(swap: OperationParcelizeModel.Swap) {
@@ -311,105 +311,105 @@ class Navigator(
 
         navigationBuilder(R.id.open_swap_detail)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openExtrinsicDetail(extrinsic: OperationParcelizeModel.Extrinsic) {
         navigationBuilder(R.id.open_extrinsic_detail)
             .setArgs(ExtrinsicDetailFragment.getBundle(extrinsic))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openWallets() {
         navigationBuilder(R.id.action_open_accounts)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSwitchWallet() {
         navigationBuilder(R.id.action_open_switch_wallet)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openDelegatedAccountsUpdates() {
         navigationBuilder(R.id.action_switchWalletFragment_to_delegatedAccountUpdates)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectAddress(arguments: Bundle) {
         navigationBuilder(R.id.action_open_select_address)
             .setArgs(arguments)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectMultipleWallets(arguments: Bundle) {
         navigationBuilder(R.id.action_open_select_multiple_wallets)
             .setArgs(arguments)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openNodes() {
         navigationBuilder(R.id.action_mainFragment_to_nodesFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReceive(assetPayload: AssetPayload) {
         navigationBuilder(R.id.action_open_receive)
             .setArgs(ReceiveFragment.getBundle(assetPayload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAssetSearch() {
         navigationBuilder(R.id.action_mainFragment_to_assetSearchFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openManageTokens() {
         navigationBuilder(R.id.action_mainFragment_to_manageTokensGraph)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openManageChainTokens(payload: ManageChainTokensPayload) {
         val args = ManageChainTokensFragment.getBundle(payload)
         navigationBuilder(R.id.action_manageTokensFragment_to_manageChainTokensFragment)
             .setArgs(args)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAddTokenSelectChain() {
         navigationBuilder(R.id.action_manageTokensFragment_to_addTokenSelectChainFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSendFlow() {
         navigationBuilder(R.id.action_mainFragment_to_sendFlow)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReceiveFlow() {
         navigationBuilder(R.id.action_mainFragment_to_receiveFlow)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openBuyFlow() {
         navigationBuilder(R.id.action_mainFragment_to_buyFlow)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openBuyFlowFromSendFlow() {
         navigationBuilder(R.id.action_sendFlow_to_buyFlow)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAddTokenEnterInfo(payload: AddTokenEnterInfoPayload) {
         val args = AddTokenEnterInfoFragment.getBundle(payload)
         navigationBuilder(R.id.action_addTokenSelectChainFragment_to_addTokenEnterInfoFragment)
             .setArgs(args)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishAddTokenFlow() {
         navigationBuilder(R.id.finish_add_token_flow)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openWalletConnectSessions(metaId: Long) {
@@ -423,7 +423,7 @@ class Navigator(
     override fun openStaking() {
         if (currentDestination?.id != R.id.mainFragment) {
             navigationBuilder(R.id.action_open_split_screen)
-                .perform()
+                .navigateInFirstAttachedContext()
         }
 
         stakingDashboardDelegate.openStakingDashboard()
@@ -431,54 +431,54 @@ class Navigator(
 
     override fun closeSendFlow() {
         navigationBuilder(R.id.action_close_send_flow)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSendNetworks(payload: NetworkFlowPayload) {
         navigationBuilder(R.id.action_sendFlow_to_sendFlowNetwork)
             .setArgs(NetworkFlowFragment.createPayload(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReceiveNetworks(payload: NetworkFlowPayload) {
         navigationBuilder(R.id.action_receiveFlow_to_receiveFlowNetwork)
             .setArgs(NetworkFlowFragment.createPayload(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSwapNetworks(payload: NetworkSwapFlowPayload) {
         navigationBuilder(R.id.action_selectAssetSwapFlowFragment_to_swapFlowNetworkFragment)
             .setArgs(NetworkSwapFlowFragment.createPayload(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openBuyNetworks(payload: NetworkFlowPayload) {
         navigationBuilder(R.id.action_buyFlow_to_buyFlowNetwork)
             .setArgs(NetworkFlowFragment.createPayload(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun returnToMainSwapScreen() {
         navigationBuilder(R.id.action_return_to_swap_settings)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSwapFlow() {
         val payload = SwapFlowPayload.InitialSelecting
         navigationBuilder(R.id.action_mainFragment_to_swapFlow)
             .setArgs(AssetSwapFlowFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSwapSetupAmount(swapSettingsPayload: SwapSettingsPayload) {
         navigationBuilder(R.id.action_open_swapSetupAmount)
             .setArgs(SwapMainSettingsFragment.getBundle(swapSettingsPayload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openNfts() {
         navigationBuilder(R.id.action_mainFragment_to_nfts_nav_graph)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun nonCancellableVerify() {
@@ -494,35 +494,35 @@ class Navigator(
             if (arguments is PinCodeAction.Change) {
                 navigationBuilder(R.id.action_pin_code_access_recovery)
                     .setArgs(bundle)
-                    .performInRoot()
+                    .navigateInRoot()
             }
         } else {
             navigationBuilder(R.id.action_pin_code_access_recovery)
                 .setArgs(bundle)
-                .performInRoot()
+                .navigateInRoot()
         }
     }
 
     override fun openUpdateNotifications() {
         navigationBuilder(R.id.action_open_update_notifications)
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun openPushWelcome() {
         navigationBuilder(R.id.action_open_pushNotificationsWelcome)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCloudBackupSettings() {
         navigationBuilder(R.id.action_open_cloudBackupSettings)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun returnToWallet() {
         // to achieve smooth animation
         postToUiThread {
             navigationBuilder(R.id.action_return_to_wallet)
-                .perform()
+                .navigateInFirstAttachedContext()
         }
     }
 
@@ -530,14 +530,14 @@ class Navigator(
         val extras = WalletDetailsFragment.getBundle(metaId)
         navigationBuilder(R.id.action_open_account_details)
             .setArgs(extras)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openNodeDetails(nodeId: Int) {
         val extras = NodeDetailsFragment.getBundle(nodeId)
         navigationBuilder(R.id.action_nodesFragment_to_nodeDetailsFragment)
             .setArgs(extras)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAssetDetails(assetPayload: AssetPayload) {
@@ -548,12 +548,12 @@ class Navigator(
             .addCase(R.id.assetSearchFragment, R.id.action_assetSearchFragment_to_balanceDetailFragment)
             .addCase(R.id.confirmTransferFragment, R.id.action_confirmTransferFragment_to_balanceDetailFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAddNode() {
         navigationBuilder(R.id.action_nodesFragment_to_addNodeFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openChangeWatchAccount(payload: AddAccountPayload.ChainAccount) {
@@ -561,18 +561,18 @@ class Navigator(
 
         navigationBuilder(R.id.action_accountDetailsFragment_to_changeWatchAccountFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCreateWallet(payload: StartCreateWalletPayload) {
         navigationBuilder(R.id.action_open_create_new_wallet)
             .setArgs(StartCreateWalletFragment.bundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openUserContributions() {
         navigationBuilder(R.id.action_mainFragment_to_userContributionsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun getExportMnemonicDelayedNavigation(exportPayload: ExportPayload.ChainAccount): DelayedNavigation {
@@ -599,12 +599,12 @@ class Navigator(
 
         navigationBuilder(R.id.action_export_json)
             .setArgs(extras)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishExportFlow() {
         navigationBuilder(R.id.finish_export_flow)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openScanImportParitySigner(payload: ParitySignerStartPayload) {
@@ -612,7 +612,7 @@ class Navigator(
 
         navigationBuilder(R.id.action_startImportParitySignerFragment_to_scanImportParitySignerFragment)
             .setArgs(args)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openPreviewImportParitySigner(payload: ParitySignerAccountPayload) {
@@ -620,7 +620,7 @@ class Navigator(
 
         navigationBuilder(R.id.action_scanImportParitySignerFragment_to_previewImportParitySignerFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openFinishImportParitySigner(payload: ParitySignerAccountPayload) {
@@ -628,7 +628,7 @@ class Navigator(
 
         navigationBuilder(R.id.action_previewImportParitySignerFragment_to_finishImportParitySignerFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openScanParitySignerSignature(payload: ScanSignParitySignerPayload) {
@@ -636,12 +636,12 @@ class Navigator(
 
         navigationBuilder(R.id.action_showSignParitySignerFragment_to_scanSignParitySignerFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishParitySignerFlow() {
         navigationBuilder(R.id.action_finish_parity_signer_flow)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAddLedgerChainAccountFlow(payload: AddAccountPayload.ChainAccount) {
@@ -649,7 +649,7 @@ class Navigator(
 
         navigationBuilder(R.id.action_accountDetailsFragment_to_addLedgerAccountGraph)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCreateCloudBackupPassword(walletName: String) {
@@ -657,34 +657,34 @@ class Navigator(
 
         navigationBuilder(R.id.action_startCreateWalletFragment_to_createCloudBackupPasswordFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun restoreCloudBackup() {
         navigationBuilder()
             .addCase(R.id.importWalletOptionsFragment, R.id.action_importWalletOptionsFragment_to_restoreCloudBackup)
             .addCase(R.id.startCreateWalletFragment, R.id.action_startCreateWalletFragment_to_resotreCloudBackupFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSyncWalletsBackupPassword() {
         navigationBuilder(R.id.action_cloudBackupSettings_to_syncWalletsBackupPasswordFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openChangeBackupPasswordFlow() {
         navigationBuilder(R.id.action_cloudBackupSettings_to_checkCloudBackupPasswordFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRestoreBackupPassword() {
         navigationBuilder(R.id.action_cloudBackupSettings_to_restoreCloudBackupPasswordFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openChangeBackupPassword() {
         navigationBuilder(R.id.action_checkCloudBackupPasswordFragment_to_changeBackupPasswordFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openManualBackupSelectAccount(metaId: Long) {
@@ -692,7 +692,7 @@ class Navigator(
 
         navigationBuilder(R.id.action_manualBackupSelectWalletFragment_to_manualBackupSelectAccountFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openManualBackupConditions(payload: ManualBackupCommonPayload) {
@@ -708,26 +708,26 @@ class Navigator(
             .addCase(R.id.manualBackupSelectWallet, R.id.action_manualBackupSelectWallet_to_pincode_check)
             .addCase(R.id.manualBackupSelectAccount, R.id.action_manualBackupSelectAccount_to_pincode_check)
             .setArgs(pinCodeBundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openManualBackupSecrets(payload: ManualBackupCommonPayload) {
         val bundle = ManualBackupSecretsFragment.bundle(payload)
         navigationBuilder(R.id.action_manualBackupWarning_to_manualBackupSecrets)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openManualBackupAdvancedSecrets(payload: ManualBackupCommonPayload) {
         val bundle = ManualBackupAdvancedSecretsFragment.bundle(payload)
         navigationBuilder(R.id.action_manualBackupSecrets_to_manualBackupAdvancedSecrets)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCreateWatchWallet() {
         navigationBuilder(R.id.action_importWalletOptionsFragment_to_createWatchWalletFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStartImportParitySigner() {
@@ -742,17 +742,17 @@ class Navigator(
         navigationBuilder()
             .addCase(R.id.welcomeFragment, R.id.action_welcomeFragment_to_importWalletOptionsFragment)
             .setFallbackCase(R.id.action_importWalletOptionsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStartImportLegacyLedger() {
         navigationBuilder(R.id.action_importWalletOptionsFragment_to_import_legacy_ledger_graph)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStartImportGenericLedger() {
         navigationBuilder(R.id.action_importWalletOptionsFragment_to_import_generic_ledger_graph)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun withPinCodeCheckRequired(
@@ -768,7 +768,7 @@ class Navigator(
 
         navigationBuilder(R.id.open_pincode_check)
             .setArgs(PincodeFragment.getPinCodeBundle(action))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     private fun openStartImportPolkadotVault(variant: PolkadotVaultVariant) {
@@ -776,7 +776,7 @@ class Navigator(
 
         navigationBuilder(R.id.action_importWalletOptionsFragment_to_import_parity_signer_graph)
             .setArgs(args)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     private fun buildCreatePinBundle(): Bundle {
@@ -791,7 +791,7 @@ class Navigator(
             is NavComponentDelayedNavigation -> {
                 navigationBuilder(delayedNavigation.globalActionId)
                     .setArgs(delayedNavigation.extras)
-                    .perform()
+                    .navigateInFirstAttachedContext()
             }
         }
     }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
@@ -169,7 +169,7 @@ class Navigator(
             .addCase(R.id.restoreCloudBackupFragment, R.id.action_restoreCloudBackupFragment_to_pincodeFragment)
             .addCase(R.id.finishImportGenericLedgerFragment, R.id.action_finishImportGenericLedgerFragment_to_pincodeFragment)
             .setArgs(args)
-            .perform()
+            .performInRoot()
     }
 
     override fun openAdvancedSettings(payload: AdvancedEncryptionModePayload) {
@@ -492,18 +492,18 @@ class Navigator(
             if (arguments is PinCodeAction.Change) {
                 navigationBuilder(R.id.action_pin_code_access_recovery)
                     .setArgs(bundle)
-                    .perform()
+                    .performInRoot()
             }
         } else {
             navigationBuilder(R.id.action_pin_code_access_recovery)
                 .setArgs(bundle)
-                .perform()
+                .performInRoot()
         }
     }
 
     override fun openUpdateNotifications() {
         navigationBuilder(R.id.action_open_update_notifications)
-            .perform()
+            .performInRoot()
     }
 
     override fun openPushWelcome() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/Navigator.kt
@@ -2,12 +2,11 @@ package io.novafoundation.nova.app.root.navigation.navigators
 
 import android.os.Bundle
 import androidx.lifecycle.asFlow
-import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.delayedNavigation.BackDelayedNavigation
 import io.novafoundation.nova.app.root.navigation.delayedNavigation.NavComponentDelayedNavigation
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.navigation.DelayedNavigation
@@ -99,11 +98,11 @@ import io.novafoundation.nova.splash.SplashRouter
 import kotlinx.coroutines.flow.Flow
 
 class Navigator(
-    private val rootNavigationHolder: RootNavigationHolder,
-    private val mainNavigationHolder: MainNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
     private val walletConnectDelegate: WalletConnectRouter,
     private val stakingDashboardDelegate: StakingDashboardRouter
-) : BaseNavigator(mainNavigationHolder),
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder),
     SplashRouter,
     OnboardingRouter,
     AccountRouter,
@@ -111,23 +110,32 @@ class Navigator(
     RootRouter,
     CrowdloanRouter {
 
-    private val rootNavController: NavController?
-        get() = rootNavigationHolder.navController
-
-    private val mainNavController: NavController?
-        get() = mainNavigationHolder.navController
-
     override fun openWelcomeScreen() {
+        /*
+        Was:
         when (rootNavController?.currentDestination?.id) {
             R.id.accountsFragment -> rootNavController?.navigate(R.id.action_walletManagment_to_welcome, WelcomeFragment.bundle(false))
             R.id.splashFragment -> rootNavController?.navigate(R.id.action_splash_to_onboarding, WelcomeFragment.bundle(false))
         }
+        */
+        // Now:
+        navigationBuilder()
+            .addCase(R.id.accountsFragment, R.id.action_walletManagment_to_welcome)
+            .addCase(R.id.splashFragment, R.id.action_splash_to_onboarding)
+            .setArgs(WelcomeFragment.bundle(false))
+            .perform()
     }
 
     override fun openInitialCheckPincode() {
-        val action = PinCodeAction.Check(NavComponentDelayedNavigation(R.id.action_open_main), ToolbarConfiguration())
-        val bundle = PincodeFragment.getPinCodeBundle(action)
-        rootNavController?.navigate(R.id.action_splash_to_pin, bundle)
+        val action = PinCodeAction.Check(NavComponentDelayedNavigation(R.id.action_open_split_screen), ToolbarConfiguration())
+
+        /* Was:
+        rootNavController?.navigate(R.id.action_splash_to_pin, PincodeFragment.getPinCodeBundle(action))
+        */
+        // Now:
+        navigationBuilder(R.id.action_splash_to_pin)
+            .setArgs(PincodeFragment.getPinCodeBundle(action))
+            .perform()
     }
 
     override fun openCreateFirstWallet() {
@@ -138,7 +146,7 @@ class Navigator(
     }
 
     override fun openMain() {
-        rootNavController?.navigate(R.id.action_open_main)
+        rootNavController?.navigate(R.id.action_open_split_screen)
     }
 
     override fun openAfterPinCode(delayedNavigation: DelayedNavigation) {
@@ -397,7 +405,7 @@ class Navigator(
     }
 
     override fun openStaking() {
-        if (mainNavController?.currentDestination?.id != R.id.mainFragment) mainNavController?.navigate(R.id.action_open_main)
+        if (mainNavController?.currentDestination?.id != R.id.mainFragment) mainNavController?.navigate(R.id.action_open_split_screen)
 
         stakingDashboardDelegate.openStakingDashboard()
     }
@@ -697,7 +705,7 @@ class Navigator(
     }
 
     private fun buildCreatePinBundle(): Bundle {
-        val delayedNavigation = NavComponentDelayedNavigation(R.id.action_open_main)
+        val delayedNavigation = NavComponentDelayedNavigation(R.id.action_open_split_screen)
         val action = PinCodeAction.Create(delayedNavigation)
         return PincodeFragment.getPinCodeBundle(action)
     }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/PolkadotVaultVariantSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/PolkadotVaultVariantSignCommunicatorImpl.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.getBackStackEntryBefore
 import io.novafoundation.nova.feature_account_api.domain.model.PolkadotVaultVariant
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator.Request
@@ -12,7 +12,7 @@ import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sig
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.show.ShowSignParitySignerPayload
 
 class PolkadotVaultVariantSignCommunicatorImpl(
-    navigationHolder: MainNavigationHolder,
+    navigationHolder: SplitScreenNavigationHolder,
 ) : NavStackInterScreenCommunicator<Request, Response>(navigationHolder), PolkadotVaultVariantSignCommunicator {
 
     private var usedPolkadotVaultVariant: PolkadotVaultVariant? = null

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/PolkadotVaultVariantSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/PolkadotVaultVariantSignCommunicatorImpl.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.getBackStackEntryBefore
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.domain.model.PolkadotVaultVariant
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator.Request
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator.Response
@@ -12,8 +13,8 @@ import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sig
 import io.novafoundation.nova.feature_account_impl.presentation.paritySigner.sign.show.ShowSignParitySignerPayload
 
 class PolkadotVaultVariantSignCommunicatorImpl(
-    navigationHolder: SplitScreenNavigationHolder,
-) : NavStackInterScreenCommunicator<Request, Response>(navigationHolder), PolkadotVaultVariantSignCommunicator {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : NavStackInterScreenCommunicator<Request, Response>(navigationHoldersRegistry), PolkadotVaultVariantSignCommunicator {
 
     private var usedPolkadotVaultVariant: PolkadotVaultVariant? = null
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/PolkadotVaultVariantSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/PolkadotVaultVariantSignCommunicatorImpl.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.getBackStackEntryBefore
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.domain.model.PolkadotVaultVariant

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectAddressCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectAddressCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectAddress.SelectAddressCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectAddress.SelectAddressRequester

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectAddressCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectAddressCommunicatorImpl.kt
@@ -1,14 +1,14 @@
 package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectAddress.SelectAddressCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectAddress.SelectAddressRequester
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectAddress.SelectAddressResponder
 import io.novafoundation.nova.feature_account_impl.presentation.account.list.selectAddress.SelectAddressFragment
 import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
 
-class SelectAddressCommunicatorImpl(private val router: AssetsRouter, navigationHolder: MainNavigationHolder) :
+class SelectAddressCommunicatorImpl(private val router: AssetsRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<SelectAddressRequester.Request, SelectAddressResponder.Response>(navigationHolder),
     SelectAddressCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectAddressCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectAddressCommunicatorImpl.kt
@@ -2,14 +2,15 @@ package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectAddress.SelectAddressCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectAddress.SelectAddressRequester
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectAddress.SelectAddressResponder
 import io.novafoundation.nova.feature_account_impl.presentation.account.list.selectAddress.SelectAddressFragment
 import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
 
-class SelectAddressCommunicatorImpl(private val router: AssetsRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<SelectAddressRequester.Request, SelectAddressResponder.Response>(navigationHolder),
+class SelectAddressCommunicatorImpl(private val router: AssetsRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<SelectAddressRequester.Request, SelectAddressResponder.Response>(navigationHoldersRegistry),
     SelectAddressCommunicator {
 
     override fun openRequest(request: SelectAddressRequester.Request) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectMultipleWalletsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectMultipleWalletsCommunicatorImpl.kt
@@ -1,14 +1,14 @@
 package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectMultipleWalletsCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectMultipleWalletsRequester
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectMultipleWalletsResponder
 import io.novafoundation.nova.feature_account_impl.presentation.account.list.multipleSelecting.SelectMultipleWalletsFragment
 import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
 
-class SelectMultipleWalletsCommunicatorImpl(private val router: AssetsRouter, navigationHolder: MainNavigationHolder) :
+class SelectMultipleWalletsCommunicatorImpl(private val router: AssetsRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<SelectMultipleWalletsRequester.Request, SelectMultipleWalletsResponder.Response>(navigationHolder),
     SelectMultipleWalletsCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectMultipleWalletsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectMultipleWalletsCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectMultipleWalletsCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectMultipleWalletsRequester

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectMultipleWalletsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectMultipleWalletsCommunicatorImpl.kt
@@ -2,14 +2,15 @@ package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectMultipleWalletsCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectMultipleWalletsRequester
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectMultipleWalletsResponder
 import io.novafoundation.nova.feature_account_impl.presentation.account.list.multipleSelecting.SelectMultipleWalletsFragment
 import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
 
-class SelectMultipleWalletsCommunicatorImpl(private val router: AssetsRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<SelectMultipleWalletsRequester.Request, SelectMultipleWalletsResponder.Response>(navigationHolder),
+class SelectMultipleWalletsCommunicatorImpl(private val router: AssetsRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<SelectMultipleWalletsRequester.Request, SelectMultipleWalletsResponder.Response>(navigationHoldersRegistry),
     SelectMultipleWalletsCommunicator {
 
     override fun openRequest(request: SelectMultipleWalletsRequester.Request) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectWalletCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectWalletCommunicatorImpl.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.account
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectWallet.SelectWalletCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectWallet.SelectWalletCommunicator.Payload

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectWalletCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/account/SelectWalletCommunicatorImpl.kt
@@ -3,17 +3,18 @@ package io.novafoundation.nova.app.root.navigation.navigators.account
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectWallet.SelectWalletCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectWallet.SelectWalletCommunicator.Payload
 import io.novafoundation.nova.feature_account_api.presenatation.mixin.selectWallet.SelectWalletCommunicator.Response
 
 class SelectWalletCommunicatorImpl(
-    private val navigationHolder: NavigationHolder,
-) : NavStackInterScreenCommunicator<Payload, Response>(navigationHolder), SelectWalletCommunicator {
+    private val navigationHoldersRegistry: NavigationHoldersRegistry
+) : NavStackInterScreenCommunicator<Payload, Response>(navigationHoldersRegistry), SelectWalletCommunicator {
 
     override fun openRequest(request: Payload) {
         super.openRequest(request)
 
-        navigationHolder.navController!!.navigate(R.id.action_open_select_wallet)
+        navController.navigate(R.id.action_open_select_wallet)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/buy/BuyNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/buy/BuyNavigator.kt
@@ -1,7 +1,9 @@
 package io.novafoundation.nova.app.root.navigation.navigators.buy
 
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_buy_impl.presentation.BuyRouter
 
-class BuyNavigator(navigationHolder: SplitScreenNavigationHolder) : BuyRouter, BaseNavigator(navigationHolder)
+class BuyNavigator(splitScreenNavigationHolder: SplitScreenNavigationHolder, rootNavigationHolder: RootNavigationHolder) : BuyRouter,
+    BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/buy/BuyNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/buy/BuyNavigator.kt
@@ -3,7 +3,8 @@ package io.novafoundation.nova.app.root.navigation.navigators.buy
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_buy_impl.presentation.BuyRouter
 
-class BuyNavigator(splitScreenNavigationHolder: SplitScreenNavigationHolder, rootNavigationHolder: RootNavigationHolder) : BuyRouter,
-    BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder)
+class BuyNavigator(navigationHoldersRegistry: NavigationHoldersRegistry) : BuyRouter,
+    BaseNavigator(navigationHoldersRegistry)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/buy/BuyNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/buy/BuyNavigator.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.buy
 
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_buy_impl.presentation.BuyRouter
 
-class BuyNavigator(navigationHolder: MainNavigationHolder) : BuyRouter, BaseNavigator(navigationHolder)
+class BuyNavigator(navigationHolder: SplitScreenNavigationHolder) : BuyRouter, BaseNavigator(navigationHolder)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/buy/BuyNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/buy/BuyNavigator.kt
@@ -1,8 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.buy
 
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_buy_impl.presentation.BuyRouter
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/ChangeBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/ChangeBackupPasswordCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.ChangeBackupPasswordCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.ChangeBackupPasswordRequester

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/ChangeBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/ChangeBackupPasswordCommunicatorImpl.kt
@@ -2,13 +2,14 @@ package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.ChangeBackupPasswordCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.ChangeBackupPasswordRequester
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.ChangeBackupPasswordResponder
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 
-class ChangeBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<ChangeBackupPasswordRequester.EmptyRequest, ChangeBackupPasswordResponder.Success>(navigationHolder),
+class ChangeBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<ChangeBackupPasswordRequester.EmptyRequest, ChangeBackupPasswordResponder.Success>(navigationHoldersRegistry),
     ChangeBackupPasswordCommunicator {
 
     override fun openRequest(request: ChangeBackupPasswordRequester.EmptyRequest) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/ChangeBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/ChangeBackupPasswordCommunicatorImpl.kt
@@ -1,13 +1,13 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.ChangeBackupPasswordCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.ChangeBackupPasswordRequester
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.ChangeBackupPasswordResponder
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 
-class ChangeBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: MainNavigationHolder) :
+class ChangeBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<ChangeBackupPasswordRequester.EmptyRequest, ChangeBackupPasswordResponder.Success>(navigationHolder),
     ChangeBackupPasswordCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/CloudBackupNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/CloudBackupNavigator.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_cloud_backup_impl.presentation.CloudBackupRouter
 
-class CloudBackupNavigator(navigationHolder: MainNavigationHolder) : CloudBackupRouter, BaseNavigator(navigationHolder)
+class CloudBackupNavigator(navigationHolder: SplitScreenNavigationHolder) : CloudBackupRouter, BaseNavigator(navigationHolder)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/CloudBackupNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/CloudBackupNavigator.kt
@@ -1,7 +1,9 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_cloud_backup_impl.presentation.CloudBackupRouter
 
-class CloudBackupNavigator(navigationHolder: SplitScreenNavigationHolder) : CloudBackupRouter, BaseNavigator(navigationHolder)
+class CloudBackupNavigator(splitScreenNavigationHolder: SplitScreenNavigationHolder, rootNavigationHolder: RootNavigationHolder) : CloudBackupRouter,
+    BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/CloudBackupNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/CloudBackupNavigator.kt
@@ -3,7 +3,8 @@ package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_cloud_backup_impl.presentation.CloudBackupRouter
 
-class CloudBackupNavigator(splitScreenNavigationHolder: SplitScreenNavigationHolder, rootNavigationHolder: RootNavigationHolder) : CloudBackupRouter,
-    BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder)
+class CloudBackupNavigator(navigationHoldersRegistry: NavigationHoldersRegistry) : CloudBackupRouter,
+    BaseNavigator(navigationHoldersRegistry)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/CloudBackupNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/CloudBackupNavigator.kt
@@ -1,8 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_cloud_backup_impl.presentation.CloudBackupRouter
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/RestoreBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/RestoreBackupPasswordCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.RestoreBackupPasswordCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.RestoreBackupPasswordRequester

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/RestoreBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/RestoreBackupPasswordCommunicatorImpl.kt
@@ -1,13 +1,13 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.RestoreBackupPasswordCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.RestoreBackupPasswordRequester
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.RestoreBackupPasswordResponder
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 
-class RestoreBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: MainNavigationHolder) :
+class RestoreBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<RestoreBackupPasswordRequester.EmptyRequest, RestoreBackupPasswordResponder.Success>(navigationHolder),
     RestoreBackupPasswordCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/RestoreBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/RestoreBackupPasswordCommunicatorImpl.kt
@@ -2,13 +2,14 @@ package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.RestoreBackupPasswordCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.RestoreBackupPasswordRequester
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.changePassword.RestoreBackupPasswordResponder
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 
-class RestoreBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<RestoreBackupPasswordRequester.EmptyRequest, RestoreBackupPasswordResponder.Success>(navigationHolder),
+class RestoreBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<RestoreBackupPasswordRequester.EmptyRequest, RestoreBackupPasswordResponder.Success>(navigationHoldersRegistry),
     RestoreBackupPasswordCommunicator {
 
     override fun openRequest(request: RestoreBackupPasswordRequester.EmptyRequest) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/SyncWalletsBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/SyncWalletsBackupPasswordCommunicatorImpl.kt
@@ -2,13 +2,14 @@ package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.createPassword.SyncWalletsBackupPasswordCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.createPassword.SyncWalletsBackupPasswordRequester
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.createPassword.SyncWalletsBackupPasswordResponder
 
-class SyncWalletsBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<SyncWalletsBackupPasswordRequester.EmptyRequest, SyncWalletsBackupPasswordResponder.Response>(navigationHolder),
+class SyncWalletsBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<SyncWalletsBackupPasswordRequester.EmptyRequest, SyncWalletsBackupPasswordResponder.Response>(navigationHoldersRegistry),
     SyncWalletsBackupPasswordCommunicator {
 
     override fun openRequest(request: SyncWalletsBackupPasswordRequester.EmptyRequest) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/SyncWalletsBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/SyncWalletsBackupPasswordCommunicatorImpl.kt
@@ -1,13 +1,13 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.createPassword.SyncWalletsBackupPasswordCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.createPassword.SyncWalletsBackupPasswordRequester
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.createPassword.SyncWalletsBackupPasswordResponder
 
-class SyncWalletsBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: MainNavigationHolder) :
+class SyncWalletsBackupPasswordCommunicatorImpl(private val router: AccountRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<SyncWalletsBackupPasswordRequester.EmptyRequest, SyncWalletsBackupPasswordResponder.Response>(navigationHolder),
     SyncWalletsBackupPasswordCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/SyncWalletsBackupPasswordCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/cloudBackup/SyncWalletsBackupPasswordCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.cloudBackup
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_account_api.presenatation.cloudBackup.createPassword.SyncWalletsBackupPasswordCommunicator

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
@@ -18,10 +18,12 @@ class DAppNavigator(
 
     override fun openChangeAccount() {
         navigationBuilder(R.id.action_open_switch_wallet)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openDAppBrowser(payload: DAppBrowserPayload, extras: FragmentNavigator.Extras?) {
+        // Close dapp browser if it is already opened
+        // TODO it's better to provide new url to existing browser
         navigationBuilder()
             .addCase(R.id.dappBrowserFragment, R.id.action_DAppBrowserFragment_to_DAppBrowserFragment)
             .addCase(R.id.dappSearchFragment, R.id.action_dappSearchFragment_to_dapp_browser_graph)
@@ -29,7 +31,7 @@ class DAppNavigator(
             .setFallbackCase(R.id.action_open_dappBrowser)
             .setExtras(extras)
             .setArgs(DAppBrowserFragment.getBundle(payload))
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun openDappSearch() {
@@ -39,39 +41,39 @@ class DAppNavigator(
     override fun openDappSearchWithCategory(categoryId: String?) {
         navigationBuilder(R.id.action_open_dappSearch)
             .setArgs(DappSearchFragment.getBundle(SearchPayload(initialUrl = null, SearchPayload.Request.OPEN_NEW_URL, preselectedCategoryId = categoryId)))
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun finishDappSearch() {
         navigationBuilder(R.id.action_finish_dapp_search)
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun openAddToFavourites(payload: AddToFavouritesPayload) {
         navigationBuilder(R.id.action_DAppBrowserFragment_to_addToFavouritesFragment)
             .setArgs(AddToFavouritesFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAuthorizedDApps() {
         navigationBuilder(R.id.action_mainFragment_to_authorizedDAppsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openTabs() {
         navigationBuilder()
             .addCase(R.id.dappBrowserFragment, R.id.action_DAppBrowserFragment_to_browserTabsFragment)
             .setFallbackCase(R.id.action_open_dappTabs)
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun closeTabsScreen() {
         navigationBuilder(R.id.action_finish_tabs_fragment)
-            .performInRoot()
+            .navigateInRoot()
     }
 
     override fun openDAppFavorites() {
         navigationBuilder(R.id.action_open_dapp_favorites)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
@@ -14,27 +14,24 @@ import io.novafoundation.nova.feature_dapp_impl.presentation.search.DappSearchFr
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.SearchPayload
 
 class DAppNavigator(
-    private val rootNavigationHolder: RootNavigationHolder,
-    private val splitScreenNavigationHolder: SplitScreenNavigationHolder
-) : BaseNavigator(rootNavigationHolder), DAppRouter {
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), DAppRouter {
 
     override fun openChangeAccount() {
-        splitScreenNavigationHolder.navController?.performNavigation(R.id.action_open_switch_wallet)
+        navigationBuilder(R.id.action_open_switch_wallet)
+            .perform()
     }
 
     override fun openDAppBrowser(payload: DAppBrowserPayload, extras: FragmentNavigator.Extras?) {
-        // Close deapp browser if it is already opened
-        // TODO it's better to provide new url to existing browser
-        val currentDestination = rootNavigationHolder.navController?.currentDestination
-
-        val destinationId = when (currentDestination?.id) {
-            R.id.dappBrowserFragment -> R.id.action_DAppBrowserFragment_to_DAppBrowserFragment
-            R.id.dappSearchFragment -> R.id.action_dappSearchFragment_to_dapp_browser_graph
-            R.id.dappTabsFragment -> R.id.action_dappTabsFragment_to_dapp_browser_graph
-            else -> R.id.action_open_dappBrowser
-        }
-
-        performNavigation(destinationId, DAppBrowserFragment.getBundle(payload), extras)
+        navigationBuilder()
+            .addCase(R.id.dappBrowserFragment, R.id.action_DAppBrowserFragment_to_DAppBrowserFragment)
+            .addCase(R.id.dappSearchFragment, R.id.action_dappSearchFragment_to_dapp_browser_graph)
+            .addCase(R.id.dappTabsFragment, R.id.action_dappTabsFragment_to_dapp_browser_graph)
+            .setFallbackCase(R.id.action_open_dappBrowser)
+            .setExtras(extras)
+            .setArgs(DAppBrowserFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openDappSearch() {
@@ -42,43 +39,41 @@ class DAppNavigator(
     }
 
     override fun openDappSearchWithCategory(categoryId: String?) {
-        performNavigation(
-            actionId = R.id.action_open_dappSearch,
-            args = DappSearchFragment.getBundle(SearchPayload(initialUrl = null, SearchPayload.Request.OPEN_NEW_URL, preselectedCategoryId = categoryId))
-        )
+        navigationBuilder(R.id.action_open_dappSearch)
+            .setArgs(DappSearchFragment.getBundle(SearchPayload(initialUrl = null, SearchPayload.Request.OPEN_NEW_URL, preselectedCategoryId = categoryId)))
+            .perform()
     }
 
     override fun finishDappSearch() {
-        performNavigation(R.id.action_finish_dapp_search)
+        navigationBuilder(R.id.action_finish_dapp_search)
+            .perform()
     }
 
-    override fun openAddToFavourites(payload: AddToFavouritesPayload) = performNavigation(
-        actionId = R.id.action_DAppBrowserFragment_to_addToFavouritesFragment,
-        args = AddToFavouritesFragment.getBundle(payload)
-    )
+    override fun openAddToFavourites(payload: AddToFavouritesPayload) {
+        navigationBuilder(R.id.action_DAppBrowserFragment_to_addToFavouritesFragment)
+            .setArgs(AddToFavouritesFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openAuthorizedDApps() {
-        splitScreenNavigationHolder.navController?.performNavigation(
-            actionId = R.id.action_mainFragment_to_authorizedDAppsFragment
-        )
+        navigationBuilder(R.id.action_mainFragment_to_authorizedDAppsFragment)
+            .perform()
     }
 
     override fun openTabs() {
-        val currentDestination = rootNavigationHolder.navController?.currentDestination
-
-        val destinationId = when (currentDestination?.id) {
-            R.id.dappBrowserFragment -> R.id.action_DAppBrowserFragment_to_browserTabsFragment
-            else -> R.id.action_open_dappTabs
-        }
-
-        performNavigation(destinationId)
+        navigationBuilder()
+            .addCase(R.id.dappBrowserFragment, R.id.action_DAppBrowserFragment_to_browserTabsFragment)
+            .setFallbackCase(R.id.action_open_dappTabs)
+            .perform()
     }
 
-    override fun closeTabsScreen() = performNavigation(
-        actionId = R.id.action_finish_tabs_fragment
-    )
+    override fun closeTabsScreen() {
+        navigationBuilder(R.id.action_finish_tabs_fragment)
+            .perform()
+    }
 
     override fun openDAppFavorites() {
-        splitScreenNavigationHolder.navController?.performNavigation(R.id.action_open_dapp_favorites)
+        navigationBuilder(R.id.action_open_dapp_favorites)
+            .perform()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
 import io.novafoundation.nova.feature_dapp_impl.presentation.addToFavourites.AddToFavouritesFragment
 import io.novafoundation.nova.feature_dapp_api.presentation.addToFavorites.AddToFavouritesPayload
@@ -14,9 +15,8 @@ import io.novafoundation.nova.feature_dapp_impl.presentation.search.DappSearchFr
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.SearchPayload
 
 class DAppNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder,
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), DAppRouter {
+    navigationHoldersRegistry: NavigationHoldersRegistry,
+) : BaseNavigator(navigationHoldersRegistry), DAppRouter {
 
     override fun openChangeAccount() {
         navigationBuilder(R.id.action_open_switch_wallet)
@@ -31,7 +31,7 @@ class DAppNavigator(
             .setFallbackCase(R.id.action_open_dappBrowser)
             .setExtras(extras)
             .setArgs(DAppBrowserFragment.getBundle(payload))
-            .perform()
+            .performInRoot()
     }
 
     override fun openDappSearch() {
@@ -41,12 +41,12 @@ class DAppNavigator(
     override fun openDappSearchWithCategory(categoryId: String?) {
         navigationBuilder(R.id.action_open_dappSearch)
             .setArgs(DappSearchFragment.getBundle(SearchPayload(initialUrl = null, SearchPayload.Request.OPEN_NEW_URL, preselectedCategoryId = categoryId)))
-            .perform()
+            .performInRoot()
     }
 
     override fun finishDappSearch() {
         navigationBuilder(R.id.action_finish_dapp_search)
-            .perform()
+            .performInRoot()
     }
 
     override fun openAddToFavourites(payload: AddToFavouritesPayload) {
@@ -64,12 +64,12 @@ class DAppNavigator(
         navigationBuilder()
             .addCase(R.id.dappBrowserFragment, R.id.action_DAppBrowserFragment_to_browserTabsFragment)
             .setFallbackCase(R.id.action_open_dappTabs)
-            .perform()
+            .performInRoot()
     }
 
     override fun closeTabsScreen() {
         navigationBuilder(R.id.action_finish_tabs_fragment)
-            .perform()
+            .performInRoot()
     }
 
     override fun openDAppFavorites() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.dApp
 
 import androidx.navigation.fragment.FragmentNavigator
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
@@ -15,11 +15,11 @@ import io.novafoundation.nova.feature_dapp_impl.presentation.search.SearchPayloa
 
 class DAppNavigator(
     private val rootNavigationHolder: RootNavigationHolder,
-    private val mainNavigationHolder: MainNavigationHolder
+    private val splitScreenNavigationHolder: SplitScreenNavigationHolder
 ) : BaseNavigator(rootNavigationHolder), DAppRouter {
 
     override fun openChangeAccount() {
-        mainNavigationHolder.navController?.performNavigation(R.id.action_open_switch_wallet)
+        splitScreenNavigationHolder.navController?.performNavigation(R.id.action_open_switch_wallet)
     }
 
     override fun openDAppBrowser(payload: DAppBrowserPayload, extras: FragmentNavigator.Extras?) {
@@ -58,7 +58,7 @@ class DAppNavigator(
     )
 
     override fun openAuthorizedDApps() {
-        mainNavigationHolder.navController?.performNavigation(
+        splitScreenNavigationHolder.navController?.performNavigation(
             actionId = R.id.action_mainFragment_to_authorizedDAppsFragment
         )
     }
@@ -79,6 +79,6 @@ class DAppNavigator(
     )
 
     override fun openDAppFavorites() {
-        mainNavigationHolder.navController?.performNavigation(R.id.action_open_dapp_favorites)
+        splitScreenNavigationHolder.navController?.performNavigation(R.id.action_open_dapp_favorites)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppNavigator.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.dApp
 
 import androidx.navigation.fragment.FragmentNavigator
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppSearchCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppSearchCommunicatorImpl.kt
@@ -17,6 +17,6 @@ class DAppSearchCommunicatorImpl(navigationHoldersRegistry: NavigationHoldersReg
 
         navigationBuilder(R.id.action_open_dappSearch_from_browser)
             .setArgs(DappSearchFragment.getBundle(request))
-            .performInRoot()
+            .navigateInRoot()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppSearchCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppSearchCommunicatorImpl.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.dApp
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DAppSearchCommunicator
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DAppSearchCommunicator.Response

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppSearchCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/dApp/DAppSearchCommunicatorImpl.kt
@@ -3,18 +3,21 @@ package io.novafoundation.nova.app.root.navigation.navigators.dApp
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DAppSearchCommunicator
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DAppSearchCommunicator.Response
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DappSearchFragment
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.SearchPayload
 
-class DAppSearchCommunicatorImpl(navigationHolder: RootNavigationHolder) :
-    NavStackInterScreenCommunicator<SearchPayload, Response>(navigationHolder),
+class DAppSearchCommunicatorImpl(navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<SearchPayload, Response>(navigationHoldersRegistry),
     DAppSearchCommunicator {
 
     override fun openRequest(request: SearchPayload) {
         super.openRequest(request)
 
-        navController.navigate(R.id.action_open_dappSearch_from_browser, DappSearchFragment.getBundle(request))
+        navigationBuilder(R.id.action_open_dappSearch_from_browser)
+            .setArgs(DappSearchFragment.getBundle(request))
+            .performInRoot()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/deepLinking/DeepLinkingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/deepLinking/DeepLinkingNavigator.kt
@@ -1,39 +1,42 @@
 package io.novafoundation.nova.app.root.navigation.navigators.deepLinking
 
+import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
+import io.novafoundation.nova.app.root.navigation.openSplitScreenWithInstantAction
 import io.novafoundation.nova.feature_account_api.presenatation.account.add.ImportAccountPayload
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
-import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
-import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
+import io.novafoundation.nova.feature_assets.presentation.balance.detail.BalanceDetailFragment
 import io.novafoundation.nova.feature_dapp_api.presentation.browser.main.DAppBrowserPayload
+import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
 import io.novafoundation.nova.feature_deep_linking.presentation.handling.DeepLinkingRouter
 import io.novafoundation.nova.feature_governance_api.presentation.referenda.details.ReferendumDetailsPayload
-import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
+import io.novafoundation.nova.feature_governance_impl.presentation.referenda.details.ReferendumDetailsFragment
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
 
 class DeepLinkingNavigator(
-    private val accountRouter: AccountRouter,
-    private val assetsRouter: AssetsRouter,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val dAppRouter: DAppRouter,
-    private val governanceRouter: GovernanceRouter
-) : DeepLinkingRouter {
+    private val accountRouter: AccountRouter
+) : BaseNavigator(navigationHoldersRegistry), DeepLinkingRouter {
 
     override fun openAssetDetails(payload: AssetPayload) {
-        assetsRouter.openAssetDetails(payload)
+        openSplitScreenWithInstantAction(R.id.action_mainFragment_to_balanceDetailFragment, BalanceDetailFragment.getBundle(payload))
     }
 
     override fun openDAppBrowser(url: String) {
         dAppRouter.openDAppBrowser(DAppBrowserPayload.Address(url))
     }
 
-    override fun openImportAccountScreen(importAccountPayload: ImportAccountPayload) {
-        accountRouter.openImportAccountScreen(importAccountPayload)
+    override fun openImportAccountScreen(payload: ImportAccountPayload) {
+        accountRouter.openImportAccountScreen(payload)
     }
 
     override fun openReferendum(payload: ReferendumDetailsPayload) {
-        governanceRouter.openReferendum(payload)
+        openSplitScreenWithInstantAction(R.id.action_open_referendum_details, ReferendumDetailsFragment.getBundle(payload))
     }
 
     override fun openStakingDashboard() {
-        assetsRouter.openStaking()
+        openSplitScreenWithInstantAction(R.id.action_open_staking)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/deepLinking/DeepLinkingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/deepLinking/DeepLinkingNavigator.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRe
 import io.novafoundation.nova.app.root.navigation.openSplitScreenWithInstantAction
 import io.novafoundation.nova.feature_account_api.presenatation.account.add.ImportAccountPayload
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
+import io.novafoundation.nova.feature_assets.presentation.AssetsRouter
 import io.novafoundation.nova.feature_assets.presentation.balance.detail.BalanceDetailFragment
 import io.novafoundation.nova.feature_dapp_api.presentation.browser.main.DAppBrowserPayload
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
@@ -17,7 +18,8 @@ import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
 class DeepLinkingNavigator(
     navigationHoldersRegistry: NavigationHoldersRegistry,
     private val dAppRouter: DAppRouter,
-    private val accountRouter: AccountRouter
+    private val accountRouter: AccountRouter,
+    private val assetsRouter: AssetsRouter
 ) : BaseNavigator(navigationHoldersRegistry), DeepLinkingRouter {
 
     override fun openAssetDetails(payload: AssetPayload) {
@@ -37,6 +39,6 @@ class DeepLinkingNavigator(
     }
 
     override fun openStakingDashboard() {
-        openSplitScreenWithInstantAction(R.id.action_open_staking)
+        assetsRouter.openStaking()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignCommunicatorImpl.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-
 class ExternalSignCommunicatorImpl(
     private val navigationHolder: NavigationHolder,
     private val automaticInteractionGate: AutomaticInteractionGate,

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignCommunicatorImpl.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+
 class ExternalSignCommunicatorImpl(
     private val navigationHolder: NavigationHolder,
     private val automaticInteractionGate: AutomaticInteractionGate,

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
@@ -13,6 +13,6 @@ class ExternalSignNavigator(
     override fun openExtrinsicDetails(extrinsicContent: String) {
         navigationBuilder(R.id.action_ConfirmSignExtrinsicFragment_to_extrinsicDetailsFragment)
             .setArgs(ExternalExtrinsicDetailsFragment.getBundle(extrinsicContent))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
@@ -4,13 +4,13 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_external_sign_impl.ExternalSignRouter
 import io.novafoundation.nova.feature_external_sign_impl.presentation.extrinsicDetails.ExternalExtrinsicDetailsFragment
 
 class ExternalSignNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), ExternalSignRouter {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : BaseNavigator(navigationHoldersRegistry), ExternalSignRouter {
 
     override fun openExtrinsicDetails(extrinsicContent: String) {
         navigationBuilder(R.id.action_ConfirmSignExtrinsicFragment_to_extrinsicDetailsFragment)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.externalSign
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_external_sign_impl.ExternalSignRouter
 import io.novafoundation.nova.feature_external_sign_impl.presentation.extrinsicDetails.ExternalExtrinsicDetailsFragment

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
@@ -1,17 +1,20 @@
 package io.novafoundation.nova.app.root.navigation.navigators.externalSign
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_external_sign_impl.ExternalSignRouter
 import io.novafoundation.nova.feature_external_sign_impl.presentation.extrinsicDetails.ExternalExtrinsicDetailsFragment
 
 class ExternalSignNavigator(
-    navigationHolder: SplitScreenNavigationHolder
-) : BaseNavigator(navigationHolder), ExternalSignRouter {
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), ExternalSignRouter {
 
-    override fun openExtrinsicDetails(extrinsicContent: String) = performNavigation(
-        actionId = R.id.action_ConfirmSignExtrinsicFragment_to_extrinsicDetailsFragment,
-        args = ExternalExtrinsicDetailsFragment.getBundle(extrinsicContent)
-    )
+    override fun openExtrinsicDetails(extrinsicContent: String) {
+        navigationBuilder(R.id.action_ConfirmSignExtrinsicFragment_to_extrinsicDetailsFragment)
+            .setArgs(ExternalExtrinsicDetailsFragment.getBundle(extrinsicContent))
+            .perform()
+    }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/externalSign/ExternalSignNavigator.kt
@@ -2,12 +2,12 @@ package io.novafoundation.nova.app.root.navigation.navigators.externalSign
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_external_sign_impl.ExternalSignRouter
 import io.novafoundation.nova.feature_external_sign_impl.presentation.extrinsicDetails.ExternalExtrinsicDetailsFragment
 
 class ExternalSignNavigator(
-    navigationHolder: MainNavigationHolder
+    navigationHolder: SplitScreenNavigationHolder
 ) : BaseNavigator(navigationHolder), ExternalSignRouter {
 
     override fun openExtrinsicDetails(extrinsicContent: String) = performNavigation(

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
@@ -56,42 +56,42 @@ class GovernanceNavigator(
             .addCase(R.id.referendaSearchFragment, R.id.action_open_referendum_details_from_referenda_search)
             .setFallbackCase(R.id.action_open_referendum_details)
             .setArgs(ReferendumDetailsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReferendumFullDetails(payload: ReferendumFullDetailsPayload) {
         navigationBuilder(R.id.action_referendumDetailsFragment_to_referendumFullDetailsFragment)
             .setArgs(ReferendumFullDetailsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReferendumVoters(payload: ReferendumVotersPayload) {
         navigationBuilder(R.id.action_referendumDetailsFragment_to_referendumVotersFragment)
             .setArgs(ReferendumVotersFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSetupReferendumVote(payload: SetupVotePayload) {
         navigationBuilder(R.id.action_referendumDetailsFragment_to_setupVoteReferendumFragment)
             .setArgs(SetupVoteFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSetupTinderGovVote(payload: SetupVotePayload) {
         navigationBuilder(R.id.action_tinderGovCards_to_setupTinderGovVoteFragment)
             .setArgs(SetupVoteFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun backToReferendumDetails() {
         navigationBuilder(R.id.action_confirmReferendumVote_to_referendumDetailsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishUnlockFlow(shouldCloseLocksScreen: Boolean) {
         if (shouldCloseLocksScreen) {
             navigationBuilder(R.id.action_confirmReferendumVote_to_mainFragment)
-                .perform()
+                .navigateInFirstAttachedContext()
         } else {
             back()
         }
@@ -105,12 +105,12 @@ class GovernanceNavigator(
         navigationBuilder()
             .addCase(R.id.mainFragment, R.id.action_mainFragment_to_delegation)
             .addCase(R.id.yourDelegationsFragment, R.id.action_yourDelegations_to_delegationList)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openYourDelegations() {
         navigationBuilder(R.id.action_mainFragment_to_your_delegation)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openBecomingDelegateTutorial() {
@@ -119,50 +119,50 @@ class GovernanceNavigator(
 
     override fun backToYourDelegations() {
         navigationBuilder(R.id.action_back_to_your_delegations)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRevokeDelegationChooseTracks(payload: RevokeDelegationChooseTracksPayload) {
         navigationBuilder(R.id.action_delegateDetailsFragment_to_revokeDelegationChooseTracksFragment)
             .setArgs(RevokeDelegationChooseTracksFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRevokeDelegationsConfirm(payload: RevokeDelegationConfirmPayload) {
         navigationBuilder(R.id.action_revokeDelegationChooseTracksFragment_to_revokeDelegationConfirmFragment)
             .setArgs(RevokeDelegationConfirmFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openDelegateSearch() {
         navigationBuilder(R.id.action_delegateListFragment_to_delegateSearchFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectGovernanceTracks(bundle: Bundle) {
         navigationBuilder(R.id.action_open_select_governance_tracks)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openTinderGovCards() {
         navigationBuilder(R.id.action_openTinderGovCards)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openTinderGovBasket() {
         navigationBuilder(R.id.action_tinderGovCards_to_tinderGovBasket)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmTinderGovVote() {
         navigationBuilder(R.id.action_setupTinderGovBasket_to_confirmTinderGovVote)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun backToTinderGovCards() {
         navigationBuilder(R.id.action_confirmTinderGovVote_to_tinderGovCards)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReferendumInfo(payload: ReferendumInfoPayload) {
@@ -170,29 +170,29 @@ class GovernanceNavigator(
             .addCase(R.id.tinderGovCards, R.id.action_tinderGovCards_to_referendumInfo)
             .addCase(R.id.setupTinderGovBasketFragment, R.id.action_setupTinderGovBasket_to_referendumInfo)
             .setArgs(ReferendumInfoFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReferendaSearch() {
         navigationBuilder(R.id.action_open_referenda_search)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReferendaFilters() {
         navigationBuilder(R.id.action_open_referenda_filters)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRemoveVotes(payload: RemoveVotesPayload) {
         navigationBuilder(R.id.action_open_remove_votes)
             .setArgs(RemoveVotesFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openDelegateDelegators(payload: DelegateDelegatorsPayload) {
         navigationBuilder(R.id.action_delegateDetailsFragment_to_delegateDelegatorsFragment)
             .setArgs(DelegateDelegatorsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openDelegateDetails(payload: DelegateDetailsPayload) {
@@ -201,64 +201,64 @@ class GovernanceNavigator(
             .addCase(R.id.yourDelegationsFragment, R.id.action_yourDelegations_to_delegationDetails)
             .addCase(R.id.delegateSearchFragment, R.id.action_delegateSearchFragment_to_delegateDetailsFragment)
             .setArgs(DelegateDetailsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openNewDelegationChooseTracks(payload: NewDelegationChooseTracksPayload) {
         navigationBuilder(R.id.action_delegateDetailsFragment_to_selectDelegationTracks)
             .setArgs(NewDelegationChooseTracksFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openNewDelegationChooseAmount(payload: NewDelegationChooseAmountPayload) {
         navigationBuilder(R.id.action_selectDelegationTracks_to_newDelegationChooseAmountFragment)
             .setArgs(NewDelegationChooseAmountFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openNewDelegationConfirm(payload: NewDelegationConfirmPayload) {
         navigationBuilder(R.id.action_newDelegationChooseAmountFragment_to_newDelegationConfirmFragment)
             .setArgs(NewDelegationConfirmFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openVotedReferenda(payload: VotedReferendaPayload) {
         navigationBuilder(R.id.action_delegateDetailsFragment_to_votedReferendaFragment)
             .setArgs(VotedReferendaFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openDelegateFullDescription(payload: DescriptionPayload) {
         navigationBuilder(R.id.action_delegateDetailsFragment_to_delegateFullDescription)
             .setArgs(DescriptionFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openDAppBrowser(url: String) {
         navigationBuilder(R.id.action_referendumDetailsFragment_to_DAppBrowserGraph)
             .setArgs(DAppBrowserFragment.getBundle(DAppBrowserPayload.Address(url)))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReferendumDescription(payload: DescriptionPayload) {
         navigationBuilder(R.id.action_referendumDetailsFragment_to_referendumDescription)
             .setArgs(DescriptionFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmVoteReferendum(payload: ConfirmVoteReferendumPayload) {
         navigationBuilder(R.id.action_setupVoteReferendumFragment_to_confirmReferendumVote)
             .setArgs(ConfirmReferendumVoteFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openGovernanceLocksOverview() {
         navigationBuilder(R.id.action_mainFragment_to_governanceLocksOverview)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmGovernanceUnlock() {
         navigationBuilder(R.id.action_governanceLocksOverview_to_confirmGovernanceUnlock)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
@@ -3,8 +3,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.governance
 import android.os.Bundle
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.common.resources.ContextManager

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
@@ -3,8 +3,10 @@ package io.novafoundation.nova.app.root.navigation.navigators.governance
 import android.os.Bundle
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
+import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.common.utils.showBrowser
 import io.novafoundation.nova.feature_dapp_api.presentation.browser.main.DAppBrowserPayload
 import io.novafoundation.nova.feature_dapp_impl.presentation.browser.main.DAppBrowserFragment
@@ -44,45 +46,54 @@ import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vot
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.voters.ReferendumVotersPayload
 
 class GovernanceNavigator(
-    private val navigationHolder: NavigationHolder,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
     private val commonNavigator: Navigator,
-) : BaseNavigator(navigationHolder), GovernanceRouter {
+    private val contextManager: ContextManager
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), GovernanceRouter {
 
     override fun openReferendum(payload: ReferendumDetailsPayload) {
-        val currentDestination = navigationHolder.navController?.currentDestination
-        val destinationId = when (currentDestination?.id) {
-            R.id.referendumDetailsFragment -> R.id.action_referendumDetailsFragment_to_referendumDetailsFragment
-            R.id.referendaSearchFragment -> R.id.action_open_referendum_details_from_referenda_search
-            else -> R.id.action_open_referendum_details
-        }
-        performNavigation(destinationId, ReferendumDetailsFragment.getBundle(payload))
+        navigationBuilder()
+            .addCase(R.id.referendumDetailsFragment, R.id.action_referendumDetailsFragment_to_referendumDetailsFragment)
+            .addCase(R.id.referendaSearchFragment, R.id.action_open_referendum_details_from_referenda_search)
+            .setFallbackCase(R.id.action_open_referendum_details)
+            .setArgs(ReferendumDetailsFragment.getBundle(payload))
+            .perform()
     }
 
-    override fun openReferendumFullDetails(payload: ReferendumFullDetailsPayload) = performNavigation(
-        actionId = R.id.action_referendumDetailsFragment_to_referendumFullDetailsFragment,
-        args = ReferendumFullDetailsFragment.getBundle(payload)
-    )
+    override fun openReferendumFullDetails(payload: ReferendumFullDetailsPayload) {
+        navigationBuilder(R.id.action_referendumDetailsFragment_to_referendumFullDetailsFragment)
+            .setArgs(ReferendumFullDetailsFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openReferendumVoters(payload: ReferendumVotersPayload) = performNavigation(
-        actionId = R.id.action_referendumDetailsFragment_to_referendumVotersFragment,
-        args = ReferendumVotersFragment.getBundle(payload)
-    )
+    override fun openReferendumVoters(payload: ReferendumVotersPayload) {
+        navigationBuilder(R.id.action_referendumDetailsFragment_to_referendumVotersFragment)
+            .setArgs(ReferendumVotersFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openSetupReferendumVote(payload: SetupVotePayload) = performNavigation(
-        actionId = R.id.action_referendumDetailsFragment_to_setupVoteReferendumFragment,
-        args = SetupVoteFragment.getBundle(payload)
-    )
+    override fun openSetupReferendumVote(payload: SetupVotePayload) {
+        navigationBuilder(R.id.action_referendumDetailsFragment_to_setupVoteReferendumFragment)
+            .setArgs(SetupVoteFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openSetupTinderGovVote(payload: SetupVotePayload) = performNavigation(
-        actionId = R.id.action_tinderGovCards_to_setupTinderGovVoteFragment,
-        args = SetupVoteFragment.getBundle(payload)
-    )
+    override fun openSetupTinderGovVote(payload: SetupVotePayload) {
+        navigationBuilder(R.id.action_tinderGovCards_to_setupTinderGovVoteFragment)
+            .setArgs(SetupVoteFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun backToReferendumDetails() = performNavigation(R.id.action_confirmReferendumVote_to_referendumDetailsFragment)
+    override fun backToReferendumDetails() {
+        navigationBuilder(R.id.action_confirmReferendumVote_to_referendumDetailsFragment)
+            .perform()
+    }
 
     override fun finishUnlockFlow(shouldCloseLocksScreen: Boolean) {
         if (shouldCloseLocksScreen) {
-            performNavigation(R.id.action_confirmReferendumVote_to_mainFragment)
+            navigationBuilder(R.id.action_confirmReferendumVote_to_mainFragment)
+                .perform()
         } else {
             back()
         }
@@ -93,141 +104,163 @@ class GovernanceNavigator(
     }
 
     override fun openAddDelegation() {
-        performNavigation(
-            cases = arrayOf(
-                R.id.mainFragment to R.id.action_mainFragment_to_delegation,
-                R.id.yourDelegationsFragment to R.id.action_yourDelegations_to_delegationList,
-            )
-        )
+        navigationBuilder()
+            .addCase(R.id.mainFragment, R.id.action_mainFragment_to_delegation)
+            .addCase(R.id.yourDelegationsFragment, R.id.action_yourDelegations_to_delegationList)
+            .perform()
     }
 
     override fun openYourDelegations() {
-        performNavigation(R.id.action_mainFragment_to_your_delegation)
+        navigationBuilder(R.id.action_mainFragment_to_your_delegation)
+            .perform()
     }
 
     override fun openBecomingDelegateTutorial() {
-        navigationHolder.contextManager.getActivity()
-            ?.showBrowser(BuildConfig.DELEGATION_TUTORIAL_URL)
+        contextManager.getActivity()?.showBrowser(BuildConfig.DELEGATION_TUTORIAL_URL)
     }
 
-    override fun backToYourDelegations() = performNavigation(R.id.action_back_to_your_delegations)
+    override fun backToYourDelegations() {
+        navigationBuilder(R.id.action_back_to_your_delegations)
+            .perform()
+    }
 
-    override fun openRevokeDelegationChooseTracks(payload: RevokeDelegationChooseTracksPayload) = performNavigation(
-        actionId = R.id.action_delegateDetailsFragment_to_revokeDelegationChooseTracksFragment,
-        args = RevokeDelegationChooseTracksFragment.getBundle(payload)
-    )
+    override fun openRevokeDelegationChooseTracks(payload: RevokeDelegationChooseTracksPayload) {
+        navigationBuilder(R.id.action_delegateDetailsFragment_to_revokeDelegationChooseTracksFragment)
+            .setArgs(RevokeDelegationChooseTracksFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openRevokeDelegationsConfirm(payload: RevokeDelegationConfirmPayload) = performNavigation(
-        actionId = R.id.action_revokeDelegationChooseTracksFragment_to_revokeDelegationConfirmFragment,
-        args = RevokeDelegationConfirmFragment.getBundle(payload)
-    )
+    override fun openRevokeDelegationsConfirm(payload: RevokeDelegationConfirmPayload) {
+        navigationBuilder(R.id.action_revokeDelegationChooseTracksFragment_to_revokeDelegationConfirmFragment)
+            .setArgs(RevokeDelegationConfirmFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openDelegateSearch() {
-        performNavigation(R.id.action_delegateListFragment_to_delegateSearchFragment)
+        navigationBuilder(R.id.action_delegateListFragment_to_delegateSearchFragment)
+            .perform()
     }
 
     override fun openSelectGovernanceTracks(bundle: Bundle) {
-        performNavigation(R.id.action_open_select_governance_tracks, args = bundle)
+        navigationBuilder(R.id.action_open_select_governance_tracks)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openTinderGovCards() {
-        performNavigation(R.id.action_openTinderGovCards)
+        navigationBuilder(R.id.action_openTinderGovCards)
+            .perform()
     }
 
     override fun openTinderGovBasket() {
-        performNavigation(R.id.action_tinderGovCards_to_tinderGovBasket)
+        navigationBuilder(R.id.action_tinderGovCards_to_tinderGovBasket)
+            .perform()
     }
 
     override fun openConfirmTinderGovVote() {
-        performNavigation(R.id.action_setupTinderGovBasket_to_confirmTinderGovVote)
+        navigationBuilder(R.id.action_setupTinderGovBasket_to_confirmTinderGovVote)
+            .perform()
     }
 
-    override fun backToTinderGovCards() = performNavigation(
-        actionId = R.id.action_confirmTinderGovVote_to_tinderGovCards
-    )
+    override fun backToTinderGovCards() {
+        navigationBuilder(R.id.action_confirmTinderGovVote_to_tinderGovCards)
+            .perform()
+    }
 
-    override fun openReferendumInfo(payload: ReferendumInfoPayload) = performNavigation(
-        cases = arrayOf(
-            R.id.tinderGovCards to R.id.action_tinderGovCards_to_referendumInfo,
-            R.id.setupTinderGovBasketFragment to R.id.action_setupTinderGovBasket_to_referendumInfo
-        ),
-        args = ReferendumInfoFragment.getBundle(payload)
-    )
+    override fun openReferendumInfo(payload: ReferendumInfoPayload) {
+        navigationBuilder()
+            .addCase(R.id.tinderGovCards, R.id.action_tinderGovCards_to_referendumInfo)
+            .addCase(R.id.setupTinderGovBasketFragment, R.id.action_setupTinderGovBasket_to_referendumInfo)
+            .setArgs(ReferendumInfoFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openReferendaSearch() {
-        performNavigation(R.id.action_open_referenda_search)
+        navigationBuilder(R.id.action_open_referenda_search)
+            .perform()
     }
 
     override fun openReferendaFilters() {
-        performNavigation(R.id.action_open_referenda_filters)
+        navigationBuilder(R.id.action_open_referenda_filters)
+            .perform()
     }
 
-    override fun openRemoveVotes(payload: RemoveVotesPayload) = performNavigation(
-        actionId = R.id.action_open_remove_votes,
-        args = RemoveVotesFragment.getBundle(payload)
-    )
+    override fun openRemoveVotes(payload: RemoveVotesPayload) {
+        navigationBuilder(R.id.action_open_remove_votes)
+            .setArgs(RemoveVotesFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openDelegateDelegators(payload: DelegateDelegatorsPayload) {
-        val bundle = DelegateDelegatorsFragment.getBundle(payload)
-        return performNavigation(R.id.action_delegateDetailsFragment_to_delegateDelegatorsFragment, args = bundle)
+        navigationBuilder(R.id.action_delegateDetailsFragment_to_delegateDelegatorsFragment)
+            .setArgs(DelegateDelegatorsFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openDelegateDetails(payload: DelegateDetailsPayload) {
-        performNavigation(
-            cases = arrayOf(
-                R.id.delegateListFragment to R.id.action_delegateListFragment_to_delegateDetailsFragment,
-                R.id.yourDelegationsFragment to R.id.action_yourDelegations_to_delegationDetails,
-                R.id.delegateSearchFragment to R.id.action_delegateSearchFragment_to_delegateDetailsFragment,
-            ),
-            args = DelegateDetailsFragment.getBundle(payload)
-        )
+        navigationBuilder()
+            .addCase(R.id.delegateListFragment, R.id.action_delegateListFragment_to_delegateDetailsFragment)
+            .addCase(R.id.yourDelegationsFragment, R.id.action_yourDelegations_to_delegationDetails)
+            .addCase(R.id.delegateSearchFragment, R.id.action_delegateSearchFragment_to_delegateDetailsFragment)
+            .setArgs(DelegateDetailsFragment.getBundle(payload))
+            .perform()
     }
 
-    override fun openNewDelegationChooseTracks(payload: NewDelegationChooseTracksPayload) = performNavigation(
-        actionId = R.id.action_delegateDetailsFragment_to_selectDelegationTracks,
-        args = NewDelegationChooseTracksFragment.getBundle(payload)
-    )
+    override fun openNewDelegationChooseTracks(payload: NewDelegationChooseTracksPayload) {
+        navigationBuilder(R.id.action_delegateDetailsFragment_to_selectDelegationTracks)
+            .setArgs(NewDelegationChooseTracksFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openNewDelegationChooseAmount(payload: NewDelegationChooseAmountPayload) = performNavigation(
-        actionId = R.id.action_selectDelegationTracks_to_newDelegationChooseAmountFragment,
-        args = NewDelegationChooseAmountFragment.getBundle(payload)
-    )
+    override fun openNewDelegationChooseAmount(payload: NewDelegationChooseAmountPayload) {
+        navigationBuilder(R.id.action_selectDelegationTracks_to_newDelegationChooseAmountFragment)
+            .setArgs(NewDelegationChooseAmountFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openNewDelegationConfirm(payload: NewDelegationConfirmPayload) = performNavigation(
-        actionId = R.id.action_newDelegationChooseAmountFragment_to_newDelegationConfirmFragment,
-        args = NewDelegationConfirmFragment.getBundle(payload)
-    )
+    override fun openNewDelegationConfirm(payload: NewDelegationConfirmPayload) {
+        navigationBuilder(R.id.action_newDelegationChooseAmountFragment_to_newDelegationConfirmFragment)
+            .setArgs(NewDelegationConfirmFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openVotedReferenda(payload: VotedReferendaPayload) = performNavigation(
-        actionId = R.id.action_delegateDetailsFragment_to_votedReferendaFragment,
-        args = VotedReferendaFragment.getBundle(payload)
-    )
+    override fun openVotedReferenda(payload: VotedReferendaPayload) {
+        navigationBuilder(R.id.action_delegateDetailsFragment_to_votedReferendaFragment)
+            .setArgs(VotedReferendaFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openDelegateFullDescription(payload: DescriptionPayload) = performNavigation(
-        actionId = R.id.action_delegateDetailsFragment_to_delegateFullDescription,
-        args = DescriptionFragment.getBundle(payload)
-    )
+    override fun openDelegateFullDescription(payload: DescriptionPayload) {
+        navigationBuilder(R.id.action_delegateDetailsFragment_to_delegateFullDescription)
+            .setArgs(DescriptionFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openDAppBrowser(url: String) = performNavigation(
-        actionId = R.id.action_referendumDetailsFragment_to_DAppBrowserGraph,
-        args = DAppBrowserFragment.getBundle(DAppBrowserPayload.Address(url))
-    )
+    override fun openDAppBrowser(url: String) {
+        navigationBuilder(R.id.action_referendumDetailsFragment_to_DAppBrowserGraph)
+            .setArgs(DAppBrowserFragment.getBundle(DAppBrowserPayload.Address(url)))
+            .perform()
+    }
 
-    override fun openReferendumDescription(payload: DescriptionPayload) = performNavigation(
-        actionId = R.id.action_referendumDetailsFragment_to_referendumDescription,
-        args = DescriptionFragment.getBundle(payload)
-    )
+    override fun openReferendumDescription(payload: DescriptionPayload) {
+        navigationBuilder(R.id.action_referendumDetailsFragment_to_referendumDescription)
+            .setArgs(DescriptionFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openConfirmVoteReferendum(payload: ConfirmVoteReferendumPayload) = performNavigation(
-        actionId = R.id.action_setupVoteReferendumFragment_to_confirmReferendumVote,
-        args = ConfirmReferendumVoteFragment.getBundle(payload)
-    )
+    override fun openConfirmVoteReferendum(payload: ConfirmVoteReferendumPayload) {
+        navigationBuilder(R.id.action_setupVoteReferendumFragment_to_confirmReferendumVote)
+            .setArgs(ConfirmReferendumVoteFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openGovernanceLocksOverview() = performNavigation(
-        actionId = R.id.action_mainFragment_to_governanceLocksOverview
-    )
+    override fun openGovernanceLocksOverview() {
+        navigationBuilder(R.id.action_mainFragment_to_governanceLocksOverview)
+            .perform()
+    }
 
-    override fun openConfirmGovernanceUnlock() = performNavigation(
-        actionId = R.id.action_governanceLocksOverview_to_confirmGovernanceUnlock
-    )
+    override fun openConfirmGovernanceUnlock() {
+        navigationBuilder(R.id.action_governanceLocksOverview_to_confirmGovernanceUnlock)
+            .perform()
+    }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.common.utils.showBrowser
@@ -46,11 +47,10 @@ import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vot
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.voters.ReferendumVotersPayload
 
 class GovernanceNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val commonNavigator: Navigator,
     private val contextManager: ContextManager
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), GovernanceRouter {
+) : BaseNavigator(navigationHoldersRegistry), GovernanceRouter {
 
     override fun openReferendum(payload: ReferendumDetailsPayload) {
         navigationBuilder()

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/SelectTracksCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/SelectTracksCommunicatorImpl.kt
@@ -1,14 +1,14 @@
 package io.novafoundation.nova.app.root.navigation.navigators.governance
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksRequester
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksResponder
 import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
 import io.novafoundation.nova.feature_governance_impl.presentation.tracks.select.governanceTracks.SelectGovernanceTracksFragment
 
-class SelectTracksCommunicatorImpl(private val router: GovernanceRouter, navigationHolder: MainNavigationHolder) :
+class SelectTracksCommunicatorImpl(private val router: GovernanceRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<SelectTracksRequester.Request, SelectTracksResponder.Response>(navigationHolder),
     SelectTracksCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/SelectTracksCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/SelectTracksCommunicatorImpl.kt
@@ -2,14 +2,15 @@ package io.novafoundation.nova.app.root.navigation.navigators.governance
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksRequester
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksResponder
 import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
 import io.novafoundation.nova.feature_governance_impl.presentation.tracks.select.governanceTracks.SelectGovernanceTracksFragment
 
-class SelectTracksCommunicatorImpl(private val router: GovernanceRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<SelectTracksRequester.Request, SelectTracksResponder.Response>(navigationHolder),
+class SelectTracksCommunicatorImpl(private val router: GovernanceRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<SelectTracksRequester.Request, SelectTracksResponder.Response>(navigationHoldersRegistry),
     SelectTracksCommunicator {
 
     override fun openRequest(request: SelectTracksRequester.Request) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/SelectTracksCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/SelectTracksCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.governance
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.list.SelectTracksRequester

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/TinderGovVoteCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/TinderGovVoteCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.governance
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.setup.common.SetupVotePayload

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/TinderGovVoteCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/TinderGovVoteCommunicatorImpl.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.governance
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.setup.common.SetupVotePayload
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.setup.tindergov.TinderGovVoteCommunicator
@@ -9,8 +10,8 @@ import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vot
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.setup.tindergov.TinderGovVoteResponder
 import kotlinx.coroutines.flow.Flow
 
-class TinderGovVoteCommunicatorImpl(private val router: GovernanceRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<TinderGovVoteRequester.Request, TinderGovVoteResponder.Response>(navigationHolder),
+class TinderGovVoteCommunicatorImpl(private val router: GovernanceRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<TinderGovVoteRequester.Request, TinderGovVoteResponder.Response>(navigationHoldersRegistry),
     TinderGovVoteCommunicator {
 
     override val responseFlow: Flow<TinderGovVoteResponder.Response>

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/TinderGovVoteCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/TinderGovVoteCommunicatorImpl.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.governance
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.setup.common.SetupVotePayload
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.setup.tindergov.TinderGovVoteCommunicator
@@ -9,7 +9,7 @@ import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vot
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.setup.tindergov.TinderGovVoteResponder
 import kotlinx.coroutines.flow.Flow
 
-class TinderGovVoteCommunicatorImpl(private val router: GovernanceRouter, navigationHolder: MainNavigationHolder) :
+class TinderGovVoteCommunicatorImpl(private val router: GovernanceRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<TinderGovVoteRequester.Request, TinderGovVoteResponder.Response>(navigationHolder),
     TinderGovVoteCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
@@ -23,18 +23,18 @@ class LedgerNavigator(
 
     override fun openImportFillWallet() {
         navigationBuilder(R.id.action_startImportLedgerFragment_to_fillWalletImportLedgerFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun returnToImportFillWallet() {
         navigationBuilder(R.id.action_selectAddressImportLedgerFragment_to_fillWalletImportLedgerFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectImportAddress(payload: SelectLedgerAddressPayload) {
         navigationBuilder(R.id.action_selectLedgerImportFragment_to_selectAddressImportLedgerFragment)
             .setArgs(SelectAddressLedgerFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCreatePincode() {
@@ -48,7 +48,7 @@ class LedgerNavigator(
     override fun openFinishImportLedger(payload: FinishImportLedgerPayload) {
         navigationBuilder(R.id.action_fillWalletImportLedgerFragment_to_finishImportLedgerFragment)
             .setArgs(FinishImportLedgerFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishSignFlow() {
@@ -58,29 +58,29 @@ class LedgerNavigator(
     override fun openAddChainAccountSelectAddress(payload: AddLedgerChainAccountSelectAddressPayload) {
         navigationBuilder(R.id.action_addChainAccountSelectLedgerFragment_to_addChainAccountSelectAddressLedgerFragment)
             .setArgs(AddLedgerChainAccountSelectAddressFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectLedgerGeneric() {
         navigationBuilder(R.id.action_startImportGenericLedgerFragment_to_selectLedgerGenericImportFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectAddressGenericLedger(payload: SelectLedgerAddressPayload) {
         navigationBuilder(R.id.action_selectLedgerGenericImportFragment_to_selectAddressImportGenericLedgerFragment)
             .setArgs(SelectAddressLedgerFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openPreviewLedgerAccountsGeneric(payload: PreviewImportGenericLedgerPayload) {
         navigationBuilder(R.id.action_selectAddressImportGenericLedgerFragment_to_previewImportGenericLedgerFragment)
             .setArgs(PreviewImportGenericLedgerFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openFinishImportLedgerGeneric(payload: FinishImportGenericLedgerPayload) {
         navigationBuilder(R.id.action_previewImportGenericLedgerFragment_to_finishImportGenericLedgerFragment)
             .setArgs(FinishImportGenericLedgerFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.ledger
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_ledger_impl.presentation.LedgerRouter

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_ledger_impl.presentation.LedgerRouter
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.addChain.selectAddress.AddLedgerChainAccountSelectAddressFragment
@@ -19,9 +20,8 @@ import io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.l
 
 class LedgerNavigator(
     private val accountRouter: AccountRouter,
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), LedgerRouter {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : BaseNavigator(navigationHoldersRegistry), LedgerRouter {
 
     override fun openImportFillWallet() {
         navigationBuilder(R.id.action_startImportLedgerFragment_to_fillWalletImportLedgerFragment)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.ledger
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
@@ -18,17 +19,25 @@ import io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.l
 
 class LedgerNavigator(
     private val accountRouter: AccountRouter,
-    navigationHolder: SplitScreenNavigationHolder
-) : BaseNavigator(navigationHolder), LedgerRouter {
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), LedgerRouter {
 
-    override fun openImportFillWallet() = performNavigation(R.id.action_startImportLedgerFragment_to_fillWalletImportLedgerFragment)
+    override fun openImportFillWallet() {
+        navigationBuilder(R.id.action_startImportLedgerFragment_to_fillWalletImportLedgerFragment)
+            .perform()
+    }
 
-    override fun returnToImportFillWallet() = performNavigation(R.id.action_selectAddressImportLedgerFragment_to_fillWalletImportLedgerFragment)
+    override fun returnToImportFillWallet() {
+        navigationBuilder(R.id.action_selectAddressImportLedgerFragment_to_fillWalletImportLedgerFragment)
+            .perform()
+    }
 
-    override fun openSelectImportAddress(payload: SelectLedgerAddressPayload) = performNavigation(
-        actionId = R.id.action_selectLedgerImportFragment_to_selectAddressImportLedgerFragment,
-        args = SelectAddressLedgerFragment.getBundle(payload)
-    )
+    override fun openSelectImportAddress(payload: SelectLedgerAddressPayload) {
+        navigationBuilder(R.id.action_selectLedgerImportFragment_to_selectAddressImportLedgerFragment)
+            .setArgs(SelectAddressLedgerFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openCreatePincode() {
         accountRouter.openCreatePincode()
@@ -38,33 +47,42 @@ class LedgerNavigator(
         accountRouter.openMain()
     }
 
-    override fun openFinishImportLedger(payload: FinishImportLedgerPayload) = performNavigation(
-        actionId = R.id.action_fillWalletImportLedgerFragment_to_finishImportLedgerFragment,
-        args = FinishImportLedgerFragment.getBundle(payload)
-    )
+    override fun openFinishImportLedger(payload: FinishImportLedgerPayload) {
+        navigationBuilder(R.id.action_fillWalletImportLedgerFragment_to_finishImportLedgerFragment)
+            .setArgs(FinishImportLedgerFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun finishSignFlow() {
         back()
     }
 
-    override fun openAddChainAccountSelectAddress(payload: AddLedgerChainAccountSelectAddressPayload) = performNavigation(
-        actionId = R.id.action_addChainAccountSelectLedgerFragment_to_addChainAccountSelectAddressLedgerFragment,
-        args = AddLedgerChainAccountSelectAddressFragment.getBundle(payload)
-    )
+    override fun openAddChainAccountSelectAddress(payload: AddLedgerChainAccountSelectAddressPayload) {
+        navigationBuilder(R.id.action_addChainAccountSelectLedgerFragment_to_addChainAccountSelectAddressLedgerFragment)
+            .setArgs(AddLedgerChainAccountSelectAddressFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openSelectLedgerGeneric() = performNavigation(R.id.action_startImportGenericLedgerFragment_to_selectLedgerGenericImportFragment)
+    override fun openSelectLedgerGeneric() {
+        navigationBuilder(R.id.action_startImportGenericLedgerFragment_to_selectLedgerGenericImportFragment)
+            .perform()
+    }
 
-    override fun openSelectAddressGenericLedger(payload: SelectLedgerAddressPayload) = performNavigation(
-        actionId = R.id.action_selectLedgerGenericImportFragment_to_selectAddressImportGenericLedgerFragment,
-        args = SelectAddressLedgerFragment.getBundle(payload)
-    )
-    override fun openPreviewLedgerAccountsGeneric(payload: PreviewImportGenericLedgerPayload) = performNavigation(
-        actionId = R.id.action_selectAddressImportGenericLedgerFragment_to_previewImportGenericLedgerFragment,
-        args = PreviewImportGenericLedgerFragment.getBundle(payload)
-    )
+    override fun openSelectAddressGenericLedger(payload: SelectLedgerAddressPayload) {
+        navigationBuilder(R.id.action_selectLedgerGenericImportFragment_to_selectAddressImportGenericLedgerFragment)
+            .setArgs(SelectAddressLedgerFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openFinishImportLedgerGeneric(payload: FinishImportGenericLedgerPayload) = performNavigation(
-        actionId = R.id.action_previewImportGenericLedgerFragment_to_finishImportGenericLedgerFragment,
-        args = FinishImportGenericLedgerFragment.getBundle(payload)
-    )
+    override fun openPreviewLedgerAccountsGeneric(payload: PreviewImportGenericLedgerPayload) {
+        navigationBuilder(R.id.action_selectAddressImportGenericLedgerFragment_to_previewImportGenericLedgerFragment)
+            .setArgs(PreviewImportGenericLedgerFragment.getBundle(payload))
+            .perform()
+    }
+
+    override fun openFinishImportLedgerGeneric(payload: FinishImportGenericLedgerPayload) {
+        navigationBuilder(R.id.action_previewImportGenericLedgerFragment_to_finishImportGenericLedgerFragment)
+            .setArgs(FinishImportGenericLedgerFragment.getBundle(payload))
+            .perform()
+    }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerNavigator.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.ledger
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
 import io.novafoundation.nova.feature_ledger_impl.presentation.LedgerRouter
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.addChain.selectAddress.AddLedgerChainAccountSelectAddressFragment
@@ -18,7 +18,7 @@ import io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.l
 
 class LedgerNavigator(
     private val accountRouter: AccountRouter,
-    navigationHolder: MainNavigationHolder
+    navigationHolder: SplitScreenNavigationHolder
 ) : BaseNavigator(navigationHolder), LedgerRouter {
 
     override fun openImportFillWallet() = performNavigation(R.id.action_startImportLedgerFragment_to_fillWalletImportLedgerFragment)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerSignCommunicatorImpl.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.ledger
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.getBackStackEntryBefore
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerSignCommunicatorImpl.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.getBackStackEntryBefore
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant
 import io.novafoundation.nova.feature_account_api.presenatation.sign.LedgerSignCommunicator
 import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterScreenCommunicator.Request
@@ -11,8 +12,8 @@ import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterSc
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerFragment
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerPayload
 
-class LedgerSignCommunicatorImpl(navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<Request, Response>(navigationHolder), LedgerSignCommunicator {
+class LedgerSignCommunicatorImpl(navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<Request, Response>(navigationHoldersRegistry), LedgerSignCommunicator {
 
     private var usedVariant: LedgerVariant? = null
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerSignCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/LedgerSignCommunicatorImpl.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.ledger
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.getBackStackEntryBefore
 import io.novafoundation.nova.feature_account_api.domain.model.LedgerVariant
 import io.novafoundation.nova.feature_account_api.presenatation.sign.LedgerSignCommunicator
@@ -11,7 +11,7 @@ import io.novafoundation.nova.feature_account_api.presenatation.sign.SignInterSc
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerFragment
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.sign.SignLedgerPayload
 
-class LedgerSignCommunicatorImpl(navigationHolder: MainNavigationHolder) :
+class LedgerSignCommunicatorImpl(navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<Request, Response>(navigationHolder), LedgerSignCommunicator {
 
     private var usedVariant: LedgerVariant? = null

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/SelectLedgerAddressCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/SelectLedgerAddressCommunicatorImpl.kt
@@ -3,13 +3,14 @@ package io.novafoundation.nova.app.root.navigation.navigators.ledger
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.selectLedger.SelectLedgerFragment
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.selectLedger.SelectLedgerPayload
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.legacy.LedgerChainAccount
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.legacy.SelectLedgerAddressInterScreenCommunicator
 
-class SelectLedgerAddressCommunicatorImpl(navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<SelectLedgerPayload, LedgerChainAccount>(navigationHolder),
+class SelectLedgerAddressCommunicatorImpl(navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<SelectLedgerPayload, LedgerChainAccount>(navigationHoldersRegistry),
     SelectLedgerAddressInterScreenCommunicator {
 
     override fun openRequest(request: SelectLedgerPayload) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/SelectLedgerAddressCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/SelectLedgerAddressCommunicatorImpl.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.ledger
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.selectLedger.SelectLedgerFragment
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.selectLedger.SelectLedgerPayload

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/SelectLedgerAddressCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/ledger/SelectLedgerAddressCommunicatorImpl.kt
@@ -2,13 +2,13 @@ package io.novafoundation.nova.app.root.navigation.navigators.ledger
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.selectLedger.SelectLedgerFragment
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.common.selectLedger.SelectLedgerPayload
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.legacy.LedgerChainAccount
 import io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.legacy.SelectLedgerAddressInterScreenCommunicator
 
-class SelectLedgerAddressCommunicatorImpl(navigationHolder: MainNavigationHolder) :
+class SelectLedgerAddressCommunicatorImpl(navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<SelectLedgerPayload, LedgerChainAccount>(navigationHolder),
     SelectLedgerAddressInterScreenCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
@@ -4,13 +4,13 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_nft_impl.NftRouter
 import io.novafoundation.nova.feature_nft_impl.presentation.nft.details.NftDetailsFragment
 
 class NftNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), NftRouter {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : BaseNavigator(navigationHoldersRegistry), NftRouter {
 
     override fun openNftDetails(nftId: String) {
         navigationBuilder(R.id.action_nftListFragment_to_nftDetailsFragment)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
@@ -2,12 +2,12 @@ package io.novafoundation.nova.app.root.navigation.navigators.nft
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_nft_impl.NftRouter
 import io.novafoundation.nova.feature_nft_impl.presentation.nft.details.NftDetailsFragment
 
 class NftNavigator(
-    navigationHolder: MainNavigationHolder,
+    navigationHolder: SplitScreenNavigationHolder,
 ) : BaseNavigator(navigationHolder), NftRouter {
 
     override fun openNftDetails(nftId: String) = performNavigation(

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
@@ -13,6 +13,6 @@ class NftNavigator(
     override fun openNftDetails(nftId: String) {
         navigationBuilder(R.id.action_nftListFragment_to_nftDetailsFragment)
             .setArgs(NftDetailsFragment.getBundle(nftId))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
@@ -1,17 +1,20 @@
 package io.novafoundation.nova.app.root.navigation.navigators.nft
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_nft_impl.NftRouter
 import io.novafoundation.nova.feature_nft_impl.presentation.nft.details.NftDetailsFragment
 
 class NftNavigator(
-    navigationHolder: SplitScreenNavigationHolder,
-) : BaseNavigator(navigationHolder), NftRouter {
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), NftRouter {
 
-    override fun openNftDetails(nftId: String) = performNavigation(
-        actionId = R.id.action_nftListFragment_to_nftDetailsFragment,
-        args = NftDetailsFragment.getBundle(nftId)
-    )
+    override fun openNftDetails(nftId: String) {
+        navigationBuilder(R.id.action_nftListFragment_to_nftDetailsFragment)
+            .setArgs(NftDetailsFragment.getBundle(nftId))
+            .perform()
+    }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/nft/NftNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.nft
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_nft_impl.NftRouter
 import io.novafoundation.nova.feature_nft_impl.presentation.nft.details.NftDetailsFragment

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.pincode
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationCommunicator
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationRequester.Request
@@ -11,7 +12,7 @@ import io.novafoundation.nova.feature_account_impl.presentation.pincode.PincodeF
 import kotlinx.coroutines.flow.Flow
 
 class PinCodeTwoFactorVerificationCommunicatorImpl(
-    navigationHolder: SplitScreenNavigationHolder
+    navigationHolder: RootNavigationHolder
 ) : NavStackInterScreenCommunicator<Request, Response>(navigationHolder), PinCodeTwoFactorVerificationCommunicator {
 
     override val responseFlow: Flow<Response>

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
@@ -2,8 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.pincode
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationCommunicator
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationRequester.Request

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.pincode
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationCommunicator
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationRequester.Request
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationResponder.Response
@@ -11,7 +11,7 @@ import io.novafoundation.nova.feature_account_impl.presentation.pincode.PincodeF
 import kotlinx.coroutines.flow.Flow
 
 class PinCodeTwoFactorVerificationCommunicatorImpl(
-    navigationHolder: MainNavigationHolder
+    navigationHolder: SplitScreenNavigationHolder
 ) : NavStackInterScreenCommunicator<Request, Response>(navigationHolder), PinCodeTwoFactorVerificationCommunicator {
 
     override val responseFlow: Flow<Response>

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
@@ -24,6 +24,6 @@ class PinCodeTwoFactorVerificationCommunicatorImpl(
 
         navigationBuilder(R.id.action_pin_code_two_factor_verification)
             .setArgs(bundle)
-            .performInRoot()
+            .navigateInRoot()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/pincode/PinCodeTwoFactorVerificationCommunicatorImpl.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationCommunicator
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationRequester.Request
 import io.novafoundation.nova.common.sequrity.verification.PinCodeTwoFactorVerificationResponder.Response
@@ -12,8 +13,8 @@ import io.novafoundation.nova.feature_account_impl.presentation.pincode.PincodeF
 import kotlinx.coroutines.flow.Flow
 
 class PinCodeTwoFactorVerificationCommunicatorImpl(
-    navigationHolder: RootNavigationHolder
-) : NavStackInterScreenCommunicator<Request, Response>(navigationHolder), PinCodeTwoFactorVerificationCommunicator {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : NavStackInterScreenCommunicator<Request, Response>(navigationHoldersRegistry), PinCodeTwoFactorVerificationCommunicator {
 
     override val responseFlow: Flow<Response>
         get() = clearedResponseFlow()
@@ -22,6 +23,9 @@ class PinCodeTwoFactorVerificationCommunicatorImpl(
         super.openRequest(request)
         val action = PinCodeAction.TwoFactorVerification(request.useBiometryIfEnabled)
         val bundle = PincodeFragment.getPinCodeBundle(action)
-        navController.navigate(R.id.action_pin_code_two_factor_verification, bundle)
+
+        navigationBuilder(R.id.action_pin_code_two_factor_verification)
+            .setArgs(bundle)
+            .performInRoot()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushGovernanceSettingsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushGovernanceSettingsCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.push
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsCommunicator

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushGovernanceSettingsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushGovernanceSettingsCommunicatorImpl.kt
@@ -1,14 +1,14 @@
 package io.novafoundation.nova.app.root.navigation.navigators.push
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsCommunicator
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsFragment
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsRequester
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsResponder
 
-class PushGovernanceSettingsCommunicatorImpl(private val router: PushNotificationsRouter, navigationHolder: MainNavigationHolder) :
+class PushGovernanceSettingsCommunicatorImpl(private val router: PushNotificationsRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<PushGovernanceSettingsRequester.Request, PushGovernanceSettingsResponder.Response>(navigationHolder),
     PushGovernanceSettingsCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushGovernanceSettingsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushGovernanceSettingsCommunicatorImpl.kt
@@ -2,14 +2,15 @@ package io.novafoundation.nova.app.root.navigation.navigators.push
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsCommunicator
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsFragment
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsRequester
 import io.novafoundation.nova.feature_push_notifications.presentation.governance.PushGovernanceSettingsResponder
 
-class PushGovernanceSettingsCommunicatorImpl(private val router: PushNotificationsRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<PushGovernanceSettingsRequester.Request, PushGovernanceSettingsResponder.Response>(navigationHolder),
+class PushGovernanceSettingsCommunicatorImpl(private val router: PushNotificationsRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<PushGovernanceSettingsRequester.Request, PushGovernanceSettingsResponder.Response>(navigationHoldersRegistry),
     PushGovernanceSettingsCommunicator {
 
     override fun openRequest(request: PushGovernanceSettingsRequester.Request) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
@@ -5,12 +5,12 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 
 class PushNotificationsNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), PushNotificationsRouter {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : BaseNavigator(navigationHoldersRegistry), PushNotificationsRouter {
 
     override fun openPushSettings() {
         navigationBuilder(R.id.action_pushWelcome_to_pushSettings)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
@@ -3,11 +3,11 @@ package io.novafoundation.nova.app.root.navigation.navigators.push
 import android.os.Bundle
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 
 class PushNotificationsNavigator(
-    navigationHolder: MainNavigationHolder,
+    navigationHolder: SplitScreenNavigationHolder,
 ) : BaseNavigator(navigationHolder), PushNotificationsRouter {
 
     override fun openPushSettings() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
@@ -12,18 +12,18 @@ class PushNotificationsNavigator(
 
     override fun openPushSettings() {
         navigationBuilder(R.id.action_pushWelcome_to_pushSettings)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openPushGovernanceSettings(args: Bundle) {
         navigationBuilder(R.id.action_pushSettings_to_governanceSettings)
             .setArgs(args)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openPushStakingSettings(args: Bundle) {
         navigationBuilder(R.id.action_pushSettings_to_stakingSettings)
             .setArgs(args)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
@@ -2,9 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.push
 
 import android.os.Bundle
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushNotificationsNavigator.kt
@@ -2,23 +2,30 @@ package io.novafoundation.nova.app.root.navigation.navigators.push
 
 import android.os.Bundle
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 
 class PushNotificationsNavigator(
-    navigationHolder: SplitScreenNavigationHolder,
-) : BaseNavigator(navigationHolder), PushNotificationsRouter {
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), PushNotificationsRouter {
 
     override fun openPushSettings() {
-        performNavigation(R.id.action_pushWelcome_to_pushSettings)
+        navigationBuilder(R.id.action_pushWelcome_to_pushSettings)
+            .perform()
     }
 
     override fun openPushGovernanceSettings(args: Bundle) {
-        performNavigation(R.id.action_pushSettings_to_governanceSettings, args)
+        navigationBuilder(R.id.action_pushSettings_to_governanceSettings)
+            .setArgs(args)
+            .perform()
     }
 
     override fun openPushStakingSettings(args: Bundle) {
-        performNavigation(R.id.action_pushSettings_to_stakingSettings, args)
+        navigationBuilder(R.id.action_pushSettings_to_stakingSettings)
+            .setArgs(args)
+            .perform()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushStakingSettingsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushStakingSettingsCommunicatorImpl.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.push
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsCommunicator

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushStakingSettingsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushStakingSettingsCommunicatorImpl.kt
@@ -1,14 +1,14 @@
 package io.novafoundation.nova.app.root.navigation.navigators.push
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsCommunicator
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsFragment
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsRequester
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsResponder
 
-class PushStakingSettingsCommunicatorImpl(private val router: PushNotificationsRouter, navigationHolder: MainNavigationHolder) :
+class PushStakingSettingsCommunicatorImpl(private val router: PushNotificationsRouter, navigationHolder: SplitScreenNavigationHolder) :
     NavStackInterScreenCommunicator<PushStakingSettingsRequester.Request, PushStakingSettingsResponder.Response>(navigationHolder),
     PushStakingSettingsCommunicator {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushStakingSettingsCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/push/PushStakingSettingsCommunicatorImpl.kt
@@ -2,14 +2,15 @@ package io.novafoundation.nova.app.root.navigation.navigators.push
 
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_push_notifications.PushNotificationsRouter
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsCommunicator
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsFragment
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsRequester
 import io.novafoundation.nova.feature_push_notifications.presentation.staking.PushStakingSettingsResponder
 
-class PushStakingSettingsCommunicatorImpl(private val router: PushNotificationsRouter, navigationHolder: SplitScreenNavigationHolder) :
-    NavStackInterScreenCommunicator<PushStakingSettingsRequester.Request, PushStakingSettingsResponder.Response>(navigationHolder),
+class PushStakingSettingsCommunicatorImpl(private val router: PushNotificationsRouter, navigationHoldersRegistry: NavigationHoldersRegistry) :
+    NavStackInterScreenCommunicator<PushStakingSettingsRequester.Request, PushStakingSettingsResponder.Response>(navigationHoldersRegistry),
     PushStakingSettingsCommunicator {
 
     override fun openRequest(request: PushStakingSettingsRequester.Request) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.settings
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.feature_account_impl.presentation.pincode.PinCodeAction
@@ -19,7 +19,7 @@ import io.novafoundation.nova.feature_wallet_connect_impl.WalletConnectRouter
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.list.WalletConnectSessionsPayload
 
 class SettingsNavigator(
-    navigationHolder: MainNavigationHolder,
+    navigationHolder: SplitScreenNavigationHolder,
     private val rootRouter: RootRouter,
     private val walletConnectDelegate: WalletConnectRouter,
     private val delegate: Navigator

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.settings
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.presentation.RootRouter

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.settings
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
@@ -19,11 +20,12 @@ import io.novafoundation.nova.feature_wallet_connect_impl.WalletConnectRouter
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.list.WalletConnectSessionsPayload
 
 class SettingsNavigator(
-    navigationHolder: SplitScreenNavigationHolder,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
     private val rootRouter: RootRouter,
     private val walletConnectDelegate: WalletConnectRouter,
     private val delegate: Navigator
-) : BaseNavigator(navigationHolder),
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder),
     SettingsRouter {
 
     override fun returnToWallet() {
@@ -35,63 +37,75 @@ class SettingsNavigator(
     }
 
     override fun openNetworks() {
-        performNavigation(R.id.action_open_networkManagement)
+        navigationBuilder(R.id.action_open_networkManagement)
+            .perform()
     }
 
     override fun openNetworkDetails(payload: ChainNetworkManagementPayload) {
-        performNavigation(
-            R.id.action_open_networkManagementDetails,
-            args = ChainNetworkManagementFragment.getBundle(payload)
-        )
+        navigationBuilder(R.id.action_open_networkManagementDetails)
+            .setArgs(ChainNetworkManagementFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openCustomNode(payload: CustomNodePayload) {
-        performNavigation(
-            R.id.action_open_customNode,
-            args = CustomNodeFragment.getBundle(payload)
-        )
+        navigationBuilder(R.id.action_open_customNode)
+            .setArgs(CustomNodeFragment.getBundle(payload))
+            .perform()
     }
 
     override fun addNetwork() {
-        performNavigation(R.id.action_open_preConfiguredNetworks)
+        navigationBuilder(R.id.action_open_preConfiguredNetworks)
+            .perform()
     }
 
     override fun openCreateNetworkFlow() {
-        performNavigation(R.id.action_open_addNetworkFragment)
+        navigationBuilder(R.id.action_open_addNetworkFragment)
+            .perform()
     }
 
     override fun openCreateNetworkFlow(payload: AddNetworkPayload.Mode.Add) {
-        performNavigation(
-            R.id.action_open_addNetworkFragment,
-            args = AddNetworkMainFragment.getBundle(AddNetworkPayload(payload))
-        )
+        navigationBuilder(R.id.action_open_addNetworkFragment)
+            .setArgs(AddNetworkMainFragment.getBundle(AddNetworkPayload(payload)))
+            .perform()
     }
 
     override fun finishCreateNetworkFlow() {
-        performNavigation(R.id.action_finishCreateNetworkFlow, args = NetworkManagementListFragment.getBundle(openAddedTab = true))
+        navigationBuilder(R.id.action_finishCreateNetworkFlow)
+            .setArgs(NetworkManagementListFragment.getBundle(openAddedTab = true))
+            .perform()
     }
 
     override fun openEditNetwork(payload: AddNetworkPayload.Mode.Edit) {
-        performNavigation(
-            R.id.action_open_editNetwork,
-            args = AddNetworkMainFragment.getBundle(AddNetworkPayload(payload))
-        )
+        navigationBuilder(R.id.action_open_editNetwork)
+            .setArgs(AddNetworkMainFragment.getBundle(AddNetworkPayload(payload)))
+            .perform()
     }
 
     override fun openPushNotificationSettings() {
-        performNavigation(R.id.action_open_pushNotificationsSettings)
+        navigationBuilder(R.id.action_open_pushNotificationsSettings)
+            .perform()
     }
 
-    override fun openCurrencies() = performNavigation(R.id.action_mainFragment_to_currenciesFragment)
+    override fun openCurrencies() {
+        navigationBuilder(R.id.action_mainFragment_to_currenciesFragment)
+            .perform()
+    }
 
-    override fun openLanguages() = performNavigation(R.id.action_mainFragment_to_languagesFragment)
+    override fun openLanguages() {
+        navigationBuilder(R.id.action_mainFragment_to_languagesFragment)
+            .perform()
+    }
 
-    override fun openAppearance() = performNavigation(R.id.action_mainFragment_to_appearanceFragment)
+    override fun openAppearance() {
+        navigationBuilder(R.id.action_mainFragment_to_appearanceFragment)
+            .perform()
+    }
 
-    override fun openChangePinCode() = performNavigation(
-        actionId = R.id.action_change_pin_code,
-        args = PincodeFragment.getPinCodeBundle(PinCodeAction.Change)
-    )
+    override fun openChangePinCode() {
+        navigationBuilder(R.id.action_change_pin_code)
+            .setArgs(PincodeFragment.getPinCodeBundle(PinCodeAction.Change))
+            .perform()
+    }
 
     override fun openWalletDetails(metaId: Long) {
         delegate.openWalletDetails(metaId)
@@ -110,10 +124,12 @@ class SettingsNavigator(
     }
 
     override fun openCloudBackupSettings() {
-        performNavigation(R.id.action_open_cloudBackupSettings)
+        navigationBuilder(R.id.action_open_cloudBackupSettings)
+            .perform()
     }
 
     override fun openManualBackup() {
-        performNavigation(R.id.action_open_manualBackupSelectWallet)
+        navigationBuilder(R.id.action_open_manualBackupSelectWallet)
+            .perform()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.feature_account_impl.presentation.pincode.PinCodeAction
@@ -20,12 +21,11 @@ import io.novafoundation.nova.feature_wallet_connect_impl.WalletConnectRouter
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.list.WalletConnectSessionsPayload
 
 class SettingsNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val rootRouter: RootRouter,
     private val walletConnectDelegate: WalletConnectRouter,
     private val delegate: Navigator
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder),
+) : BaseNavigator(navigationHoldersRegistry),
     SettingsRouter {
 
     override fun returnToWallet() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/settings/SettingsNavigator.kt
@@ -36,73 +36,73 @@ class SettingsNavigator(
 
     override fun openNetworks() {
         navigationBuilder(R.id.action_open_networkManagement)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openNetworkDetails(payload: ChainNetworkManagementPayload) {
         navigationBuilder(R.id.action_open_networkManagementDetails)
             .setArgs(ChainNetworkManagementFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCustomNode(payload: CustomNodePayload) {
         navigationBuilder(R.id.action_open_customNode)
             .setArgs(CustomNodeFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun addNetwork() {
         navigationBuilder(R.id.action_open_preConfiguredNetworks)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCreateNetworkFlow() {
         navigationBuilder(R.id.action_open_addNetworkFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCreateNetworkFlow(payload: AddNetworkPayload.Mode.Add) {
         navigationBuilder(R.id.action_open_addNetworkFragment)
             .setArgs(AddNetworkMainFragment.getBundle(AddNetworkPayload(payload)))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishCreateNetworkFlow() {
         navigationBuilder(R.id.action_finishCreateNetworkFlow)
             .setArgs(NetworkManagementListFragment.getBundle(openAddedTab = true))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openEditNetwork(payload: AddNetworkPayload.Mode.Edit) {
         navigationBuilder(R.id.action_open_editNetwork)
             .setArgs(AddNetworkMainFragment.getBundle(AddNetworkPayload(payload)))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openPushNotificationSettings() {
         navigationBuilder(R.id.action_open_pushNotificationsSettings)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCurrencies() {
         navigationBuilder(R.id.action_mainFragment_to_currenciesFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openLanguages() {
         navigationBuilder(R.id.action_mainFragment_to_languagesFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAppearance() {
         navigationBuilder(R.id.action_mainFragment_to_appearanceFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openChangePinCode() {
         navigationBuilder(R.id.action_change_pin_code)
             .setArgs(PincodeFragment.getPinCodeBundle(PinCodeAction.Change))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openWalletDetails(metaId: Long) {
@@ -123,11 +123,11 @@ class SettingsNavigator(
 
     override fun openCloudBackupSettings() {
         navigationBuilder(R.id.action_open_cloudBackupSettings)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openManualBackup() {
         navigationBuilder(R.id.action_open_manualBackupSelectWallet)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
@@ -3,10 +3,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking
 import androidx.lifecycle.MutableLiveData
 import androidx.navigation.NavController
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
-import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.event
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking
 import androidx.lifecycle.MutableLiveData
 import androidx.navigation.NavController
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.common.utils.Event
@@ -10,8 +11,9 @@ import io.novafoundation.nova.common.utils.event
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 
 class StakingDashboardNavigator(
-    navigationHolder: SplitScreenNavigationHolder,
-) : BaseNavigator(navigationHolder), StakingDashboardRouter {
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), StakingDashboardRouter {
 
     private var stakingTabNavController: NavController? = null
     private var pendingAction: Int? = null

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
@@ -4,13 +4,13 @@ import androidx.lifecycle.MutableLiveData
 import androidx.navigation.NavController
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.event
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 
 class StakingDashboardNavigator(
-    navigationHolder: MainNavigationHolder,
+    navigationHolder: SplitScreenNavigationHolder,
 ) : BaseNavigator(navigationHolder), StakingDashboardRouter {
 
     private var stakingTabNavController: NavController? = null

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
@@ -11,9 +11,7 @@ import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.event
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 
-class StakingDashboardNavigator(
-    navigationHoldersRegistry: NavigationHoldersRegistry
-) : BaseNavigator(navigationHoldersRegistry), StakingDashboardRouter {
+class StakingDashboardNavigator : StakingDashboardRouter {
 
     private var stakingTabNavController: NavController? = null
     private var pendingAction: Int? = null
@@ -42,8 +40,7 @@ class StakingDashboardNavigator(
     }
 
     override fun returnToStakingDashboard() {
-        navigationBuilder(R.id.back_to_main)
-            .perform()
+        stakingTabNavController?.navigate(R.id.back_to_main)
 
         returnToStakingTabRoot()
         scrollToDashboardTopEvent.value = Unit.event()

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
@@ -6,14 +6,14 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.event
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 
 class StakingDashboardNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), StakingDashboardRouter {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : BaseNavigator(navigationHoldersRegistry), StakingDashboardRouter {
 
     private var stakingTabNavController: NavController? = null
     private var pendingAction: Int? = null
@@ -24,7 +24,7 @@ class StakingDashboardNavigator(
         stakingTabNavController = navController
 
         if (pendingAction != null) {
-            navController.performNavigation(pendingAction!!)
+            navController.navigate(pendingAction!!)
             pendingAction = null
         }
     }
@@ -34,7 +34,7 @@ class StakingDashboardNavigator(
     }
 
     override fun openMoreStakingOptions() {
-        stakingTabNavController?.performNavigation(R.id.action_stakingDashboardFragment_to_moreStakingOptionsFragment)
+        stakingTabNavController?.navigate(R.id.action_stakingDashboardFragment_to_moreStakingOptionsFragment)
     }
 
     override fun backInStakingTab() {
@@ -42,11 +42,12 @@ class StakingDashboardNavigator(
     }
 
     override fun returnToStakingDashboard() {
-        performNavigation(R.id.back_to_main)
+        navigationBuilder(R.id.back_to_main)
+            .perform()
+
         returnToStakingTabRoot()
         scrollToDashboardTopEvent.value = Unit.event()
     }
-
     override fun openStakingDashboard() {
         stakingTabNavController.performNavigationOrDelay(R.id.action_open_staking)
     }
@@ -59,7 +60,7 @@ class StakingDashboardNavigator(
         val controller = this
 
         if (controller != null) {
-            controller.performNavigation(actionId)
+            controller.navigate(actionId)
         } else {
             pendingAction = actionId
         }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
@@ -27,36 +27,36 @@ class StartMultiStakingNavigator(
     override fun openStartStakingLanding(payload: StartStakingLandingPayload) {
         navigationBuilder(R.id.action_mainFragment_to_startStackingLanding)
             .setArgs(StartStakingLandingFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStartParachainStaking() {
         navigationBuilder(R.id.action_startStakingLandingFragment_to_staking_parachain_start_graph)
             .setArgs(StartParachainStakingFragment.getBundle(StartParachainStakingPayload(StartParachainStakingMode.START)))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStartMultiStaking(payload: SetupAmountMultiStakingPayload) {
         navigationBuilder(R.id.action_startStakingLandingFragment_to_start_multi_staking_nav_graph)
             .setArgs(SetupAmountMultiStakingFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSetupStakingType(payload: SetupStakingTypePayload) {
         navigationBuilder(R.id.action_setupAmountMultiStakingFragment_to_setupStakingType)
             .setArgs(SetupStakingTypeFragment.getArguments(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirm(payload: ConfirmMultiStakingPayload) {
         navigationBuilder(R.id.action_setupAmountMultiStakingFragment_to_confirmMultiStakingFragment)
             .setArgs(ConfirmMultiStakingFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectedValidators() {
         navigationBuilder(R.id.action_confirmMultiStakingFragment_to_confirmNominationsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun returnToStakingDashboard() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.staking
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
@@ -19,38 +20,45 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.se
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.setupStakingType.SetupStakingTypePayload
 
 class StartMultiStakingNavigator(
-    navigationHolder: SplitScreenNavigationHolder,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
     private val stakingDashboardRouter: StakingDashboardRouter,
     private val commonNavigationHolder: Navigator,
-) : BaseNavigator(navigationHolder), StartMultiStakingRouter {
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), StartMultiStakingRouter {
 
-    override fun openStartStakingLanding(payload: StartStakingLandingPayload) = performNavigation(
-        actionId = R.id.action_mainFragment_to_startStackingLanding,
-        args = StartStakingLandingFragment.getBundle(payload)
-    )
+    override fun openStartStakingLanding(payload: StartStakingLandingPayload) {
+        navigationBuilder(R.id.action_mainFragment_to_startStackingLanding)
+            .setArgs(StartStakingLandingFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openStartParachainStaking() = performNavigation(
-        actionId = R.id.action_startStakingLandingFragment_to_staking_parachain_start_graph,
-        args = StartParachainStakingFragment.getBundle(StartParachainStakingPayload(StartParachainStakingMode.START))
-    )
+    override fun openStartParachainStaking() {
+        navigationBuilder(R.id.action_startStakingLandingFragment_to_staking_parachain_start_graph)
+            .setArgs(StartParachainStakingFragment.getBundle(StartParachainStakingPayload(StartParachainStakingMode.START)))
+            .perform()
+    }
 
-    override fun openStartMultiStaking(payload: SetupAmountMultiStakingPayload) = performNavigation(
-        actionId = R.id.action_startStakingLandingFragment_to_start_multi_staking_nav_graph,
-        args = SetupAmountMultiStakingFragment.getBundle(payload)
-    )
+    override fun openStartMultiStaking(payload: SetupAmountMultiStakingPayload) {
+        navigationBuilder(R.id.action_startStakingLandingFragment_to_start_multi_staking_nav_graph)
+            .setArgs(SetupAmountMultiStakingFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openSetupStakingType(payload: SetupStakingTypePayload) = performNavigation(
-        R.id.action_setupAmountMultiStakingFragment_to_setupStakingType,
-        args = SetupStakingTypeFragment.getArguments(payload)
-    )
+    override fun openSetupStakingType(payload: SetupStakingTypePayload) {
+        navigationBuilder(R.id.action_setupAmountMultiStakingFragment_to_setupStakingType)
+            .setArgs(SetupStakingTypeFragment.getArguments(payload))
+            .perform()
+    }
 
-    override fun openConfirm(payload: ConfirmMultiStakingPayload) = performNavigation(
-        actionId = R.id.action_setupAmountMultiStakingFragment_to_confirmMultiStakingFragment,
-        args = ConfirmMultiStakingFragment.getBundle(payload)
-    )
+    override fun openConfirm(payload: ConfirmMultiStakingPayload) {
+        navigationBuilder(R.id.action_setupAmountMultiStakingFragment_to_confirmMultiStakingFragment)
+            .setArgs(ConfirmMultiStakingFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openSelectedValidators() {
-        performNavigation(R.id.action_confirmMultiStakingFragment_to_confirmNominationsFragment)
+        navigationBuilder(R.id.action_confirmMultiStakingFragment_to_confirmNominationsFragment)
+            .perform()
     }
 
     override fun returnToStakingDashboard() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StartMultiStakingRouter
@@ -20,11 +21,10 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.se
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.setupStakingType.SetupStakingTypePayload
 
 class StartMultiStakingNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val stakingDashboardRouter: StakingDashboardRouter,
     private val commonNavigationHolder: Navigator,
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), StartMultiStakingRouter {
+) : BaseNavigator(navigationHoldersRegistry), StartMultiStakingRouter {
 
     override fun openStartStakingLanding(payload: StartStakingLandingPayload) {
         navigationBuilder(R.id.action_mainFragment_to_startStackingLanding)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.staking
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StartMultiStakingNavigator.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StartMultiStakingRouter
@@ -19,7 +19,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.se
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.setupStakingType.SetupStakingTypePayload
 
 class StartMultiStakingNavigator(
-    navigationHolder: MainNavigationHolder,
+    navigationHolder: SplitScreenNavigationHolder,
     private val stakingDashboardRouter: StakingDashboardRouter,
     private val commonNavigationHolder: Navigator,
 ) : BaseNavigator(navigationHolder), StartMultiStakingRouter {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.staking.nominationPools
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
@@ -11,29 +12,42 @@ import io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.
 import io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.unbond.confirm.NominationPoolsConfirmUnbondPayload
 
 class NominationPoolsStakingNavigator(
-    navigationHolder: SplitScreenNavigationHolder,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
     private val commonNavigator: Navigator,
-) : BaseNavigator(navigationHolder), NominationPoolsRouter {
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), NominationPoolsRouter {
 
-    override fun openSetupBondMore() = performNavigation(R.id.action_stakingFragment_to_PoolsBondMoreGraph)
+    override fun openSetupBondMore() {
+        navigationBuilder(R.id.action_stakingFragment_to_PoolsBondMoreGraph).perform()
+    }
 
-    override fun openConfirmBondMore(payload: NominationPoolsConfirmBondMorePayload) = performNavigation(
-        actionId = R.id.action_nominationPoolsSetupBondMoreFragment_to_nominationPoolsConfirmBondMoreFragment,
-        args = NominationPoolsConfirmBondMoreFragment.getBundle(payload)
-    )
+    override fun openConfirmBondMore(payload: NominationPoolsConfirmBondMorePayload) {
+        navigationBuilder(R.id.action_nominationPoolsSetupBondMoreFragment_to_nominationPoolsConfirmBondMoreFragment)
+            .setArgs(NominationPoolsConfirmBondMoreFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openConfirmUnbond(payload: NominationPoolsConfirmUnbondPayload) = performNavigation(
-        actionId = R.id.action_nominationPoolsSetupUnbondFragment_to_nominationPoolsConfirmUnbondFragment,
-        args = NominationPoolsConfirmUnbondFragment.getBundle(payload)
-    )
+    override fun openConfirmUnbond(payload: NominationPoolsConfirmUnbondPayload) {
+        navigationBuilder(R.id.action_nominationPoolsSetupUnbondFragment_to_nominationPoolsConfirmUnbondFragment)
+            .setArgs(NominationPoolsConfirmUnbondFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openRedeem() = performNavigation(R.id.action_stakingFragment_to_PoolsRedeemFragment)
+    override fun openRedeem() {
+        navigationBuilder(R.id.action_stakingFragment_to_PoolsRedeemFragment).perform()
+    }
 
-    override fun openClaimRewards() = performNavigation(R.id.action_stakingFragment_to_PoolsClaimRewardsFragment)
+    override fun openClaimRewards() {
+        navigationBuilder(R.id.action_stakingFragment_to_PoolsClaimRewardsFragment).perform()
+    }
 
-    override fun openSetupUnbond() = performNavigation(R.id.action_stakingFragment_to_PoolsUnbondGraph)
+    override fun openSetupUnbond() {
+        navigationBuilder(R.id.action_stakingFragment_to_PoolsUnbondGraph).perform()
+    }
 
-    override fun returnToStakingMain() = performNavigation(R.id.back_to_staking_main)
+    override fun returnToStakingMain() {
+        navigationBuilder(R.id.back_to_staking_main).perform()
+    }
 
     override fun returnToMain() {
         commonNavigator.returnToMain()

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.staking.nominationPools
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.NominationPoolsRouter

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking.nomination
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.NominationPoolsRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.bondMore.confirm.NominationPoolsConfirmBondMoreFragment
@@ -11,7 +11,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.
 import io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.unbond.confirm.NominationPoolsConfirmUnbondPayload
 
 class NominationPoolsStakingNavigator(
-    navigationHolder: MainNavigationHolder,
+    navigationHolder: SplitScreenNavigationHolder,
     private val commonNavigator: Navigator,
 ) : BaseNavigator(navigationHolder), NominationPoolsRouter {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.NominationPoolsRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.bondMore.confirm.NominationPoolsConfirmBondMoreFragment
@@ -12,10 +13,9 @@ import io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.
 import io.novafoundation.nova.feature_staking_impl.presentation.nominationPools.unbond.confirm.NominationPoolsConfirmUnbondPayload
 
 class NominationPoolsStakingNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val commonNavigator: Navigator,
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), NominationPoolsRouter {
+) : BaseNavigator(navigationHoldersRegistry), NominationPoolsRouter {
 
     override fun openSetupBondMore() {
         navigationBuilder(R.id.action_stakingFragment_to_PoolsBondMoreGraph).perform()

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/nominationPools/NominationPoolsStakingNavigator.kt
@@ -16,35 +16,35 @@ class NominationPoolsStakingNavigator(
 ) : BaseNavigator(navigationHoldersRegistry), NominationPoolsRouter {
 
     override fun openSetupBondMore() {
-        navigationBuilder(R.id.action_stakingFragment_to_PoolsBondMoreGraph).perform()
+        navigationBuilder(R.id.action_stakingFragment_to_PoolsBondMoreGraph).navigateInFirstAttachedContext()
     }
 
     override fun openConfirmBondMore(payload: NominationPoolsConfirmBondMorePayload) {
         navigationBuilder(R.id.action_nominationPoolsSetupBondMoreFragment_to_nominationPoolsConfirmBondMoreFragment)
             .setArgs(NominationPoolsConfirmBondMoreFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmUnbond(payload: NominationPoolsConfirmUnbondPayload) {
         navigationBuilder(R.id.action_nominationPoolsSetupUnbondFragment_to_nominationPoolsConfirmUnbondFragment)
             .setArgs(NominationPoolsConfirmUnbondFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRedeem() {
-        navigationBuilder(R.id.action_stakingFragment_to_PoolsRedeemFragment).perform()
+        navigationBuilder(R.id.action_stakingFragment_to_PoolsRedeemFragment).navigateInFirstAttachedContext()
     }
 
     override fun openClaimRewards() {
-        navigationBuilder(R.id.action_stakingFragment_to_PoolsClaimRewardsFragment).perform()
+        navigationBuilder(R.id.action_stakingFragment_to_PoolsClaimRewardsFragment).navigateInFirstAttachedContext()
     }
 
     override fun openSetupUnbond() {
-        navigationBuilder(R.id.action_stakingFragment_to_PoolsUnbondGraph).perform()
+        navigationBuilder(R.id.action_stakingFragment_to_PoolsUnbondGraph).navigateInFirstAttachedContext()
     }
 
     override fun returnToStakingMain() {
-        navigationBuilder(R.id.back_to_staking_main).perform()
+        navigationBuilder(R.id.back_to_staking_main).navigateInFirstAttachedContext()
     }
 
     override fun returnToMain() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.ParachainStakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.rebond.ParachainStakingRebondFragment
@@ -20,10 +21,9 @@ import io.novafoundation.nova.feature_staking_impl.presentation.validators.detai
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.details.ValidatorDetailsFragment
 
 class ParachainStakingNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val commonNavigator: Navigator,
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), ParachainStakingRouter {
+) : BaseNavigator(navigationHoldersRegistry), ParachainStakingRouter {
 
     override fun openStartStaking(payload: StartParachainStakingPayload) {
         navigationBuilder(R.id.action_open_startParachainStakingGraph)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
@@ -2,7 +2,7 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.ParachainStakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.rebond.ParachainStakingRebondFragment
@@ -19,7 +19,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.validators.detai
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.details.ValidatorDetailsFragment
 
 class ParachainStakingNavigator(
-    navigationHolder: MainNavigationHolder,
+    navigationHolder: SplitScreenNavigationHolder,
     private val commonNavigator: Navigator,
 ) : BaseNavigator(navigationHolder), ParachainStakingRouter {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
@@ -19,61 +20,81 @@ import io.novafoundation.nova.feature_staking_impl.presentation.validators.detai
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.details.ValidatorDetailsFragment
 
 class ParachainStakingNavigator(
-    navigationHolder: SplitScreenNavigationHolder,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
     private val commonNavigator: Navigator,
-) : BaseNavigator(navigationHolder), ParachainStakingRouter {
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), ParachainStakingRouter {
 
-    override fun openStartStaking(payload: StartParachainStakingPayload) = performNavigation(
-        actionId = R.id.action_open_startParachainStakingGraph,
-        args = StartParachainStakingFragment.getBundle(payload)
-    )
+    override fun openStartStaking(payload: StartParachainStakingPayload) {
+        navigationBuilder(R.id.action_open_startParachainStakingGraph)
+            .setArgs(StartParachainStakingFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openConfirmStartStaking(payload: ConfirmStartParachainStakingPayload) = performNavigation(
-        actionId = R.id.action_startParachainStakingFragment_to_confirmStartParachainStakingFragment,
-        args = ConfirmStartParachainStakingFragment.getBundle(payload)
-    )
+    override fun openConfirmStartStaking(payload: ConfirmStartParachainStakingPayload) {
+        navigationBuilder(R.id.action_startParachainStakingFragment_to_confirmStartParachainStakingFragment)
+            .setArgs(ConfirmStartParachainStakingFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openSearchCollator() = performNavigation(R.id.action_selectCollatorFragment_to_searchCollatorFragment)
+    override fun openSearchCollator() {
+        navigationBuilder(R.id.action_selectCollatorFragment_to_searchCollatorFragment)
+            .perform()
+    }
 
-    override fun openCollatorDetails(payload: StakeTargetDetailsPayload) = performNavigation(
-        actionId = R.id.open_validator_details,
-        args = ValidatorDetailsFragment.getBundle(payload)
-    )
+    override fun openCollatorDetails(payload: StakeTargetDetailsPayload) {
+        navigationBuilder(R.id.open_validator_details)
+            .setArgs(ValidatorDetailsFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openWalletDetails(metaId: Long) {
         commonNavigator.openWalletDetails(metaId)
     }
 
-    override fun returnToStakingMain() = performNavigation(R.id.back_to_staking_main)
+    override fun returnToStakingMain() {
+        navigationBuilder(R.id.back_to_staking_main).perform()
+    }
 
-    override fun returnToStartStaking() = performNavigation(R.id.action_return_to_start_staking)
+    override fun returnToStartStaking() {
+        navigationBuilder(R.id.action_return_to_start_staking).perform()
+    }
 
-    override fun openCurrentCollators() = performNavigation(R.id.action_stakingFragment_to_currentCollatorsFragment)
+    override fun openCurrentCollators() {
+        navigationBuilder(R.id.action_stakingFragment_to_currentCollatorsFragment).perform()
+    }
 
-    override fun openUnbond() = performNavigation(R.id.action_open_parachainUnbondGraph)
+    override fun openUnbond() {
+        navigationBuilder(R.id.action_open_parachainUnbondGraph).perform()
+    }
 
-    override fun openConfirmUnbond(payload: ParachainStakingUnbondConfirmPayload) = performNavigation(
-        actionId = R.id.action_parachainStakingUnbondFragment_to_parachainStakingUnbondConfirmFragment,
-        args = ParachainStakingUnbondConfirmFragment.getBundle(payload)
-    )
+    override fun openConfirmUnbond(payload: ParachainStakingUnbondConfirmPayload) {
+        navigationBuilder(R.id.action_parachainStakingUnbondFragment_to_parachainStakingUnbondConfirmFragment)
+            .setArgs(ParachainStakingUnbondConfirmFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openRedeem() = performNavigation(R.id.action_stakingFragment_to_parachainStakingRedeemFragment)
+    override fun openRedeem() {
+        navigationBuilder(R.id.action_stakingFragment_to_parachainStakingRedeemFragment).perform()
+    }
 
-    override fun openRebond(payload: ParachainStakingRebondPayload) = performNavigation(
-        actionId = R.id.action_stakingFragment_to_parachainStakingRebondFragment,
-        args = ParachainStakingRebondFragment.getBundle(payload)
-    )
+    override fun openRebond(payload: ParachainStakingRebondPayload) {
+        navigationBuilder(R.id.action_stakingFragment_to_parachainStakingRebondFragment)
+            .setArgs(ParachainStakingRebondFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun openSetupYieldBoost() = performNavigation(R.id.action_stakingFragment_to_yieldBoostGraph)
+    override fun openSetupYieldBoost() {
+        navigationBuilder(R.id.action_stakingFragment_to_yieldBoostGraph).perform()
+    }
 
-    override fun openConfirmYieldBoost(
-        payload: YieldBoostConfirmPayload
-    ) = performNavigation(
-        actionId = R.id.action_setupYieldBoostFragment_to_yieldBoostConfirmFragment,
-        args = YieldBoostConfirmFragment.getBundle(payload)
-    )
+    override fun openConfirmYieldBoost(payload: YieldBoostConfirmPayload) {
+        navigationBuilder(R.id.action_setupYieldBoostFragment_to_yieldBoostConfirmFragment)
+            .setArgs(YieldBoostConfirmFragment.getBundle(payload))
+            .perform()
+    }
 
     override fun openAddStakingProxy() {
-        performNavigation(R.id.action_open_addStakingProxyFragment)
+        navigationBuilder(R.id.action_open_addStakingProxyFragment).perform()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_staking_impl.presentation.ParachainStakingRouter

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/ParachainStakingNavigator.kt
@@ -26,24 +26,24 @@ class ParachainStakingNavigator(
     override fun openStartStaking(payload: StartParachainStakingPayload) {
         navigationBuilder(R.id.action_open_startParachainStakingGraph)
             .setArgs(StartParachainStakingFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmStartStaking(payload: ConfirmStartParachainStakingPayload) {
         navigationBuilder(R.id.action_startParachainStakingFragment_to_confirmStartParachainStakingFragment)
             .setArgs(ConfirmStartParachainStakingFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSearchCollator() {
         navigationBuilder(R.id.action_selectCollatorFragment_to_searchCollatorFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCollatorDetails(payload: StakeTargetDetailsPayload) {
         navigationBuilder(R.id.open_validator_details)
             .setArgs(ValidatorDetailsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openWalletDetails(metaId: Long) {
@@ -51,48 +51,48 @@ class ParachainStakingNavigator(
     }
 
     override fun returnToStakingMain() {
-        navigationBuilder(R.id.back_to_staking_main).perform()
+        navigationBuilder(R.id.back_to_staking_main).navigateInFirstAttachedContext()
     }
 
     override fun returnToStartStaking() {
-        navigationBuilder(R.id.action_return_to_start_staking).perform()
+        navigationBuilder(R.id.action_return_to_start_staking).navigateInFirstAttachedContext()
     }
 
     override fun openCurrentCollators() {
-        navigationBuilder(R.id.action_stakingFragment_to_currentCollatorsFragment).perform()
+        navigationBuilder(R.id.action_stakingFragment_to_currentCollatorsFragment).navigateInFirstAttachedContext()
     }
 
     override fun openUnbond() {
-        navigationBuilder(R.id.action_open_parachainUnbondGraph).perform()
+        navigationBuilder(R.id.action_open_parachainUnbondGraph).navigateInFirstAttachedContext()
     }
 
     override fun openConfirmUnbond(payload: ParachainStakingUnbondConfirmPayload) {
         navigationBuilder(R.id.action_parachainStakingUnbondFragment_to_parachainStakingUnbondConfirmFragment)
             .setArgs(ParachainStakingUnbondConfirmFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRedeem() {
-        navigationBuilder(R.id.action_stakingFragment_to_parachainStakingRedeemFragment).perform()
+        navigationBuilder(R.id.action_stakingFragment_to_parachainStakingRedeemFragment).navigateInFirstAttachedContext()
     }
 
     override fun openRebond(payload: ParachainStakingRebondPayload) {
         navigationBuilder(R.id.action_stakingFragment_to_parachainStakingRebondFragment)
             .setArgs(ParachainStakingRebondFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSetupYieldBoost() {
-        navigationBuilder(R.id.action_stakingFragment_to_yieldBoostGraph).perform()
+        navigationBuilder(R.id.action_stakingFragment_to_yieldBoostGraph).navigateInFirstAttachedContext()
     }
 
     override fun openConfirmYieldBoost(payload: YieldBoostConfirmPayload) {
         navigationBuilder(R.id.action_setupYieldBoostFragment_to_yieldBoostConfirmFragment)
             .setArgs(YieldBoostConfirmFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openAddStakingProxy() {
-        navigationBuilder(R.id.action_open_addStakingProxyFragment).perform()
+        navigationBuilder(R.id.action_open_addStakingProxyFragment).navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorInterScreenCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorInterScreenCommunicatorImpl.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.common.SelectCollatorInterScreenCommunicator
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.common.SelectCollatorInterScreenCommunicator.Request

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorInterScreenCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorInterScreenCommunicatorImpl.kt
@@ -2,12 +2,12 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.common.SelectCollatorInterScreenCommunicator
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.common.SelectCollatorInterScreenCommunicator.Request
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.common.SelectCollatorInterScreenCommunicator.Response
 
-class SelectCollatorInterScreenCommunicatorImpl(navigationHolder: MainNavigationHolder) :
+class SelectCollatorInterScreenCommunicatorImpl(navigationHolder: SplitScreenNavigationHolder) :
     SelectCollatorInterScreenCommunicator,
     NavStackInterScreenCommunicator<Request, Response>(navigationHolder) {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorInterScreenCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorInterScreenCommunicatorImpl.kt
@@ -3,13 +3,14 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.common.SelectCollatorInterScreenCommunicator
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.common.SelectCollatorInterScreenCommunicator.Request
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.common.SelectCollatorInterScreenCommunicator.Response
 
-class SelectCollatorInterScreenCommunicatorImpl(navigationHolder: SplitScreenNavigationHolder) :
+class SelectCollatorInterScreenCommunicatorImpl(navigationHoldersRegistry: NavigationHoldersRegistry) :
     SelectCollatorInterScreenCommunicator,
-    NavStackInterScreenCommunicator<Request, Response>(navigationHolder) {
+    NavStackInterScreenCommunicator<Request, Response>(navigationHoldersRegistry) {
 
     override fun respond(response: Response) {
         val responseEntry = navController.getBackStackEntry(R.id.startParachainStakingFragment)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorSettingsInterScreenCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorSettingsInterScreenCommunicatorImpl.kt
@@ -3,14 +3,15 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsFragment
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsInterScreenCommunicator
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsInterScreenCommunicator.Request
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsInterScreenCommunicator.Response
 
-class SelectCollatorSettingsInterScreenCommunicatorImpl(navigationHolder: SplitScreenNavigationHolder) :
+class SelectCollatorSettingsInterScreenCommunicatorImpl(navigationHoldersRegistry: NavigationHoldersRegistry) :
     SelectCollatorSettingsInterScreenCommunicator,
-    NavStackInterScreenCommunicator<Request, Response>(navigationHolder) {
+    NavStackInterScreenCommunicator<Request, Response>(navigationHoldersRegistry) {
 
     override fun openRequest(request: Request) {
         val bundle = SelectCollatorSettingsFragment.getBundle(request.currentConfig)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorSettingsInterScreenCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorSettingsInterScreenCommunicatorImpl.kt
@@ -2,13 +2,13 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsFragment
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsInterScreenCommunicator
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsInterScreenCommunicator.Request
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsInterScreenCommunicator.Response
 
-class SelectCollatorSettingsInterScreenCommunicatorImpl(navigationHolder: MainNavigationHolder) :
+class SelectCollatorSettingsInterScreenCommunicatorImpl(navigationHolder: SplitScreenNavigationHolder) :
     SelectCollatorSettingsInterScreenCommunicator,
     NavStackInterScreenCommunicator<Request, Response>(navigationHolder) {
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorSettingsInterScreenCommunicatorImpl.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/parachain/SelectCollatorSettingsInterScreenCommunicatorImpl.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.staking.parachain
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.NavStackInterScreenCommunicator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsFragment
 import io.novafoundation.nova.feature_staking_impl.presentation.parachainStaking.collator.settings.SelectCollatorSettingsInterScreenCommunicator

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_dapp_api.presentation.browser.main.DAppBrowserPayload
 import io.novafoundation.nova.feature_dapp_impl.presentation.browser.main.DAppBrowserFragment
@@ -45,11 +46,10 @@ import io.novafoundation.nova.feature_staking_impl.presentation.validators.detai
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.details.ValidatorDetailsFragment
 
 class RelayStakingNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val commonNavigator: Navigator,
     private val stakingDashboardRouter: StakingDashboardRouter,
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), StakingRouter {
+) : BaseNavigator(navigationHoldersRegistry), StakingRouter {
 
     override fun returnToStakingMain() {
         navigationBuilder(R.id.back_to_staking_main)
@@ -103,19 +103,17 @@ class RelayStakingNavigator(
     }
 
     override fun openSelectCustomValidators() {
-        val flowType = when (navigationHolder.navController?.currentDestination?.id) {
+        val flowType = when (currentDestination?.id) {
             R.id.setupStakingType -> FlowType.SETUP_STAKING_VALIDATORS
             else -> FlowType.CHANGE_STAKING_VALIDATORS
         }
         val payload = CustomValidatorsPayload(flowType)
 
-        performNavigation(
-            cases = arrayOf(
-                R.id.setupStakingType to R.id.action_setupStakingType_to_selectCustomValidatorsFragment,
-                R.id.startChangeValidatorsFragment to R.id.action_startChangeValidatorsFragment_to_selectCustomValidatorsFragment,
-            ),
-            args = SelectCustomValidatorsFragment.getBundle(payload)
-        )
+        navigationBuilder()
+            .addCase(R.id.setupStakingType, R.id.action_setupStakingType_to_selectCustomValidatorsFragment)
+            .addCase(R.id.startChangeValidatorsFragment, R.id.action_startChangeValidatorsFragment_to_selectCustomValidatorsFragment)
+            .setArgs(SelectCustomValidatorsFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openCustomValidatorsSettings() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
@@ -1,7 +1,8 @@
 package io.novafoundation.nova.app.root.navigation.navigators.staking.relaychain
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_dapp_api.presentation.browser.main.DAppBrowserPayload
@@ -44,53 +45,61 @@ import io.novafoundation.nova.feature_staking_impl.presentation.validators.detai
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.details.ValidatorDetailsFragment
 
 class RelayStakingNavigator(
-    private val navigationHolder: NavigationHolder,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
     private val commonNavigator: Navigator,
     private val stakingDashboardRouter: StakingDashboardRouter,
-) : BaseNavigator(navigationHolder), StakingRouter {
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), StakingRouter {
 
-    override fun returnToStakingMain() = performNavigation(R.id.back_to_staking_main)
+    override fun returnToStakingMain() {
+        navigationBuilder(R.id.back_to_staking_main)
+            .perform()
+    }
 
     override fun openSwitchWallet() = commonNavigator.openSwitchWallet()
 
     override fun openWalletDetails(metaAccountId: Long) = commonNavigator.openWalletDetails(metaAccountId)
 
     override fun openCustomRebond() {
-        performNavigation(R.id.action_stakingFragment_to_customRebondFragment)
+        navigationBuilder(R.id.action_stakingFragment_to_customRebondFragment)
+            .perform()
     }
 
     override fun openCurrentValidators() {
-        performNavigation(R.id.action_stakingFragment_to_currentValidatorsFragment)
+        navigationBuilder(R.id.action_stakingFragment_to_currentValidatorsFragment)
+            .perform()
     }
 
     override fun returnToCurrentValidators() {
-        performNavigation(R.id.action_confirmStakingFragment_back_to_currentValidatorsFragment)
+        navigationBuilder(R.id.action_confirmStakingFragment_back_to_currentValidatorsFragment)
+            .perform()
     }
 
     override fun openChangeRewardDestination() {
-        performNavigation(R.id.action_stakingFragment_to_selectRewardDestinationFragment)
+        navigationBuilder(R.id.action_stakingFragment_to_selectRewardDestinationFragment)
+            .perform()
     }
 
     override fun openConfirmRewardDestination(payload: ConfirmRewardDestinationPayload) {
-        performNavigation(
-            R.id.action_selectRewardDestinationFragment_to_confirmRewardDestinationFragment,
-            ConfirmRewardDestinationFragment.getBundle(payload)
-        )
+        navigationBuilder(R.id.action_selectRewardDestinationFragment_to_confirmRewardDestinationFragment)
+            .setArgs(ConfirmRewardDestinationFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openControllerAccount() {
-        performNavigation(R.id.action_stakingBalanceFragment_to_setControllerAccountFragment)
+        navigationBuilder(R.id.action_stakingBalanceFragment_to_setControllerAccountFragment)
+            .perform()
     }
 
     override fun openConfirmSetController(payload: ConfirmSetControllerPayload) {
-        performNavigation(
-            R.id.action_stakingSetControllerAccountFragment_to_confirmSetControllerAccountFragment,
-            ConfirmSetControllerFragment.getBundle(payload)
-        )
+        navigationBuilder(R.id.action_stakingSetControllerAccountFragment_to_confirmSetControllerAccountFragment)
+            .setArgs(ConfirmSetControllerFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openRecommendedValidators() {
-        performNavigation(R.id.action_startChangeValidatorsFragment_to_recommendedValidatorsFragment)
+        navigationBuilder(R.id.action_startChangeValidatorsFragment_to_recommendedValidatorsFragment)
+            .perform()
     }
 
     override fun openSelectCustomValidators() {
@@ -110,109 +119,144 @@ class RelayStakingNavigator(
     }
 
     override fun openCustomValidatorsSettings() {
-        performNavigation(R.id.action_selectCustomValidatorsFragment_to_settingsCustomValidatorsFragment)
+        navigationBuilder(R.id.action_selectCustomValidatorsFragment_to_settingsCustomValidatorsFragment)
+            .perform()
     }
 
     override fun openSearchCustomValidators() {
-        performNavigation(R.id.action_selectCustomValidatorsFragment_to_searchCustomValidatorsFragment)
+        navigationBuilder(R.id.action_selectCustomValidatorsFragment_to_searchCustomValidatorsFragment)
+            .perform()
     }
 
     override fun openReviewCustomValidators(payload: CustomValidatorsPayload) {
-        performNavigation(
-            R.id.action_selectCustomValidatorsFragment_to_reviewCustomValidatorsFragment,
-            args = ReviewCustomValidatorsFragment.getBundle(payload)
-        )
+        navigationBuilder(R.id.action_selectCustomValidatorsFragment_to_reviewCustomValidatorsFragment)
+            .setArgs(ReviewCustomValidatorsFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openConfirmStaking() {
-        performNavigation(R.id.openConfirmStakingFragment)
+        navigationBuilder(R.id.openConfirmStakingFragment)
+            .perform()
     }
 
     override fun openConfirmNominations() {
-        performNavigation(R.id.action_confirmStakingFragment_to_confirmNominationsFragment)
+        navigationBuilder(R.id.action_confirmStakingFragment_to_confirmNominationsFragment)
+            .perform()
     }
 
-    override fun openChainStakingMain() = performNavigation(R.id.action_mainFragment_to_stakingGraph)
+    override fun openChainStakingMain() {
+        navigationBuilder(R.id.action_mainFragment_to_stakingGraph)
+            .perform()
+    }
 
     override fun openStartChangeValidators() {
-        performNavigation(R.id.openStartChangeValidatorsFragment)
+        navigationBuilder(R.id.openStartChangeValidatorsFragment)
+            .perform()
     }
 
     override fun openStory(story: StakingStoryModel) {
-        performNavigation(R.id.open_staking_story, StoryFragment.getBundle(story))
+        navigationBuilder(R.id.open_staking_story)
+            .setArgs(StoryFragment.getBundle(story))
+            .perform()
     }
 
     override fun openPayouts() {
-        performNavigation(R.id.action_stakingFragment_to_payoutsListFragment)
+        navigationBuilder(R.id.action_stakingFragment_to_payoutsListFragment)
+            .perform()
     }
 
     override fun openPayoutDetails(payout: PendingPayoutParcelable) {
-        performNavigation(R.id.action_payoutsListFragment_to_payoutDetailsFragment, PayoutDetailsFragment.getBundle(payout))
+        navigationBuilder(R.id.action_payoutsListFragment_to_payoutDetailsFragment)
+            .setArgs(PayoutDetailsFragment.getBundle(payout))
+            .perform()
     }
 
     override fun openConfirmPayout(payload: ConfirmPayoutPayload) {
-        performNavigation(R.id.action_open_confirm_payout, ConfirmPayoutFragment.getBundle(payload))
+        navigationBuilder(R.id.action_open_confirm_payout)
+            .setArgs(ConfirmPayoutFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openBondMore() {
-        performNavigation(R.id.action_open_selectBondMoreFragment, SelectBondMoreFragment.getBundle(SelectBondMorePayload()))
+        navigationBuilder(R.id.action_open_selectBondMoreFragment)
+            .setArgs(SelectBondMoreFragment.getBundle(SelectBondMorePayload()))
+            .perform()
     }
 
     override fun openConfirmBondMore(payload: ConfirmBondMorePayload) {
-        performNavigation(R.id.action_selectBondMoreFragment_to_confirmBondMoreFragment, ConfirmBondMoreFragment.getBundle(payload))
+        navigationBuilder(R.id.action_selectBondMoreFragment_to_confirmBondMoreFragment)
+            .setArgs(ConfirmBondMoreFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openSelectUnbond() {
-        performNavigation(R.id.action_stakingFragment_to_selectUnbondFragment)
+        navigationBuilder(R.id.action_stakingFragment_to_selectUnbondFragment)
+            .perform()
     }
 
     override fun openConfirmUnbond(payload: ConfirmUnbondPayload) {
-        performNavigation(R.id.action_selectUnbondFragment_to_confirmUnbondFragment, ConfirmUnbondFragment.getBundle(payload))
+        navigationBuilder(R.id.action_selectUnbondFragment_to_confirmUnbondFragment)
+            .setArgs(ConfirmUnbondFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openRedeem() {
-        performNavigation(R.id.action_open_redeemFragment, RedeemFragment.getBundle(RedeemPayload()))
+        navigationBuilder(R.id.action_open_redeemFragment)
+            .setArgs(RedeemFragment.getBundle(RedeemPayload()))
+            .perform()
     }
 
     override fun openConfirmRebond(payload: ConfirmRebondPayload) {
-        performNavigation(R.id.action_open_confirm_rebond, ConfirmRebondFragment.getBundle(payload))
+        navigationBuilder(R.id.action_open_confirm_rebond)
+            .setArgs(ConfirmRebondFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openValidatorDetails(payload: StakeTargetDetailsPayload) {
-        performNavigation(R.id.open_validator_details, ValidatorDetailsFragment.getBundle(payload))
+        navigationBuilder(R.id.open_validator_details)
+            .setArgs(ValidatorDetailsFragment.getBundle(payload))
+            .perform()
     }
 
-    override fun openRebag() = performNavigation(R.id.action_stakingFragment_to_rebag)
+    override fun openRebag() {
+        navigationBuilder(R.id.action_stakingFragment_to_rebag)
+            .perform()
+    }
 
     override fun openStakingPeriods() {
-        performNavigation(R.id.action_stakingFragment_to_staking_periods)
+        navigationBuilder(R.id.action_stakingFragment_to_staking_periods)
+            .perform()
     }
 
     override fun openSetupStakingType() {
-        performNavigation(R.id.action_setupAmountMultiStakingFragment_to_setupStakingType)
+        navigationBuilder(R.id.action_setupAmountMultiStakingFragment_to_setupStakingType)
+            .perform()
     }
 
     override fun openSelectPool(payload: SelectingPoolPayload) {
         val arguments = SelectPoolFragment.getBundle(payload)
-        performNavigation(R.id.action_setupStakingType_to_selectCustomPoolFragment, args = arguments)
+        navigationBuilder(R.id.action_setupStakingType_to_selectCustomPoolFragment)
+            .setArgs(arguments)
+            .perform()
     }
 
     override fun openSearchPool(payload: SelectingPoolPayload) {
         val arguments = SearchPoolFragment.getBundle(payload)
-        performNavigation(R.id.action_selectPool_to_searchPoolFragment, args = arguments)
+        navigationBuilder(R.id.action_selectPool_to_searchPoolFragment)
+            .setArgs(arguments)
+            .perform()
     }
 
     override fun finishSetupValidatorsFlow() {
-        performNavigation(R.id.action_back_to_setupAmountMultiStakingFragment)
+        navigationBuilder(R.id.action_back_to_setupAmountMultiStakingFragment)
+            .perform()
     }
 
     override fun finishSetupPoolFlow() {
-        performNavigation(
-            cases = arrayOf(
-                R.id.searchPoolFragment to R.id.action_searchPool_to_setupAmountMultiStakingFragment,
-                R.id.selectPoolFragment to R.id.action_selectPool_to_setupAmountMultiStakingFragment,
-            )
-        )
+        navigationBuilder()
+            .addCase(R.id.searchPoolFragment, R.id.action_searchPool_to_setupAmountMultiStakingFragment)
+            .addCase(R.id.selectPoolFragment, R.id.action_selectPool_to_setupAmountMultiStakingFragment)
+            .perform()
     }
 
     override fun finishRedeemFlow(redeemConsequences: RedeemConsequences) {
@@ -224,26 +268,30 @@ class RelayStakingNavigator(
     }
 
     override fun openAddStakingProxy() {
-        performNavigation(R.id.action_open_addStakingProxyFragment)
+        navigationBuilder(R.id.action_open_addStakingProxyFragment)
+            .perform()
     }
 
     override fun openConfirmAddStakingProxy(payload: ConfirmAddStakingProxyPayload) {
-        performNavigation(
-            R.id.action_addStakingProxyFragment_to_confirmAddStakingProxyFragment,
-            ConfirmAddStakingProxyFragment.getBundle(payload)
-        )
+        navigationBuilder(R.id.action_addStakingProxyFragment_to_confirmAddStakingProxyFragment)
+            .setArgs(ConfirmAddStakingProxyFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openStakingProxyList() {
-        performNavigation(R.id.action_open_stakingProxyList)
+        navigationBuilder(R.id.action_open_stakingProxyList)
+            .perform()
     }
 
     override fun openConfirmRemoveStakingProxy(payload: ConfirmRemoveStakingProxyPayload) {
-        val arguments = ConfirmRemoveStakingProxyFragment.getBundle(payload)
-        performNavigation(R.id.action_open_confirmRemoveStakingProxyFragment, arguments)
+        navigationBuilder(R.id.action_open_confirmRemoveStakingProxyFragment)
+            .setArgs(ConfirmRemoveStakingProxyFragment.getBundle(payload))
+            .perform()
     }
 
     override fun openDAppBrowser(url: String) {
-        performNavigation(R.id.action_open_dappBrowser, DAppBrowserFragment.getBundle(DAppBrowserPayload.Address(url)))
+        navigationBuilder(R.id.action_open_dappBrowser)
+            .setArgs(DAppBrowserFragment.getBundle(DAppBrowserPayload.Address(url)))
+            .perform()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
@@ -1,8 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.staking.relaychain
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
@@ -51,7 +51,7 @@ class RelayStakingNavigator(
 
     override fun returnToStakingMain() {
         navigationBuilder(R.id.back_to_staking_main)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSwitchWallet() = commonNavigator.openSwitchWallet()
@@ -60,44 +60,44 @@ class RelayStakingNavigator(
 
     override fun openCustomRebond() {
         navigationBuilder(R.id.action_stakingFragment_to_customRebondFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCurrentValidators() {
         navigationBuilder(R.id.action_stakingFragment_to_currentValidatorsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun returnToCurrentValidators() {
         navigationBuilder(R.id.action_confirmStakingFragment_back_to_currentValidatorsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openChangeRewardDestination() {
         navigationBuilder(R.id.action_stakingFragment_to_selectRewardDestinationFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmRewardDestination(payload: ConfirmRewardDestinationPayload) {
         navigationBuilder(R.id.action_selectRewardDestinationFragment_to_confirmRewardDestinationFragment)
             .setArgs(ConfirmRewardDestinationFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openControllerAccount() {
         navigationBuilder(R.id.action_stakingBalanceFragment_to_setControllerAccountFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmSetController(payload: ConfirmSetControllerPayload) {
         navigationBuilder(R.id.action_stakingSetControllerAccountFragment_to_confirmSetControllerAccountFragment)
             .setArgs(ConfirmSetControllerFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRecommendedValidators() {
         navigationBuilder(R.id.action_startChangeValidatorsFragment_to_recommendedValidatorsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectCustomValidators() {
@@ -111,148 +111,148 @@ class RelayStakingNavigator(
             .addCase(R.id.setupStakingType, R.id.action_setupStakingType_to_selectCustomValidatorsFragment)
             .addCase(R.id.startChangeValidatorsFragment, R.id.action_startChangeValidatorsFragment_to_selectCustomValidatorsFragment)
             .setArgs(SelectCustomValidatorsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openCustomValidatorsSettings() {
         navigationBuilder(R.id.action_selectCustomValidatorsFragment_to_settingsCustomValidatorsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSearchCustomValidators() {
         navigationBuilder(R.id.action_selectCustomValidatorsFragment_to_searchCustomValidatorsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openReviewCustomValidators(payload: CustomValidatorsPayload) {
         navigationBuilder(R.id.action_selectCustomValidatorsFragment_to_reviewCustomValidatorsFragment)
             .setArgs(ReviewCustomValidatorsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmStaking() {
         navigationBuilder(R.id.openConfirmStakingFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmNominations() {
         navigationBuilder(R.id.action_confirmStakingFragment_to_confirmNominationsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openChainStakingMain() {
         navigationBuilder(R.id.action_mainFragment_to_stakingGraph)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStartChangeValidators() {
         navigationBuilder(R.id.openStartChangeValidatorsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStory(story: StakingStoryModel) {
         navigationBuilder(R.id.open_staking_story)
             .setArgs(StoryFragment.getBundle(story))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openPayouts() {
         navigationBuilder(R.id.action_stakingFragment_to_payoutsListFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openPayoutDetails(payout: PendingPayoutParcelable) {
         navigationBuilder(R.id.action_payoutsListFragment_to_payoutDetailsFragment)
             .setArgs(PayoutDetailsFragment.getBundle(payout))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmPayout(payload: ConfirmPayoutPayload) {
         navigationBuilder(R.id.action_open_confirm_payout)
             .setArgs(ConfirmPayoutFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openBondMore() {
         navigationBuilder(R.id.action_open_selectBondMoreFragment)
             .setArgs(SelectBondMoreFragment.getBundle(SelectBondMorePayload()))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmBondMore(payload: ConfirmBondMorePayload) {
         navigationBuilder(R.id.action_selectBondMoreFragment_to_confirmBondMoreFragment)
             .setArgs(ConfirmBondMoreFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectUnbond() {
         navigationBuilder(R.id.action_stakingFragment_to_selectUnbondFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmUnbond(payload: ConfirmUnbondPayload) {
         navigationBuilder(R.id.action_selectUnbondFragment_to_confirmUnbondFragment)
             .setArgs(ConfirmUnbondFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRedeem() {
         navigationBuilder(R.id.action_open_redeemFragment)
             .setArgs(RedeemFragment.getBundle(RedeemPayload()))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmRebond(payload: ConfirmRebondPayload) {
         navigationBuilder(R.id.action_open_confirm_rebond)
             .setArgs(ConfirmRebondFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openValidatorDetails(payload: StakeTargetDetailsPayload) {
         navigationBuilder(R.id.open_validator_details)
             .setArgs(ValidatorDetailsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openRebag() {
         navigationBuilder(R.id.action_stakingFragment_to_rebag)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStakingPeriods() {
         navigationBuilder(R.id.action_stakingFragment_to_staking_periods)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSetupStakingType() {
         navigationBuilder(R.id.action_setupAmountMultiStakingFragment_to_setupStakingType)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSelectPool(payload: SelectingPoolPayload) {
         val arguments = SelectPoolFragment.getBundle(payload)
         navigationBuilder(R.id.action_setupStakingType_to_selectCustomPoolFragment)
             .setArgs(arguments)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSearchPool(payload: SelectingPoolPayload) {
         val arguments = SearchPoolFragment.getBundle(payload)
         navigationBuilder(R.id.action_selectPool_to_searchPoolFragment)
             .setArgs(arguments)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishSetupValidatorsFlow() {
         navigationBuilder(R.id.action_back_to_setupAmountMultiStakingFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishSetupPoolFlow() {
         navigationBuilder()
             .addCase(R.id.searchPoolFragment, R.id.action_searchPool_to_setupAmountMultiStakingFragment)
             .addCase(R.id.selectPoolFragment, R.id.action_selectPool_to_setupAmountMultiStakingFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun finishRedeemFlow(redeemConsequences: RedeemConsequences) {
@@ -265,29 +265,29 @@ class RelayStakingNavigator(
 
     override fun openAddStakingProxy() {
         navigationBuilder(R.id.action_open_addStakingProxyFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmAddStakingProxy(payload: ConfirmAddStakingProxyPayload) {
         navigationBuilder(R.id.action_addStakingProxyFragment_to_confirmAddStakingProxyFragment)
             .setArgs(ConfirmAddStakingProxyFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openStakingProxyList() {
         navigationBuilder(R.id.action_open_stakingProxyList)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openConfirmRemoveStakingProxy(payload: ConfirmRemoveStakingProxyPayload) {
         navigationBuilder(R.id.action_open_confirmRemoveStakingProxyFragment)
             .setArgs(ConfirmRemoveStakingProxyFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openDAppBrowser(url: String) {
         navigationBuilder(R.id.action_open_dappBrowser)
             .setArgs(DAppBrowserFragment.getBundle(DAppBrowserPayload.Address(url)))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/swap/SwapNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/swap/SwapNavigator.kt
@@ -23,12 +23,12 @@ class SwapNavigator(
 
         navigationBuilder(R.id.action_swapMainSettingsFragment_to_swapConfirmationFragment)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSwapOptions() {
         navigationBuilder(R.id.action_swapMainSettingsFragment_to_swapOptionsFragment)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openBalanceDetails(assetPayload: AssetPayload) {
@@ -36,7 +36,7 @@ class SwapNavigator(
 
         navigationBuilder(R.id.action_swapConfirmationFragment_to_assetDetails)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun selectAssetIn(selectedAsset: AssetPayload?) {
@@ -45,7 +45,7 @@ class SwapNavigator(
 
         navigationBuilder(R.id.action_swapSettingsFragment_to_select_swap_token_graph)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun selectAssetOut(selectedAsset: AssetPayload?) {
@@ -54,7 +54,7 @@ class SwapNavigator(
 
         navigationBuilder(R.id.action_swapSettingsFragment_to_select_swap_token_graph)
             .setArgs(bundle)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openSendCrossChain(destination: AssetPayload, recipientAddress: String?) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/swap/SwapNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/swap/SwapNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.swap
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_assets.presentation.send.amount.SendPayload

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/swap/SwapNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/swap/SwapNavigator.kt
@@ -1,8 +1,9 @@
 package io.novafoundation.nova.app.root.navigation.navigators.swap
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_assets.presentation.send.amount.SendPayload
 import io.novafoundation.nova.feature_assets.presentation.balance.detail.BalanceDetailFragment
@@ -14,31 +15,48 @@ import io.novafoundation.nova.feature_swap_impl.presentation.confirmation.payloa
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
 
 class SwapNavigator(
-    private val navigationHolder: NavigationHolder,
+    private val splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    private val rootNavigationHolder: RootNavigationHolder,
     private val commonDelegate: Navigator
-) : BaseNavigator(navigationHolder), SwapRouter {
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), SwapRouter {
 
     override fun openSwapConfirmation(payload: SwapConfirmationPayload) {
         val bundle = SwapConfirmationFragment.getBundle(payload)
-        navigationHolder.navController?.navigate(R.id.action_swapMainSettingsFragment_to_swapConfirmationFragment, bundle)
+
+        navigationBuilder(R.id.action_swapMainSettingsFragment_to_swapConfirmationFragment)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openSwapOptions() {
-        navigationHolder.navController?.navigate(R.id.action_swapMainSettingsFragment_to_swapOptionsFragment)
+        navigationBuilder(R.id.action_swapMainSettingsFragment_to_swapOptionsFragment)
+            .perform()
     }
 
     override fun openBalanceDetails(assetPayload: AssetPayload) {
-        navigationHolder.navController?.navigate(R.id.action_swapConfirmationFragment_to_assetDetails, BalanceDetailFragment.getBundle(assetPayload))
+        val bundle = BalanceDetailFragment.getBundle(assetPayload)
+
+        navigationBuilder(R.id.action_swapConfirmationFragment_to_assetDetails)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun selectAssetIn(selectedAsset: AssetPayload?) {
         val payload = SwapFlowPayload.ReselectAssetIn(selectedAsset)
-        navigationHolder.navController?.navigate(R.id.action_swapSettingsFragment_to_select_swap_token_graph, AssetSwapFlowFragment.getBundle(payload))
+        val bundle = AssetSwapFlowFragment.getBundle(payload)
+
+        navigationBuilder(R.id.action_swapSettingsFragment_to_select_swap_token_graph)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun selectAssetOut(selectedAsset: AssetPayload?) {
         val payload = SwapFlowPayload.ReselectAssetOut(selectedAsset)
-        navigationHolder.navController?.navigate(R.id.action_swapSettingsFragment_to_select_swap_token_graph, AssetSwapFlowFragment.getBundle(payload))
+        val bundle = AssetSwapFlowFragment.getBundle(payload)
+
+        navigationBuilder(R.id.action_swapSettingsFragment_to_select_swap_token_graph)
+            .setArgs(bundle)
+            .perform()
     }
 
     override fun openSendCrossChain(destination: AssetPayload, recipientAddress: String?) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/swap/SwapNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/swap/SwapNavigator.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_assets.presentation.send.amount.SendPayload
 import io.novafoundation.nova.feature_assets.presentation.balance.detail.BalanceDetailFragment
@@ -15,10 +16,9 @@ import io.novafoundation.nova.feature_swap_impl.presentation.confirmation.payloa
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetPayload
 
 class SwapNavigator(
-    private val splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    private val rootNavigationHolder: RootNavigationHolder,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val commonDelegate: Navigator
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), SwapRouter {
+) : BaseNavigator(navigationHoldersRegistry), SwapRouter {
 
     override fun openSwapConfirmation(payload: SwapConfirmationPayload) {
         val bundle = SwapConfirmationFragment.getBundle(payload)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
@@ -19,6 +19,6 @@ class VersionsNavigator(
 
     override fun closeUpdateNotifications() {
         navigationBuilder(R.id.action_close_update_notifications)
-            .performInRoot()
+            .navigateInRoot()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
@@ -1,8 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.versions
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.common.resources.ContextManager

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
@@ -4,16 +4,16 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.common.utils.showBrowser
 import io.novafoundation.nova.feature_versions_api.presentation.VersionsRouter
 
 class VersionsNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder,
+    navigationHoldersRegistry: NavigationHoldersRegistry,
     private val contextManager: ContextManager,
     private val updateSourceLink: String
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder),VersionsRouter {
+) : BaseNavigator(navigationHoldersRegistry),VersionsRouter {
 
     override fun openAppUpdater() {
         contextManager.getActivity()?.showBrowser(updateSourceLink, R.string.common_cannot_find_app)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
@@ -13,9 +13,14 @@ class VersionsNavigator(
     navigationHoldersRegistry: NavigationHoldersRegistry,
     private val contextManager: ContextManager,
     private val updateSourceLink: String
-) : BaseNavigator(navigationHoldersRegistry),VersionsRouter {
+) : BaseNavigator(navigationHoldersRegistry), VersionsRouter {
 
     override fun openAppUpdater() {
         contextManager.getActivity()?.showBrowser(updateSourceLink, R.string.common_cannot_find_app)
+    }
+
+    override fun closeUpdateNotifications() {
+        navigationBuilder(R.id.action_close_update_notifications)
+            .performInRoot()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/versions/VersionsNavigator.kt
@@ -1,20 +1,21 @@
 package io.novafoundation.nova.app.root.navigation.navigators.versions
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.NavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
+import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.common.utils.showBrowser
 import io.novafoundation.nova.feature_versions_api.presentation.VersionsRouter
 
 class VersionsNavigator(
-    private val navigationHolder: NavigationHolder,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder,
+    private val contextManager: ContextManager,
     private val updateSourceLink: String
-) : VersionsRouter {
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder),VersionsRouter {
 
     override fun openAppUpdater() {
-        navigationHolder.contextManager.getActivity()?.showBrowser(updateSourceLink, R.string.common_cannot_find_app)
-    }
-
-    override fun back() {
-        navigationHolder.navController?.popBackStack()
+        contextManager.getActivity()?.showBrowser(updateSourceLink, R.string.common_cannot_find_app)
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/wallet/CurrencyNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/wallet/CurrencyNavigator.kt
@@ -1,11 +1,16 @@
 package io.novafoundation.nova.app.root.navigation.navigators.wallet
 
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.feature_currency_api.presentation.CurrencyRouter
 
-class CurrencyNavigator(val rootRouter: RootRouter, navigationHolder: SplitScreenNavigationHolder) : BaseNavigator(navigationHolder), CurrencyRouter {
+class CurrencyNavigator(
+    val rootRouter: RootRouter,
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), CurrencyRouter {
 
     override fun returnToWallet() {
         rootRouter.returnToWallet()

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/wallet/CurrencyNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/wallet/CurrencyNavigator.kt
@@ -1,8 +1,6 @@
 package io.novafoundation.nova.app.root.navigation.navigators.wallet
 
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.feature_currency_api.presentation.CurrencyRouter

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/wallet/CurrencyNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/wallet/CurrencyNavigator.kt
@@ -3,14 +3,14 @@ package io.novafoundation.nova.app.root.navigation.navigators.wallet
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.feature_currency_api.presentation.CurrencyRouter
 
 class CurrencyNavigator(
     val rootRouter: RootRouter,
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), CurrencyRouter {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : BaseNavigator(navigationHoldersRegistry), CurrencyRouter {
 
     override fun returnToWallet() {
         rootRouter.returnToWallet()

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/wallet/CurrencyNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/wallet/CurrencyNavigator.kt
@@ -1,11 +1,11 @@
 package io.novafoundation.nova.app.root.navigation.navigators.wallet
 
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.feature_currency_api.presentation.CurrencyRouter
 
-class CurrencyNavigator(val rootRouter: RootRouter, navigationHolder: MainNavigationHolder) : BaseNavigator(navigationHolder), CurrencyRouter {
+class CurrencyNavigator(val rootRouter: RootRouter, navigationHolder: SplitScreenNavigationHolder) : BaseNavigator(navigationHolder), CurrencyRouter {
 
     override fun returnToWallet() {
         rootRouter.returnToWallet()

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.walletConnect
 
 import io.novafoundation.nova.app.R
-import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_wallet_connect_impl.WalletConnectRouter
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.details.WalletConnectSessionDetailsFragment

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
+import io.novafoundation.nova.app.root.navigation.navigators.NavigationHoldersRegistry
 import io.novafoundation.nova.feature_wallet_connect_impl.WalletConnectRouter
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.details.WalletConnectSessionDetailsFragment
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.details.WalletConnectSessionDetailsPayload
@@ -11,9 +12,8 @@ import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.list.WalletConnectSessionsPayload
 
 class WalletConnectNavigator(
-    splitScreenNavigationHolder: SplitScreenNavigationHolder,
-    rootNavigationHolder: RootNavigationHolder
-) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), WalletConnectRouter {
+    navigationHoldersRegistry: NavigationHoldersRegistry
+) : BaseNavigator(navigationHoldersRegistry), WalletConnectRouter {
 
     override fun openSessionDetails(payload: WalletConnectSessionDetailsPayload) {
         navigationBuilder(R.id.action_walletConnectSessionsFragment_to_walletConnectSessionDetailsFragment)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.app.root.navigation.navigators.walletConnect
 
 import io.novafoundation.nova.app.R
+import io.novafoundation.nova.app.root.navigation.holders.RootNavigationHolder
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_wallet_connect_impl.WalletConnectRouter
@@ -9,18 +10,30 @@ import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.list.WalletConnectSessionsFragment
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.list.WalletConnectSessionsPayload
 
-class WalletConnectNavigator(navigationHolder: SplitScreenNavigationHolder) : BaseNavigator(navigationHolder), WalletConnectRouter {
-    override fun openSessionDetails(payload: WalletConnectSessionDetailsPayload) = performNavigation(
-        actionId = R.id.action_walletConnectSessionsFragment_to_walletConnectSessionDetailsFragment,
-        args = WalletConnectSessionDetailsFragment.getBundle(payload)
-    )
+class WalletConnectNavigator(
+    splitScreenNavigationHolder: SplitScreenNavigationHolder,
+    rootNavigationHolder: RootNavigationHolder
+) : BaseNavigator(splitScreenNavigationHolder, rootNavigationHolder), WalletConnectRouter {
 
-    override fun openScanPairingQrCode() = performNavigation(R.id.action_open_scanWalletConnect)
+    override fun openSessionDetails(payload: WalletConnectSessionDetailsPayload) {
+        navigationBuilder(R.id.action_walletConnectSessionsFragment_to_walletConnectSessionDetailsFragment)
+            .setArgs(WalletConnectSessionDetailsFragment.getBundle(payload))
+            .perform()
+    }
 
-    override fun backToSettings() = performNavigation(R.id.walletConnectSessionDetailsFragment_to_settings)
+    override fun openScanPairingQrCode() {
+        navigationBuilder(R.id.action_open_scanWalletConnect)
+            .perform()
+    }
 
-    override fun openWalletConnectSessions(payload: WalletConnectSessionsPayload) = performNavigation(
-        actionId = R.id.action_mainFragment_to_walletConnectGraph,
-        args = WalletConnectSessionsFragment.getBundle(payload)
-    )
+    override fun backToSettings() {
+        navigationBuilder(R.id.walletConnectSessionDetailsFragment_to_settings)
+            .perform()
+    }
+
+    override fun openWalletConnectSessions(payload: WalletConnectSessionsPayload) {
+        navigationBuilder(R.id.action_mainFragment_to_walletConnectGraph)
+            .setArgs(WalletConnectSessionsFragment.getBundle(payload))
+            .perform()
+    }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
@@ -2,14 +2,14 @@ package io.novafoundation.nova.app.root.navigation.navigators.walletConnect
 
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.navigation.navigators.BaseNavigator
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.feature_wallet_connect_impl.WalletConnectRouter
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.details.WalletConnectSessionDetailsFragment
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.details.WalletConnectSessionDetailsPayload
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.list.WalletConnectSessionsFragment
 import io.novafoundation.nova.feature_wallet_connect_impl.presentation.sessions.list.WalletConnectSessionsPayload
 
-class WalletConnectNavigator(navigationHolder: MainNavigationHolder) : BaseNavigator(navigationHolder), WalletConnectRouter {
+class WalletConnectNavigator(navigationHolder: SplitScreenNavigationHolder) : BaseNavigator(navigationHolder), WalletConnectRouter {
     override fun openSessionDetails(payload: WalletConnectSessionDetailsPayload) = performNavigation(
         actionId = R.id.action_walletConnectSessionsFragment_to_walletConnectSessionDetailsFragment,
         args = WalletConnectSessionDetailsFragment.getBundle(payload)

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/walletConnect/WalletConnectNavigator.kt
@@ -16,22 +16,22 @@ class WalletConnectNavigator(
     override fun openSessionDetails(payload: WalletConnectSessionDetailsPayload) {
         navigationBuilder(R.id.action_walletConnectSessionsFragment_to_walletConnectSessionDetailsFragment)
             .setArgs(WalletConnectSessionDetailsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openScanPairingQrCode() {
         navigationBuilder(R.id.action_open_scanWalletConnect)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun backToSettings() {
         navigationBuilder(R.id.walletConnectSessionDetailsFragment_to_settings)
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 
     override fun openWalletConnectSessions(payload: WalletConnectSessionsPayload) {
         navigationBuilder(R.id.action_mainFragment_to_walletConnectGraph)
             .setArgs(WalletConnectSessionsFragment.getBundle(payload))
-            .perform()
+            .navigateInFirstAttachedContext()
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenFragment.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenFragment.kt
@@ -17,7 +17,7 @@ import coil.load
 import io.novafoundation.nova.app.R
 import io.novafoundation.nova.app.root.di.RootApi
 import io.novafoundation.nova.app.root.di.RootComponent
-import io.novafoundation.nova.app.root.navigation.holders.MainNavigationHolder
+import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.RoundCornersOutlineProvider
@@ -34,7 +34,7 @@ import kotlinx.android.synthetic.main.fragment_split_screen.mainNavHost
 class SplitScreenFragment : BaseFragment<SplitScreenViewModel>() {
 
     @Inject
-    lateinit var mainNavigationHolder: MainNavigationHolder
+    lateinit var splitScreenNavigationHolder: SplitScreenNavigationHolder
 
     @Inject
     lateinit var imageLoader: ImageLoader
@@ -46,13 +46,13 @@ class SplitScreenFragment : BaseFragment<SplitScreenViewModel>() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        mainNavigationHolder.attach(mainNavController)
+        splitScreenNavigationHolder.attach(mainNavController)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
 
-        mainNavigationHolder.detach()
+        splitScreenNavigationHolder.detach()
     }
 
     override fun inject() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenFragment.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenFragment.kt
@@ -39,6 +39,12 @@ class SplitScreenFragment : BaseFragment<SplitScreenViewModel>() {
     @Inject
     lateinit var imageLoader: ImageLoader
 
+    private val mainNavController: NavController by lazy {
+        val navHostFragment = childFragmentManager.findFragmentById(R.id.mainNavHost) as NavHostFragment
+
+        navHostFragment.navController
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_split_screen, container, false)
     }
@@ -50,9 +56,9 @@ class SplitScreenFragment : BaseFragment<SplitScreenViewModel>() {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
+        splitScreenNavigationHolder.detachNavController(mainNavController)
 
-        splitScreenNavigationHolder.detach()
+        super.onDestroyView()
     }
 
     override fun inject() {
@@ -85,12 +91,6 @@ class SplitScreenFragment : BaseFragment<SplitScreenViewModel>() {
             dappEntryPointText.text = model.title
         }
         manageImeInsets()
-    }
-
-    private val mainNavController: NavController by lazy {
-        val navHostFragment = childFragmentManager.findFragmentById(R.id.mainNavHost) as NavHostFragment
-
-        navHostFragment.navController
     }
 
     /**

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenFragment.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenFragment.kt
@@ -20,8 +20,11 @@ import io.novafoundation.nova.app.root.di.RootComponent
 import io.novafoundation.nova.app.root.navigation.holders.SplitScreenNavigationHolder
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.FragmentPayloadCreator
+import io.novafoundation.nova.common.utils.PayloadCreator
 import io.novafoundation.nova.common.utils.RoundCornersOutlineProvider
 import io.novafoundation.nova.common.utils.letOrHide
+import io.novafoundation.nova.common.utils.payloadOrElse
 import io.novafoundation.nova.feature_dapp_impl.presentation.tab.setupCloseAllDappTabsDialogue
 import java.io.File
 import javax.inject.Inject
@@ -32,6 +35,8 @@ import kotlinx.android.synthetic.main.fragment_split_screen.dappEntryPointText
 import kotlinx.android.synthetic.main.fragment_split_screen.mainNavHost
 
 class SplitScreenFragment : BaseFragment<SplitScreenViewModel>() {
+
+    companion object : PayloadCreator<SplitScreenPayload> by FragmentPayloadCreator()
 
     @Inject
     lateinit var splitScreenNavigationHolder: SplitScreenNavigationHolder
@@ -53,6 +58,8 @@ class SplitScreenFragment : BaseFragment<SplitScreenViewModel>() {
         super.onViewCreated(view, savedInstanceState)
 
         splitScreenNavigationHolder.attach(mainNavController)
+
+        viewModel.onNavigationAttached()
     }
 
     override fun onDestroyView() {
@@ -64,7 +71,7 @@ class SplitScreenFragment : BaseFragment<SplitScreenViewModel>() {
     override fun inject() {
         FeatureUtils.getFeature<RootComponent>(this, RootApi::class.java)
             .splitScreenFragmentComponentFactory()
-            .create(this)
+            .create(this, payloadOrElse { SplitScreenPayload.NoNavigation })
             .inject(this)
     }
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenPayload.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenPayload.kt
@@ -1,0 +1,16 @@
+package io.novafoundation.nova.app.root.presentation.splitScreen
+
+import android.os.Parcelable
+import io.novafoundation.nova.common.navigation.DelayedNavigation
+import kotlinx.android.parcel.Parcelize
+
+sealed interface SplitScreenPayload : Parcelable {
+
+    @Parcelize
+    object NoNavigation : SplitScreenPayload
+
+    @Parcelize
+    class InstantNavigationOnAttach(
+        val delayedNavigation: DelayedNavigation
+    ) : SplitScreenPayload
+}

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenViewModel.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenViewModel.kt
@@ -80,7 +80,7 @@ class SplitScreenViewModel(
     }
 
     fun onNavigationAttached() {
-        consumablePayload.use {
+        consumablePayload.useOnce {
             when (it) {
                 is SplitScreenPayload.InstantNavigationOnAttach -> {
                     delayedNavigationRouter.runDelayedNavigation(it.delayedNavigation)

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenViewModel.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenViewModel.kt
@@ -28,10 +28,10 @@ class SplitScreenViewModel(
     private val delayedNavigationRouter: DelayedNavigationRouter,
     private val actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
     private val resourceManager: ResourceManager,
-    private val splitScreenPayload: SplitScreenPayload
+    private val payload: SplitScreenPayload
 ) : BaseViewModel() {
 
-    private val consumablePayload = Consumer(splitScreenPayload)
+    private val consumablePayload = Consumer(payload)
 
     val closeAllTabsConfirmation = actionAwaitableMixinFactory.confirmingAction<Unit>()
 
@@ -80,14 +80,16 @@ class SplitScreenViewModel(
     }
 
     fun onNavigationAttached() {
-        when (val payload = consumablePayload.get()) {
-            is SplitScreenPayload.InstantNavigationOnAttach -> {
-                delayedNavigationRouter.runDelayedNavigation(payload.delayedNavigation)
-            }
+        consumablePayload.use {
+            when (it) {
+                is SplitScreenPayload.InstantNavigationOnAttach -> {
+                    delayedNavigationRouter.runDelayedNavigation(it.delayedNavigation)
+                }
 
-            SplitScreenPayload.NoNavigation,
-            null -> {
-            } // Do nothing
+                SplitScreenPayload.NoNavigation,
+                null -> {
+                } // Do nothing
+            }
         }
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenViewModel.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/SplitScreenViewModel.kt
@@ -6,7 +6,9 @@ import io.novafoundation.nova.common.base.BaseViewModel
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.mixin.actionAwaitable.awaitAction
 import io.novafoundation.nova.common.mixin.actionAwaitable.confirmingAction
+import io.novafoundation.nova.common.navigation.DelayedNavigationRouter
 import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.utils.Consumer
 import io.novafoundation.nova.feature_dapp_api.data.model.SimpleTabModel
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
 import io.novafoundation.nova.feature_dapp_api.presentation.browser.main.DAppBrowserPayload
@@ -23,9 +25,13 @@ data class TabsTitleModel(
 class SplitScreenViewModel(
     private val interactor: SplitScreenInteractor,
     private val router: DAppRouter,
+    private val delayedNavigationRouter: DelayedNavigationRouter,
     private val actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
-    private val resourceManager: ResourceManager
+    private val resourceManager: ResourceManager,
+    private val splitScreenPayload: SplitScreenPayload
 ) : BaseViewModel() {
+
+    private val consumablePayload = Consumer(splitScreenPayload)
 
     val closeAllTabsConfirmation = actionAwaitableMixinFactory.confirmingAction<Unit>()
 
@@ -71,5 +77,17 @@ class SplitScreenViewModel(
             resourceManager.getString(R.string.dapp_entry_point_title, size),
             null
         )
+    }
+
+    fun onNavigationAttached() {
+        when (val payload = consumablePayload.get()) {
+            is SplitScreenPayload.InstantNavigationOnAttach -> {
+                delayedNavigationRouter.runDelayedNavigation(payload.delayedNavigation)
+            }
+
+            SplitScreenPayload.NoNavigation,
+            null -> {
+            } // Do nothing
+        }
     }
 }

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/di/SplitScreenFragmentComponent.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/di/SplitScreenFragmentComponent.kt
@@ -20,7 +20,7 @@ interface SplitScreenFragmentComponent {
 
         fun create(
             @BindsInstance fragment: Fragment,
-            @BindsInstance payloadOrElse: SplitScreenPayload
+            @BindsInstance payload: SplitScreenPayload
         ): SplitScreenFragmentComponent
     }
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/di/SplitScreenFragmentComponent.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/di/SplitScreenFragmentComponent.kt
@@ -4,6 +4,7 @@ import androidx.fragment.app.Fragment
 import dagger.BindsInstance
 import dagger.Subcomponent
 import io.novafoundation.nova.app.root.presentation.splitScreen.SplitScreenFragment
+import io.novafoundation.nova.app.root.presentation.splitScreen.SplitScreenPayload
 import io.novafoundation.nova.common.di.scope.ScreenScope
 
 @Subcomponent(
@@ -18,7 +19,8 @@ interface SplitScreenFragmentComponent {
     interface Factory {
 
         fun create(
-            @BindsInstance fragment: Fragment
+            @BindsInstance fragment: Fragment,
+            @BindsInstance payloadOrElse: SplitScreenPayload
         ): SplitScreenFragmentComponent
     }
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/di/SplitScreenFragmentModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/di/SplitScreenFragmentModule.kt
@@ -7,10 +7,12 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
 import io.novafoundation.nova.app.root.domain.SplitScreenInteractor
+import io.novafoundation.nova.app.root.presentation.splitScreen.SplitScreenPayload
 import io.novafoundation.nova.app.root.presentation.splitScreen.SplitScreenViewModel
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
+import io.novafoundation.nova.common.navigation.DelayedNavigationRouter
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_dapp_api.data.repository.BrowserTabExternalRepository
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
@@ -33,10 +35,12 @@ class SplitScreenFragmentModule {
     fun provideViewModel(
         interactor: SplitScreenInteractor,
         dAppRouter: DAppRouter,
+        delayedNavigationRouter: DelayedNavigationRouter,
         actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
-        resourceManager: ResourceManager
+        resourceManager: ResourceManager,
+        payloadOrElse: SplitScreenPayload
     ): ViewModel {
-        return SplitScreenViewModel(interactor, dAppRouter, actionAwaitableMixinFactory, resourceManager)
+        return SplitScreenViewModel(interactor, dAppRouter, delayedNavigationRouter, actionAwaitableMixinFactory, resourceManager, payloadOrElse)
     }
 
     @Provides

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/di/SplitScreenFragmentModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/splitScreen/di/SplitScreenFragmentModule.kt
@@ -38,9 +38,9 @@ class SplitScreenFragmentModule {
         delayedNavigationRouter: DelayedNavigationRouter,
         actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
         resourceManager: ResourceManager,
-        payloadOrElse: SplitScreenPayload
+        payload: SplitScreenPayload
     ): ViewModel {
-        return SplitScreenViewModel(interactor, dAppRouter, delayedNavigationRouter, actionAwaitableMixinFactory, resourceManager, payloadOrElse)
+        return SplitScreenViewModel(interactor, dAppRouter, delayedNavigationRouter, actionAwaitableMixinFactory, resourceManager, payload)
     }
 
     @Provides

--- a/app/src/main/res/layout/fragment_split_screen.xml
+++ b/app/src/main/res/layout/fragment_split_screen.xml
@@ -15,7 +15,7 @@
         android:layout_weight="1"
         app:defaultNavHost="true"
         app:layout_constraintBottom_toTopOf="@id/dappEntryPoint"
-        app:navGraph="@navigation/main_nav_graph" />
+        app:navGraph="@navigation/split_screen_nav_graph" />
 
     <FrameLayout
         android:id="@+id/dappEntryPoint"

--- a/app/src/main/res/navigation/import_parity_signer_graph.xml
+++ b/app/src/main/res/navigation/import_parity_signer_graph.xml
@@ -1,54 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/import_parity_signer_graph"
     app:startDestination="@id/startImportParitySignerFragment">
 
     <fragment
-        tools:layout="@layout/fragment_import_parity_signer_start"
         android:id="@+id/startImportParitySignerFragment"
         android:name="io.novafoundation.nova.feature_account_impl.presentation.paritySigner.connect.start.StartImportParitySignerFragment"
-        android:label="StartImportParitySignerFragment" >
+        android:label="StartImportParitySignerFragment"
+        tools:layout="@layout/fragment_import_parity_signer_start">
 
         <action
+            android:id="@+id/action_startImportParitySignerFragment_to_scanImportParitySignerFragment"
+            app:destination="@id/scanImportParitySignerFragment"
             app:enterAnim="@anim/fragment_open_enter"
             app:exitAnim="@anim/fragment_open_exit"
             app:popEnterAnim="@anim/fragment_close_enter"
-            app:popExitAnim="@anim/fragment_close_exit"
-            android:id="@+id/action_startImportParitySignerFragment_to_scanImportParitySignerFragment"
-            app:destination="@id/scanImportParitySignerFragment" />
+            app:popExitAnim="@anim/fragment_close_exit" />
     </fragment>
 
     <fragment
-        tools:layout="@layout/fragment_import_parity_signer_scan"
         android:id="@+id/scanImportParitySignerFragment"
         android:name="io.novafoundation.nova.feature_account_impl.presentation.paritySigner.connect.scan.ScanImportParitySignerFragment"
-        android:label="ScanImportParitySignerFragment" >
+        android:label="ScanImportParitySignerFragment"
+        tools:layout="@layout/fragment_import_parity_signer_scan">
 
         <action
+            android:id="@+id/action_scanImportParitySignerFragment_to_previewImportParitySignerFragment"
+            app:destination="@id/previewImportParitySignerFragment"
             app:enterAnim="@anim/fragment_open_enter"
             app:exitAnim="@anim/fragment_open_exit"
             app:popEnterAnim="@anim/fragment_close_enter"
-            app:popExitAnim="@anim/fragment_close_exit"
-            android:id="@+id/action_scanImportParitySignerFragment_to_previewImportParitySignerFragment"
-            app:destination="@id/previewImportParitySignerFragment" />
+            app:popExitAnim="@anim/fragment_close_exit" />
     </fragment>
 
     <fragment
         android:id="@+id/previewImportParitySignerFragment"
-        tools:layout="@layout/fragment_chain_account_preview"
         android:name="io.novafoundation.nova.feature_account_impl.presentation.paritySigner.connect.preview.PreviewImportParitySignerFragment"
-        android:label="PreviewImportParitySignerFragment" >
-
+        android:label="PreviewImportParitySignerFragment"
+        tools:layout="@layout/fragment_chain_account_preview">
 
         <action
+            android:id="@+id/action_previewImportParitySignerFragment_to_finishImportParitySignerFragment"
+            app:destination="@id/finishImportParitySignerFragment"
             app:enterAnim="@anim/fragment_open_enter"
             app:exitAnim="@anim/fragment_open_exit"
             app:popEnterAnim="@anim/fragment_close_enter"
-            app:popExitAnim="@anim/fragment_close_exit"
-            android:id="@+id/action_previewImportParitySignerFragment_to_finishImportParitySignerFragment"
-            app:destination="@id/finishImportParitySignerFragment" />
+            app:popExitAnim="@anim/fragment_close_exit" />
     </fragment>
 
 

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -60,6 +60,14 @@
         app:popExitAnim="@anim/fragment_close_exit" />
 
     <action
+        android:id="@+id/open_pincode_check"
+        app:destination="@+id/pincodeFragment"
+        app:enterAnim="@anim/fragment_open_enter"
+        app:exitAnim="@anim/fragment_open_exit"
+        app:popEnterAnim="@anim/fragment_close_enter"
+        app:popExitAnim="@anim/fragment_close_exit" />
+
+    <action
         android:id="@+id/action_open_send"
         app:destination="@id/selectSendFragment"
         app:enterAnim="@anim/fragment_open_enter"

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -29,8 +29,6 @@
 
     <include app:graph="@navigation/wallet_connect_nav_graph" />
 
-    <include app:graph="@navigation/external_sign_graph" />
-
     <include app:graph="@navigation/staking_main_graph" />
 
     <include app:graph="@navigation/push_settings_graph" />
@@ -233,13 +231,6 @@
         app:popEnterAnim="@anim/fragment_close_enter"
         app:popExitAnim="@anim/fragment_close_exit" />
 
-    <action
-        android:id="@+id/action_open_externalSignGraph"
-        app:destination="@id/external_sign_graph"
-        app:enterAnim="@anim/fragment_open_enter"
-        app:exitAnim="@anim/fragment_open_exit"
-        app:popEnterAnim="@anim/fragment_close_enter"
-        app:popExitAnim="@anim/fragment_close_exit" />
 
     <action
         android:id="@+id/action_open_scanWalletConnect"

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -5,6 +5,56 @@
     android:id="@+id/main_nav_graph"
     app:startDestination="@id/mainFragment">
 
+    <include app:graph="@navigation/import_wallet_options_nav_graph" />
+
+    <include app:graph="@navigation/start_swap_nav_graph" />
+
+    <include app:graph="@navigation/manage_tokens_graph" />
+
+    <include app:graph="@navigation/sign_parity_signer_graph" />
+
+    <include app:graph="@navigation/sign_ledger_nav_graph" />
+
+    <include app:graph="@navigation/add_ledger_chain_account_graph" />
+
+    <include app:graph="@navigation/referendum_details_graph" />
+
+    <include app:graph="@navigation/referendum_unlock_graph" />
+
+    <include app:graph="@navigation/delegation_nav_graph" />
+
+    <include app:graph="@navigation/your_delegations_nav_graph" />
+
+    <include app:graph="@navigation/referenda_search_graph" />
+
+    <include app:graph="@navigation/wallet_connect_nav_graph" />
+
+    <include app:graph="@navigation/external_sign_graph" />
+
+    <include app:graph="@navigation/staking_main_graph" />
+
+    <include app:graph="@navigation/push_settings_graph" />
+
+    <include app:graph="@navigation/cloud_backup_settings_graph" />
+
+    <include app:graph="@navigation/manual_backup_graph" />
+
+    <include app:graph="@navigation/create_wallet_nav_graph" />
+
+    <include app:graph="@navigation/network_management_graph" />
+
+    <include app:graph="@navigation/tinder_gov_graph" />
+
+    <include app:graph="@navigation/select_swap_token_nav_graph" />
+
+    <action
+        android:id="@+id/action_importWalletOptionsFragment"
+        app:destination="@id/import_wallet_options_nav_graph"
+        app:enterAnim="@anim/fragment_open_enter"
+        app:exitAnim="@anim/fragment_open_exit"
+        app:popEnterAnim="@anim/fragment_close_enter"
+        app:popExitAnim="@anim/fragment_close_exit" />
+
     <action
         android:id="@+id/action_open_send"
         app:destination="@id/selectSendFragment"
@@ -997,45 +1047,5 @@
         android:name="io.novafoundation.nova.feature_dapp_impl.presentation.favorites.DappFavoritesFragment"
         android:label="fragment_favorites"
         tools:layout="@layout/fragment_favorites_dapp"/>
-
-    <include app:graph="@navigation/start_swap_nav_graph" />
-
-    <include app:graph="@navigation/manage_tokens_graph" />
-
-    <include app:graph="@navigation/sign_parity_signer_graph" />
-
-    <include app:graph="@navigation/sign_ledger_nav_graph" />
-
-    <include app:graph="@navigation/add_ledger_chain_account_graph" />
-
-    <include app:graph="@navigation/referendum_details_graph" />
-
-    <include app:graph="@navigation/referendum_unlock_graph" />
-
-    <include app:graph="@navigation/delegation_nav_graph" />
-
-    <include app:graph="@navigation/your_delegations_nav_graph" />
-
-    <include app:graph="@navigation/referenda_search_graph" />
-
-    <include app:graph="@navigation/wallet_connect_nav_graph" />
-
-    <include app:graph="@navigation/external_sign_graph" />
-
-    <include app:graph="@navigation/staking_main_graph" />
-
-    <include app:graph="@navigation/push_settings_graph" />
-
-    <include app:graph="@navigation/cloud_backup_settings_graph" />
-
-    <include app:graph="@navigation/manual_backup_graph" />
-
-    <include app:graph="@navigation/create_wallet_nav_graph" />
-
-    <include app:graph="@navigation/network_management_graph" />
-
-    <include app:graph="@navigation/tinder_gov_graph" />
-
-    <include app:graph="@navigation/select_swap_token_nav_graph" />
 
 </navigation>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -47,6 +47,10 @@
 
     <include app:graph="@navigation/select_swap_token_nav_graph" />
 
+    <include app:graph="@navigation/import_nav_graph" />
+
+    <include app:graph="@navigation/import_wallet_options_nav_graph" />
+
     <action
         android:id="@+id/action_importWalletOptionsFragment"
         app:destination="@id/import_wallet_options_nav_graph"
@@ -184,6 +188,14 @@
     <action
         android:id="@+id/action_open_account_details"
         app:destination="@id/walletDetailsFragment"
+        app:enterAnim="@anim/fragment_open_enter"
+        app:exitAnim="@anim/fragment_open_exit"
+        app:popEnterAnim="@anim/fragment_close_enter"
+        app:popExitAnim="@anim/fragment_close_exit" />
+
+    <action
+        android:id="@+id/action_import_nav_graph"
+        app:destination="@id/import_nav_graph"
         app:enterAnim="@anim/fragment_open_enter"
         app:exitAnim="@anim/fragment_open_exit"
         app:popEnterAnim="@anim/fragment_close_enter"

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -49,6 +49,8 @@
 
     <include app:graph="@navigation/import_wallet_options_nav_graph" />
 
+    <include app:graph="@navigation/onboarding_nav_graph" />
+
     <action
         android:id="@+id/action_importWalletOptionsFragment"
         app:destination="@id/import_wallet_options_nav_graph"
@@ -347,6 +349,12 @@
         app:exitAnim="@anim/fragment_open_exit"
         app:popEnterAnim="@anim/fragment_close_enter"
         app:popExitAnim="@anim/fragment_close_exit" />
+
+    <action
+        android:id="@+id/action_onboarding"
+        app:destination="@id/onboarding_nav_graph"
+        app:popEnterAnim="@anim/fragment_close_enter"
+        app:popExitAnim="@anim/fragment_close_exit"/>
 
     <fragment
         android:id="@+id/mainFragment"

--- a/app/src/main/res/navigation/root_nav_graph.xml
+++ b/app/src/main/res/navigation/root_nav_graph.xml
@@ -17,6 +17,18 @@
 
     <include app:graph="@navigation/import_wallet_options_nav_graph" />
 
+    <include app:graph="@navigation/external_sign_graph" />
+
+    <include app:graph="@navigation/sign_ledger_nav_graph" />
+
+    <action
+        android:id="@+id/action_open_externalSignGraph"
+        app:destination="@id/external_sign_graph"
+        app:enterAnim="@anim/fragment_open_enter"
+        app:exitAnim="@anim/fragment_open_exit"
+        app:popEnterAnim="@anim/fragment_close_enter"
+        app:popExitAnim="@anim/fragment_close_exit" />
+
     <action
         android:id="@+id/action_open_split_screen"
         app:destination="@id/splitScreenFragment"
@@ -68,6 +80,14 @@
         app:popExitAnim="@anim/fragment_slide_out" />
 
     <action
+        android:id="@+id/action_import_nav_graph"
+        app:destination="@id/import_nav_graph"
+        app:enterAnim="@anim/fragment_open_enter"
+        app:exitAnim="@anim/fragment_open_exit"
+        app:popEnterAnim="@anim/fragment_close_enter"
+        app:popExitAnim="@anim/fragment_close_exit" />
+
+    <action
         android:id="@+id/action_open_dappSearch"
         app:destination="@id/dapp_search_graph"
         app:enterAnim="@anim/fragment_slide_in"
@@ -86,6 +106,14 @@
     <action
         android:id="@+id/action_importWalletOptionsFragment"
         app:destination="@id/import_wallet_options_nav_graph"
+        app:enterAnim="@anim/fragment_open_enter"
+        app:exitAnim="@anim/fragment_open_exit"
+        app:popEnterAnim="@anim/fragment_close_enter"
+        app:popExitAnim="@anim/fragment_close_exit" />
+
+    <action
+        android:id="@+id/action_open_sign_parity_signer"
+        app:destination="@id/sign_parity_signer_graph"
         app:enterAnim="@anim/fragment_open_enter"
         app:exitAnim="@anim/fragment_open_exit"
         app:popEnterAnim="@anim/fragment_close_enter"
@@ -146,7 +174,6 @@
 
         <action
             android:id="@+id/action_close_update_notifications"
-            app:destination="@id/updateNotificationsFragment"
             app:enterAnim="@anim/fragment_open_enter"
             app:exitAnim="@anim/fragment_open_exit"
             app:popEnterAnim="@anim/fragment_close_enter"

--- a/app/src/main/res/navigation/root_nav_graph.xml
+++ b/app/src/main/res/navigation/root_nav_graph.xml
@@ -5,8 +5,6 @@
     android:id="@+id/root_nav_graph"
     app:startDestination="@id/splashFragment">
 
-    <include app:graph="@navigation/main_nav_graph" />
-
     <include app:graph="@navigation/onboarding_nav_graph" />
 
     <include app:graph="@navigation/import_nav_graph" />
@@ -20,7 +18,7 @@
     <include app:graph="@navigation/import_wallet_options_nav_graph" />
 
     <action
-        android:id="@+id/action_open_main"
+        android:id="@+id/action_open_split_screen"
         app:destination="@id/splitScreenFragment"
         app:enterAnim="@anim/fragment_open_enter"
         app:exitAnim="@anim/fragment_open_exit"

--- a/app/src/main/res/navigation/root_nav_graph.xml
+++ b/app/src/main/res/navigation/root_nav_graph.xml
@@ -162,7 +162,6 @@
         android:id="@+id/pincodeFragmentOverlay"
         android:name="io.novafoundation.nova.feature_account_impl.presentation.pincode.PincodeFragment"
         android:label="fragment_pincode"
-        app:useAdd="true"
         tools:layout="@layout/fragment_pincode" />
 
     <fragment

--- a/app/src/main/res/navigation/root_nav_graph.xml
+++ b/app/src/main/res/navigation/root_nav_graph.xml
@@ -158,7 +158,19 @@
         android:name="io.novafoundation.nova.feature_versions_impl.presentation.update.UpdateNotificationFragment"
         android:label="updateNotificationsFragment"
         app:useAdd="true"
-        tools:layout="@layout/fragment_update_notifications" />
+        tools:layout="@layout/fragment_update_notifications">
+
+        <action
+            android:id="@+id/action_close_update_notifications"
+            app:destination="@id/updateNotificationsFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit"
+            app:popUpTo="@+id/updateNotificationsFragment"
+            app:popUpToInclusive="true" />
+
+    </fragment>
 
     <fragment
         android:id="@+id/balanceDetailFragment"

--- a/app/src/main/res/navigation/root_nav_graph.xml
+++ b/app/src/main/res/navigation/root_nav_graph.xml
@@ -60,22 +60,6 @@
         app:popExitAnim="@anim/fragment_close_exit" />
 
     <action
-        android:id="@+id/action_import_nav_graph"
-        app:destination="@id/import_nav_graph"
-        app:enterAnim="@anim/fragment_open_enter"
-        app:exitAnim="@anim/fragment_open_exit"
-        app:popEnterAnim="@anim/fragment_close_enter"
-        app:popExitAnim="@anim/fragment_close_exit" />
-
-    <action
-        android:id="@+id/action_root_to_balanceDetailFragment"
-        app:destination="@id/balanceDetailFragment"
-        app:enterAnim="@anim/fragment_open_enter"
-        app:exitAnim="@anim/fragment_open_exit"
-        app:popEnterAnim="@anim/fragment_close_enter"
-        app:popExitAnim="@anim/fragment_close_exit" />
-
-    <action
         android:id="@+id/action_open_dappBrowser"
         app:destination="@id/dapp_browser_graph"
         app:enterAnim="@anim/fragment_slide_in"

--- a/app/src/main/res/navigation/split_screen_nav_graph.xml
+++ b/app/src/main/res/navigation/split_screen_nav_graph.xml
@@ -2,7 +2,7 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main_nav_graph"
+    android:id="@+id/split_screen_nav_graph"
     app:startDestination="@id/mainFragment">
 
     <include app:graph="@navigation/import_wallet_options_nav_graph" />
@@ -147,7 +147,7 @@
         app:launchSingleTop="true"
         app:popEnterAnim="@anim/fragment_open_enter"
         app:popExitAnim="@anim/fragment_open_exit"
-        app:popUpTo="@id/main_nav_graph" />
+        app:popUpTo="@id/split_screen_nav_graph" />
 
     <action
         android:id="@+id/action_export_seed"

--- a/common/src/main/java/io/novafoundation/nova/common/navigation/DelayedNavigation.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/navigation/DelayedNavigation.kt
@@ -1,0 +1,5 @@
+package io.novafoundation.nova.common.navigation
+
+import android.os.Parcelable
+
+interface DelayedNavigation : Parcelable

--- a/common/src/main/java/io/novafoundation/nova/common/navigation/DelayedNavigationRouter.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/navigation/DelayedNavigationRouter.kt
@@ -1,0 +1,6 @@
+package io.novafoundation.nova.common.navigation
+
+interface DelayedNavigationRouter {
+
+    fun runDelayedNavigation(delayedNavigation: DelayedNavigation)
+}

--- a/common/src/main/java/io/novafoundation/nova/common/navigation/SecureRouter.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/navigation/SecureRouter.kt
@@ -1,11 +1,7 @@
 package io.novafoundation.nova.common.navigation
 
-import android.os.Parcelable
-
 @Retention(AnnotationRetention.SOURCE)
 annotation class PinRequired
-
-interface DelayedNavigation : Parcelable
 
 interface SecureRouter {
 

--- a/common/src/main/java/io/novafoundation/nova/common/utils/Consumer.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/Consumer.kt
@@ -1,0 +1,10 @@
+package io.novafoundation.nova.common.utils
+
+class Consumer<T>(private var target: T?) {
+
+    fun get(): T? {
+        val returnable = target
+        target = null
+        return returnable
+    }
+}

--- a/common/src/main/java/io/novafoundation/nova/common/utils/Consumer.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/Consumer.kt
@@ -7,4 +7,11 @@ class Consumer<T>(private var target: T?) {
         target = null
         return returnable
     }
+
+    fun use(block: (T) -> Unit) {
+        val target = get()
+        if (target != null) {
+            block(target)
+        }
+    }
 }

--- a/common/src/main/java/io/novafoundation/nova/common/utils/Consumer.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/Consumer.kt
@@ -2,16 +2,13 @@ package io.novafoundation.nova.common.utils
 
 class Consumer<T>(private var target: T?) {
 
-    fun get(): T? {
-        val returnable = target
-        target = null
-        return returnable
+    fun getOnce(): T? {
+        return target.also {
+            target = null
+        }
     }
 
-    fun use(block: (T) -> Unit) {
-        val target = get()
-        if (target != null) {
-            block(target)
-        }
+    fun useOnce(block: (T) -> Unit) {
+        getOnce()?.let(block)
     }
 }

--- a/common/src/main/java/io/novafoundation/nova/common/utils/PayloadCreator.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/PayloadCreator.kt
@@ -25,7 +25,7 @@ fun <T> BaseFragment<*>.payload(): T {
 }
 
 fun <T> BaseFragment<*>.payloadOrNull(): T? {
-    return requireArguments().getParcelable(KEY_PAYLOAD)
+    return arguments?.getParcelable(KEY_PAYLOAD) as? T
 }
 
 fun <T> BaseFragment<*>.payloadOrElse(fallback: () -> T): T {

--- a/common/src/main/java/io/novafoundation/nova/common/utils/PayloadCreator.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/PayloadCreator.kt
@@ -23,3 +23,11 @@ class FragmentPayloadCreator<T : Parcelable> : PayloadCreator<T> {
 fun <T> BaseFragment<*>.payload(): T {
     return requireArguments().getParcelable(KEY_PAYLOAD)!!
 }
+
+fun <T> BaseFragment<*>.payloadOrNull(): T? {
+    return requireArguments().getParcelable(KEY_PAYLOAD)
+}
+
+fun <T> BaseFragment<*>.payloadOrElse(fallback: () -> T): T {
+    return payloadOrNull() ?: fallback()
+}

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/AccountRouter.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/AccountRouter.kt
@@ -97,6 +97,6 @@ interface AccountRouter : SecureRouter, ReturnableRouter {
     fun openManualBackupSecrets(payload: ManualBackupCommonPayload)
 
     fun openManualBackupAdvancedSecrets(payload: ManualBackupCommonPayload)
-    
+
     fun finishApp()
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/AccountRouter.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/AccountRouter.kt
@@ -78,8 +78,6 @@ interface AccountRouter : SecureRouter, ReturnableRouter {
 
     fun openAddLedgerChainAccountFlow(payload: AddAccountPayload.ChainAccount)
 
-    fun finishApp()
-
     fun openCreateCloudBackupPassword(walletName: String)
 
     fun restoreCloudBackup()

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/AccountRouter.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/AccountRouter.kt
@@ -97,4 +97,6 @@ interface AccountRouter : SecureRouter, ReturnableRouter {
     fun openManualBackupSecrets(payload: ManualBackupCommonPayload)
 
     fun openManualBackupAdvancedSecrets(payload: ManualBackupCommonPayload)
+    
+    fun finishApp()
 }

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/data/repository/tabs/RealBrowserTabRepository.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/data/repository/tabs/RealBrowserTabRepository.kt
@@ -8,7 +8,6 @@ import io.novafoundation.nova.feature_dapp_impl.utils.tabs.models.BrowserTab
 import io.novafoundation.nova.feature_dapp_impl.utils.tabs.models.PageSnapshot
 import java.util.Date
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 class RealBrowserTabRepository(
     private val browserTabsDao: BrowserTabsDao
@@ -26,14 +25,6 @@ class RealBrowserTabRepository(
         return browserTabsDao.observeAllTabs()
             .mapList {
                 SimpleTabModel(it.id, it.pageName, it.pageIconPath)
-            }.map {
-                it + listOf(
-                    SimpleTabModel(
-                        "someId",
-                        "Hmm",
-                        null
-                    )
-                )
             }
     }
 

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/data/repository/tabs/RealBrowserTabRepository.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/data/repository/tabs/RealBrowserTabRepository.kt
@@ -8,6 +8,7 @@ import io.novafoundation.nova.feature_dapp_impl.utils.tabs.models.BrowserTab
 import io.novafoundation.nova.feature_dapp_impl.utils.tabs.models.PageSnapshot
 import java.util.Date
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class RealBrowserTabRepository(
     private val browserTabsDao: BrowserTabsDao
@@ -25,6 +26,14 @@ class RealBrowserTabRepository(
         return browserTabsDao.observeAllTabs()
             .mapList {
                 SimpleTabModel(it.id, it.pageName, it.pageIconPath)
+            }.map {
+                it + listOf(
+                    SimpleTabModel(
+                        "someId",
+                        "Hmm",
+                        null
+                    )
+                )
             }
     }
 

--- a/feature-deep-linking/src/main/java/io/novafoundation/nova/feature_deep_linking/presentation/handling/DeepLinkingRouter.kt
+++ b/feature-deep-linking/src/main/java/io/novafoundation/nova/feature_deep_linking/presentation/handling/DeepLinkingRouter.kt
@@ -10,7 +10,7 @@ interface DeepLinkingRouter {
 
     fun openDAppBrowser(url: String)
 
-    fun openImportAccountScreen(importAccountPayload: ImportAccountPayload)
+    fun openImportAccountScreen(payload: ImportAccountPayload)
 
     fun openReferendum(payload: ReferendumDetailsPayload)
 

--- a/feature-versions-api/src/main/java/io/novafoundation/nova/feature_versions_api/presentation/VersionsRouter.kt
+++ b/feature-versions-api/src/main/java/io/novafoundation/nova/feature_versions_api/presentation/VersionsRouter.kt
@@ -4,5 +4,5 @@ interface VersionsRouter {
 
     fun openAppUpdater()
 
-    fun back()
+    fun closeUpdateNotifications()
 }

--- a/feature-versions-impl/src/main/java/io/novafoundation/nova/feature_versions_impl/presentation/update/UpdateNotificationViewModel.kt
+++ b/feature-versions-impl/src/main/java/io/novafoundation/nova/feature_versions_impl/presentation/update/UpdateNotificationViewModel.kt
@@ -50,11 +50,11 @@ class UpdateNotificationViewModel(
 
     fun skipClicked() = launch {
         interactor.skipNewUpdates()
-        router.back()
+        router.closeUpdateNotifications()
     }
 
     fun installUpdateClicked() {
-        router.back()
+        router.closeUpdateNotifications()
         router.openAppUpdater()
     }
 


### PR DESCRIPTION
#8696rb6z7
#8697140h8
#86972enh0
#869714a36
#8697150vu

Since we now have 2 containers where we can open screens (ROOT and SPLIT_SCREEN), there is a need to contain 2 NavigationHolders, as well as launch the action for the correct NavController.

In addition, we want to make sure that when the action is launched, the new fragment will open in the currently attached navcontroller. SplitScreenNavController is detached every time we open a fragment in ROOT, so when we launch the action, it will automatically be executed for ROOT.

I moved this logic to NavigationBuilder. It is where the decision is made in which controller the fragment will be launched