### PR TITLE
Myth staking/start staking landing

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/FearlessLibExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/FearlessLibExt.kt
@@ -64,7 +64,6 @@ import io.novasama.substrate_sdk_android.wsrpc.SocketService
 import io.novasama.substrate_sdk_android.wsrpc.networkStateFlow
 import io.novasama.substrate_sdk_android.wsrpc.state.SocketStateMachine
 import kotlinx.coroutines.flow.first
-import org.bouncycastle.math.raw.Mod
 import org.web3j.crypto.Sign
 import java.io.ByteArrayOutputStream
 import java.math.BigInteger

--- a/common/src/main/java/io/novafoundation/nova/common/utils/Fraction.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/Fraction.kt
@@ -56,6 +56,8 @@ enum class FractionUnit {
     PERCENT
 }
 
+fun Fraction?.orZero(): Fraction = this ?: Fraction.ZERO
+
 private fun FractionUnit.convertToFraction(value: Double): Double {
     return when (this) {
         FractionUnit.FRACTION -> value

--- a/common/src/main/java/io/novafoundation/nova/common/utils/Percent.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/Percent.kt
@@ -1,4 +1,4 @@
-@file:Suppress("NOTHING_TO_INLINE")
+@file:Suppress("NOTHING_TO_INLINE", "DeprecatedCallableAddReplaceWith")
 
 package io.novafoundation.nova.common.utils
 
@@ -44,12 +44,17 @@ value class Percent(val value: Double) : Comparable<Percent> {
     }
 }
 
+@Deprecated("Use Fraction instead")
 inline fun BigDecimal.asPerbill(): Perbill = Perbill(this.toDouble())
 
+@Deprecated("Use Fraction instead")
 inline fun Double.asPerbill(): Perbill = Perbill(this)
 
+@Deprecated("Use Fraction instead")
 inline fun Double.asPercent(): Percent = Percent(this)
 
+@Deprecated("Use Fraction instead")
 inline fun Perbill.toPercent(): Percent = Percent(value * 100)
 
+@Deprecated("Use Fraction instead")
 inline fun Perbill?.orZero(): Perbill = this ?: Perbill(0.0)

--- a/common/src/main/java/io/novafoundation/nova/common/utils/RuntimeContext.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/RuntimeContext.kt
@@ -17,5 +17,3 @@ fun RuntimeContext(runtime: RuntimeSnapshot): RuntimeContext {
 
 @JvmInline
 private value class InlineRuntimeContext(override val runtime: RuntimeSnapshot) : RuntimeContext
-
-

--- a/common/src/main/java/io/novafoundation/nova/common/utils/RuntimeContext.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/RuntimeContext.kt
@@ -1,0 +1,21 @@
+package io.novafoundation.nova.common.utils
+
+import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
+import io.novasama.substrate_sdk_android.runtime.metadata.RuntimeMetadata
+
+interface RuntimeContext {
+
+    val runtime: RuntimeSnapshot
+}
+
+val RuntimeContext.metadata: RuntimeMetadata
+    get() = runtime.metadata
+
+fun RuntimeContext(runtime: RuntimeSnapshot): RuntimeContext {
+    return InlineRuntimeContext(runtime)
+}
+
+@JvmInline
+private value class InlineRuntimeContext(override val runtime: RuntimeSnapshot) : RuntimeContext
+
+

--- a/core-api/src/main/java/io/novafoundation/nova/core/updater/Updater.kt
+++ b/core-api/src/main/java/io/novafoundation/nova/core/updater/Updater.kt
@@ -38,6 +38,7 @@ interface GlobalScopeUpdater : Updater<Unit> {
 interface Updater<V> : SideEffectScope {
 
     val requiredModules: List<String>
+        get() = emptyList()
 
     val scope: UpdateScope<V>
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/duration/MythosSessionDurationCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/duration/MythosSessionDurationCalculator.kt
@@ -1,10 +1,21 @@
 package io.novafoundation.nova.feature_staking_impl.data.mythos.duration
 
+import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.common.utils.flowOfAll
 import io.novafoundation.nova.common.utils.toDuration
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
+import io.novafoundation.nova.feature_staking_impl.data.chain
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.RealMythosSessionRepository
+import io.novafoundation.nova.feature_staking_impl.domain.common.EraRewardCalculatorComparable
+import io.novafoundation.nova.feature_staking_impl.domain.common.ignoreInsignificantTimeChanges
+import io.novafoundation.nova.runtime.repository.ChainStateRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import java.math.BigInteger
+import javax.inject.Inject
 import kotlin.time.Duration
 
-interface MythosSessionDurationCalculator {
+interface MythosSessionDurationCalculator : EraRewardCalculatorComparable {
 
     fun sessionDuration(): Duration
 
@@ -14,7 +25,37 @@ interface MythosSessionDurationCalculator {
     fun remainingSessionDuration(): Duration
 }
 
-class RealMythosSessionDurationCalculator(
+fun MythosSessionDurationCalculator.sessionsDuration(numberOfSessions: Int): Duration {
+    return sessionDuration() * numberOfSessions
+}
+
+@FeatureScope
+class MythosSessionDurationCalculatorFactory @Inject constructor(
+    private val mythosSessionRepository: RealMythosSessionRepository,
+    private val chainStateRepository: ChainStateRepository,
+) {
+
+    fun create(stakingOption: StakingOption): Flow<MythosSessionDurationCalculator> {
+        val chainId = stakingOption.chain.id
+
+        return flowOfAll {
+            val sessionLength = mythosSessionRepository.sessionLength(stakingOption.chain)
+
+            combine(
+                mythosSessionRepository.currentSlotFlow(chainId),
+                chainStateRepository.predictedBlockTimeFlow(chainId)
+            ) { currentSlot, blockTime ->
+                RealMythosSessionDurationCalculator(
+                    blockTime = blockTime,
+                    currentSlot = currentSlot,
+                    slotsInSession = sessionLength
+                )
+            }
+        }.ignoreInsignificantTimeChanges()
+    }
+}
+
+private class RealMythosSessionDurationCalculator(
     private val blockTime: BigInteger,
     private val currentSlot: BigInteger,
     private val slotsInSession: BigInteger
@@ -28,8 +69,13 @@ class RealMythosSessionDurationCalculator(
         return (slotsInSession - sessionProgress()).toDuration()
     }
 
+    override fun derivedTimestamp(): Duration {
+        return (currentSlot * blockTime).toDuration()
+    }
+
     private fun sessionProgress(): BigInteger {
         // Mythos has 0 offset for sessions, so first block number of a session is divisible by session length
         return currentSlot % slotsInSession
     }
 }
+

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/duration/MythosSessionDurationCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/duration/MythosSessionDurationCalculator.kt
@@ -78,4 +78,3 @@ private class RealMythosSessionDurationCalculator(
         return currentSlot % slotsInSession
     }
 }
-

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/network/blockchain/api/CollatorStakingRuntimeApi.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/network/blockchain/api/CollatorStakingRuntimeApi.kt
@@ -6,7 +6,6 @@ import io.novafoundation.nova.common.utils.collatorStaking
 import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.model.UserStakeInfo
 import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.model.bindUserStakeInfo
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
-import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.runtime.storage.source.query.api.QueryableModule
 import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry0
 import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry1

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/network/blockchain/api/CollatorStakingRuntimeApi.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/network/blockchain/api/CollatorStakingRuntimeApi.kt
@@ -1,11 +1,16 @@
 package io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.api
 
+import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
+import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novafoundation.nova.common.utils.collatorStaking
 import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.model.UserStakeInfo
 import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.model.bindUserStakeInfo
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.runtime.storage.source.query.api.QueryableModule
+import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry0
 import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry1
+import io.novafoundation.nova.runtime.storage.source.query.api.storage0
 import io.novafoundation.nova.runtime.storage.source.query.api.storage1
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.runtime.metadata.RuntimeMetadata
@@ -14,10 +19,14 @@ import io.novasama.substrate_sdk_android.runtime.metadata.module.Module
 @JvmInline
 value class CollatorStakingRuntimeApi(override val module: Module) : QueryableModule
 
-context(StorageQueryContext)
+context(RuntimeContext)
 val RuntimeMetadata.collatorStaking: CollatorStakingRuntimeApi
     get() = CollatorStakingRuntimeApi(collatorStaking())
 
-context(StorageQueryContext)
+context(RuntimeContext)
 val CollatorStakingRuntimeApi.userStake: QueryableStorageEntry1<AccountId, UserStakeInfo>
     get() = storage1("UserStake", binding = { decoded, _ -> bindUserStakeInfo(decoded) })
+
+context(RuntimeContext)
+val CollatorStakingRuntimeApi.minStake: QueryableStorageEntry0<Balance>
+    get() = storage0("MinStake", binding = ::bindNumber)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosSessionRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosSessionRepository.kt
@@ -1,0 +1,31 @@
+package io.novafoundation.nova.feature_staking_impl.data.mythos.repository
+
+import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
+import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.feature_staking_impl.data.repository.consensus.AuraSession
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+interface MythosSessionRepository {
+
+    suspend fun sessionLength(chain: Chain): BlockNumber
+
+    fun currentSlotFlow(chainId: ChainId): Flow<BlockNumber>
+}
+
+@FeatureScope
+class RealMythosSessionRepository @Inject constructor(
+    private val auraSession: AuraSession,
+): MythosSessionRepository {
+
+    override suspend fun sessionLength(chain: Chain): BlockNumber {
+        return chain.additional?.sessionLength?.toBigInteger()
+            ?: auraSession.sessionLength(chain.id)
+    }
+
+    override fun currentSlotFlow(chainId: ChainId): Flow<BlockNumber> {
+        return auraSession.currentSlotFlow(chainId)
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosSessionRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosSessionRepository.kt
@@ -18,7 +18,7 @@ interface MythosSessionRepository {
 @FeatureScope
 class RealMythosSessionRepository @Inject constructor(
     private val auraSession: AuraSession,
-): MythosSessionRepository {
+) : MythosSessionRepository {
 
     override suspend fun sessionLength(chain: Chain): BlockNumber {
         return chain.additional?.sessionLength?.toBigInteger()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosStakingRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosStakingRepository.kt
@@ -1,6 +1,5 @@
 package io.novafoundation.nova.feature_staking_impl.data.mythos.repository
 
-import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.utils.collatorStaking
 import io.novafoundation.nova.common.utils.metadata
@@ -30,7 +29,7 @@ class RealMythosStakingRepository @Inject constructor(
     @Named(LOCAL_STORAGE_SOURCE)
     private val localStorageDataSource: StorageDataSource,
     private val chainRegistry: ChainRegistry
-): MythosStakingRepository {
+) : MythosStakingRepository {
 
     override fun minStakeFlow(chainId: ChainId): Flow<Balance> {
         return localStorageDataSource.subscribe(chainId) {
@@ -39,8 +38,8 @@ class RealMythosStakingRepository @Inject constructor(
     }
 
     override suspend fun unstakeDurationInSessions(chainId: ChainId): Int {
-       return chainRegistry.withRuntime(chainId) {
-           metadata.collatorStaking().numberConstant("StakeUnlockDelay").toInt()
-       }
+        return chainRegistry.withRuntime(chainId) {
+            metadata.collatorStaking().numberConstant("StakeUnlockDelay").toInt()
+        }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosStakingRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosStakingRepository.kt
@@ -1,0 +1,32 @@
+package io.novafoundation.nova.feature_staking_impl.data.mythos.repository
+
+import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.common.utils.metadata
+import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.api.collatorStaking
+import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.api.minStake
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.runtime.di.LOCAL_STORAGE_SOURCE
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.storage.source.StorageDataSource
+import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNull
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Named
+
+interface MythosStakingRepository {
+
+    suspend fun minStakeFlow(chainId: ChainId): Flow<Balance>
+}
+
+@FeatureScope
+class RealMythosStakingRepository @Inject constructor(
+    @Named(LOCAL_STORAGE_SOURCE)
+    private val localStorageDataSource: StorageDataSource,
+): MythosStakingRepository {
+
+    override suspend fun minStakeFlow(chainId: ChainId): Flow<Balance> {
+        return localStorageDataSource.subscribe(chainId) {
+            metadata.collatorStaking.minStake.observeNonNull()
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosStakingRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosStakingRepository.kt
@@ -1,12 +1,17 @@
 package io.novafoundation.nova.feature_staking_impl.data.mythos.repository
 
+import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
 import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.common.utils.collatorStaking
 import io.novafoundation.nova.common.utils.metadata
+import io.novafoundation.nova.common.utils.numberConstant
 import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.api.collatorStaking
 import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.api.minStake
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.runtime.di.LOCAL_STORAGE_SOURCE
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.multiNetwork.withRuntime
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNull
 import kotlinx.coroutines.flow.Flow
@@ -15,18 +20,27 @@ import javax.inject.Named
 
 interface MythosStakingRepository {
 
-    suspend fun minStakeFlow(chainId: ChainId): Flow<Balance>
+    fun minStakeFlow(chainId: ChainId): Flow<Balance>
+
+    suspend fun unstakeDurationInSessions(chainId: ChainId): Int
 }
 
 @FeatureScope
 class RealMythosStakingRepository @Inject constructor(
     @Named(LOCAL_STORAGE_SOURCE)
     private val localStorageDataSource: StorageDataSource,
+    private val chainRegistry: ChainRegistry
 ): MythosStakingRepository {
 
-    override suspend fun minStakeFlow(chainId: ChainId): Flow<Balance> {
+    override fun minStakeFlow(chainId: ChainId): Flow<Balance> {
         return localStorageDataSource.subscribe(chainId) {
             metadata.collatorStaking.minStake.observeNonNull()
         }
+    }
+
+    override suspend fun unstakeDurationInSessions(chainId: ChainId): Int {
+       return chainRegistry.withRuntime(chainId) {
+           metadata.collatorStaking().numberConstant("StakeUnlockDelay").toInt()
+       }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/updaters/MythosMinStakeUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/updaters/MythosMinStakeUpdater.kt
@@ -1,20 +1,18 @@
-package io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.session
+package io.novafoundation.nova.feature_staking_impl.data.mythos.updaters
 
 import io.novafoundation.nova.common.utils.RuntimeContext
-import io.novafoundation.nova.common.utils.session
+import io.novafoundation.nova.common.utils.metadata
 import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.core.updater.GlobalScope
 import io.novafoundation.nova.core.updater.Updater
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
-import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.api.session
-import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.api.validators
+import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.api.collatorStaking
+import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.api.minStake
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.network.updaters.SingleStorageKeyUpdater
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
-import io.novasama.substrate_sdk_android.runtime.metadata.storage
-import io.novasama.substrate_sdk_android.runtime.metadata.storageKey
 
-class SessionValidatorsUpdater(
+class MythosMinStakeUpdater(
     stakingSharedState: StakingSharedState,
     chainRegistry: ChainRegistry,
     storageCache: StorageCache
@@ -22,7 +20,8 @@ class SessionValidatorsUpdater(
 
     override suspend fun storageKey(runtime: RuntimeSnapshot, scopeValue: Unit): String {
         return with(RuntimeContext(runtime)) {
-            runtime.metadata.session.validators.storageKey()
+            metadata.collatorStaking.minStake.storageKey()
         }
     }
 }
+

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/updaters/MythosMinStakeUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/updaters/MythosMinStakeUpdater.kt
@@ -24,4 +24,3 @@ class MythosMinStakeUpdater(
         }
     }
 }
-

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/api/SessionRuntimeApi.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/api/SessionRuntimeApi.kt
@@ -5,7 +5,6 @@ import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novafoundation.nova.common.utils.session
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.bindSessionIndex
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.bindSessionValidators
-import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.runtime.storage.source.query.api.QueryableModule
 import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry0
 import io.novafoundation.nova.runtime.storage.source.query.api.storage0

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/api/SessionRuntimeApi.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/api/SessionRuntimeApi.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_staking_impl.data.network.blockhain.api
 
 import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novafoundation.nova.common.utils.session
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.bindSessionIndex
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.bindSessionValidators
@@ -15,14 +16,14 @@ import java.math.BigInteger
 @JvmInline
 value class SessionRuntimeApi(override val module: Module) : QueryableModule
 
-context(StorageQueryContext)
+context(RuntimeContext)
 val RuntimeMetadata.session: SessionRuntimeApi
     get() = SessionRuntimeApi(session())
 
-context(StorageQueryContext)
+context(RuntimeContext)
 val SessionRuntimeApi.currentIndex: QueryableStorageEntry0<BigInteger>
     get() = storage0("CurrentIndex", binding = ::bindSessionIndex)
 
-context(StorageQueryContext)
+context(RuntimeContext)
 val SessionRuntimeApi.validators: QueryableStorageEntry0<List<AccountIdKey>>
     get() = storage0("Validators", binding = ::bindSessionValidators)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/session/SessionValidatorsUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/session/SessionValidatorsUpdater.kt
@@ -11,7 +11,6 @@ import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.api.va
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.network.updaters.SingleStorageKeyUpdater
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
-import io.novasama.substrate_sdk_android.runtime.metadata.storage
 import io.novasama.substrate_sdk_android.runtime.metadata.storageKey
 
 class SessionValidatorsUpdater(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/consensus/AuraSession.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/consensus/AuraSession.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.data.repository.consensus
 
 import io.novafoundation.nova.common.utils.committeeManagementOrNull
 import io.novafoundation.nova.common.utils.electionsOrNull
+import io.novafoundation.nova.common.utils.metadata
 import io.novafoundation.nova.common.utils.numberConstantOrNull
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
@@ -9,7 +10,6 @@ import io.novafoundation.nova.runtime.multiNetwork.getRuntime
 import io.novafoundation.nova.runtime.network.updaters.SharedAssetBlockNumberUpdater
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNull
-import io.novafoundation.nova.runtime.storage.source.query.metadata
 import io.novafoundation.nova.runtime.storage.typed.number
 import io.novafoundation.nova.runtime.storage.typed.system
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/consensus/ElectionsSessionRegistry.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/consensus/ElectionsSessionRegistry.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.feature_staking_impl.data.stakingType
 import io.novafoundation.nova.feature_staking_impl.data.unwrapNominationPools
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.ALEPH_ZERO
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.MYTHOS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 
@@ -25,7 +26,7 @@ class RealElectionsSessionRegistry(
     private fun electionsFor(stakingType: Chain.Asset.StakingType): ElectionsSession {
         return when (stakingType) {
             RELAYCHAIN -> babeSession
-            RELAYCHAIN_AURA, ALEPH_ZERO -> auraSession
+            RELAYCHAIN_AURA, ALEPH_ZERO, MYTHOS -> auraSession
             else -> throw IllegalArgumentException("Unsupported staking type in RealStakingSessionRegistry")
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureModule.kt
@@ -32,6 +32,7 @@ import io.novafoundation.nova.feature_staking_api.presentation.nominationPools.d
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.data.config.api.StakingGlobalConfigApi
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.StakingDashboardRepository
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosStakingRepository
 import io.novafoundation.nova.feature_staking_impl.data.network.subquery.StakingApi
 import io.novafoundation.nova.feature_staking_impl.data.network.subquery.SubQueryValidatorSetFetcher
 import io.novafoundation.nova.feature_staking_impl.data.nominationPools.network.blockhain.updater.RealPooledBalanceUpdaterFactory
@@ -80,6 +81,7 @@ import io.novafoundation.nova.feature_staking_impl.domain.alerts.AlertsInteracto
 import io.novafoundation.nova.feature_staking_impl.domain.common.EraTimeCalculatorFactory
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.era.StakingEraInteractorFactory
+import io.novafoundation.nova.feature_staking_impl.domain.mythos.common.MythosSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.nominationPools.common.validations.StakingTypesConflictValidationFactory
 import io.novafoundation.nova.feature_staking_impl.domain.payout.PayoutInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.period.RealStakingRewardPeriodInteractor
@@ -142,11 +144,15 @@ class StakingFeatureModule {
     fun provideStakingEraInteractorFactory(
         roundDurationEstimator: RoundDurationEstimator,
         stakingSharedComputation: StakingSharedComputation,
-        stakingConstantsRepository: StakingConstantsRepository
+        stakingConstantsRepository: StakingConstantsRepository,
+        mythosSharedComputation: MythosSharedComputation,
+        mythosStakingRepository: MythosStakingRepository,
     ) = StakingEraInteractorFactory(
         roundDurationEstimator = roundDurationEstimator,
         stakingSharedComputation = stakingSharedComputation,
-        stakingConstantsRepository = stakingConstantsRepository
+        stakingConstantsRepository = stakingConstantsRepository,
+        mythosSharedComputation = mythosSharedComputation,
+        mythosStakingRepository = mythosStakingRepository
     )
 
     @Provides

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/mythos/MythosBindsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/mythos/MythosBindsModule.kt
@@ -2,6 +2,8 @@ package io.novafoundation.nova.feature_staking_impl.di.staking.mythos
 
 import dagger.Binds
 import dagger.Module
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosStakingRepository
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.RealMythosStakingRepository
 import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.RealUserStakeRepository
 import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.UserStakeRepository
 import io.novafoundation.nova.feature_staking_impl.domain.mythos.common.MythosUserStakeUseCase
@@ -14,6 +16,9 @@ interface MythosBindsModule {
 
     @Binds
     fun bindUserStakeRepository(implementation: RealUserStakeRepository): UserStakeRepository
+
+    @Binds
+    fun bindStakingRepository(implementation: RealMythosStakingRepository): MythosStakingRepository
 
     @Binds
     fun bindUserStakeUseCase(implementation: RealMythosUserStakeUseCase): MythosUserStakeUseCase

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/mythos/MythosBindsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/mythos/MythosBindsModule.kt
@@ -2,7 +2,9 @@ package io.novafoundation.nova.feature_staking_impl.di.staking.mythos
 
 import dagger.Binds
 import dagger.Module
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosSessionRepository
 import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosStakingRepository
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.RealMythosSessionRepository
 import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.RealMythosStakingRepository
 import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.RealUserStakeRepository
 import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.UserStakeRepository
@@ -19,6 +21,9 @@ interface MythosBindsModule {
 
     @Binds
     fun bindStakingRepository(implementation: RealMythosStakingRepository): MythosStakingRepository
+
+    @Binds
+    fun bindSessionRepository(implementation: RealMythosSessionRepository): MythosSessionRepository
 
     @Binds
     fun bindUserStakeUseCase(implementation: RealMythosUserStakeUseCase): MythosUserStakeUseCase

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/mythos/MythosStakingUpdatersModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/mythos/MythosStakingUpdatersModule.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.data.mythos.updaters.MythosMinStakeUpdater
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.StakingUpdaters
+import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.session.CurrentSlotUpdater
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.session.SessionValidatorsUpdater
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 
@@ -43,11 +44,14 @@ class MythosStakingUpdatersModule {
     fun provideMythosStakingUpdaters(
         // UserStake in synced in-place in StakingDashboardMythosUpdater by dashboard
         sessionValidatorsUpdater: SessionValidatorsUpdater,
-        minStakeUpdater: MythosMinStakeUpdater
+        minStakeUpdater: MythosMinStakeUpdater,
+        // For syncing aura session info
+        currentSlotUpdater: CurrentSlotUpdater
     ): StakingUpdaters.Group {
         return StakingUpdaters.Group(
             sessionValidatorsUpdater,
-            minStakeUpdater
+            minStakeUpdater,
+            currentSlotUpdater
         )
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/mythos/MythosStakingUpdatersModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/mythos/MythosStakingUpdatersModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.mythos.updaters.MythosMinStakeUpdater
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.StakingUpdaters
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.session.SessionValidatorsUpdater
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
@@ -26,11 +27,27 @@ class MythosStakingUpdatersModule {
 
     @Provides
     @FeatureScope
+    fun provideMinStakeUpdater(
+        sharedState: StakingSharedState,
+        chainRegistry: ChainRegistry,
+        storageCache: StorageCache,
+    ) = MythosMinStakeUpdater(
+        sharedState,
+        chainRegistry,
+        storageCache
+    )
+
+    @Provides
+    @FeatureScope
     @Mythos
     fun provideMythosStakingUpdaters(
         // UserStake in synced in-place in StakingDashboardMythosUpdater by dashboard
-        sessionValidatorsUpdater: SessionValidatorsUpdater
+        sessionValidatorsUpdater: SessionValidatorsUpdater,
+        minStakeUpdater: MythosMinStakeUpdater
     ): StakingUpdaters.Group {
-        return StakingUpdaters.Group(sessionValidatorsUpdater)
+        return StakingUpdaters.Group(
+            sessionValidatorsUpdater,
+            minStakeUpdater
+        )
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/stakingTypeDetails/StakingTypeDetailsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/stakingTypeDetails/StakingTypeDetailsModule.kt
@@ -8,10 +8,12 @@ import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.era.StakingEraInteractorFactory
+import io.novafoundation.nova.feature_staking_impl.domain.mythos.common.MythosSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.nominationPools.common.NominationPoolSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.ParachainNetworkInfoInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.rewards.ParachainStakingRewardCalculatorFactory
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.NominationPoolsAvailableBalanceResolver
+import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.direct.MythosStakingTypeDetailsInteractorFactory
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.direct.ParachainStakingTypeDetailsInteractorFactory
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.direct.RelaychainStakingTypeDetailsInteractorFactory
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.direct.StakingTypeDetailsInteractorFactory
@@ -66,6 +68,14 @@ class StakingTypeDetailsModule {
 
     @Provides
     @FeatureScope
+    fun provideMythosStakingTypeDetailsInteractorFactory(
+        mythosSharedComputation: MythosSharedComputation,
+    ): MythosStakingTypeDetailsInteractorFactory {
+        return MythosStakingTypeDetailsInteractorFactory(mythosSharedComputation)
+    }
+
+    @Provides
+    @FeatureScope
     @IntoMap
     @StakingTypeDetailsKey(StakingTypeGroup.NOMINATION_POOL)
     fun provideAbstractPoolStakingTypeDetailsInteractorFactory(
@@ -90,6 +100,16 @@ class StakingTypeDetailsModule {
     @StakingTypeDetailsKey(StakingTypeGroup.PARACHAIN)
     fun provideAbstractParachainStakingTypeDetailsInteractorFactory(
         stakingTypeDetailsInteractorFactory: ParachainStakingTypeDetailsInteractorFactory
+    ): StakingTypeDetailsInteractorFactory {
+        return stakingTypeDetailsInteractorFactory
+    }
+
+    @Provides
+    @FeatureScope
+    @IntoMap
+    @StakingTypeDetailsKey(StakingTypeGroup.MYTHOS)
+    fun provideAbstractMythosStakingTypeDetailsInteractorFactory(
+        stakingTypeDetailsInteractorFactory: MythosStakingTypeDetailsInteractorFactory
     ): StakingTypeDetailsInteractorFactory {
         return stakingTypeDetailsInteractorFactory
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/EraCalculatorDiffing.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/EraCalculatorDiffing.kt
@@ -1,0 +1,37 @@
+package io.novafoundation.nova.feature_staking_impl.domain.common
+
+import android.util.Log
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+interface EraRewardCalculatorComparable {
+
+    /**
+     * Returns a number that can be used to compare different instances of [EraTimeCalculator]
+     * to determine how much their calculations would deffer between each other
+     * This wont correspond to real timestamp and shouldn't be used as such
+     */
+    fun derivedTimestamp(): Duration
+}
+
+fun <T : EraRewardCalculatorComparable> Flow<T>.ignoreInsignificantTimeChanges(): Flow<T> {
+    return distinctUntilChanged { old, new -> new.canBeIgnoredAfter(old) }
+
+}
+
+private fun EraRewardCalculatorComparable.canBeIgnoredAfter(previous: EraRewardCalculatorComparable): Boolean {
+    val previousTimestamp = previous.derivedTimestamp()
+    val newTimestamp = derivedTimestamp()
+
+    val difference = (newTimestamp - previousTimestamp).absoluteValue
+
+    val canIgnore = difference < ERA_DURATION_DIFFERENCE_THRESHOLD
+
+    Log.d("EraRewardCalculatorComparable", "New update for EraRewardCalculatorComparable, difference: $difference can ignore: $canIgnore")
+
+    return canIgnore
+}
+
+private val ERA_DURATION_DIFFERENCE_THRESHOLD = 10.minutes

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/EraCalculatorDiffing.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/EraCalculatorDiffing.kt
@@ -18,7 +18,6 @@ interface EraRewardCalculatorComparable {
 
 fun <T : EraRewardCalculatorComparable> Flow<T>.ignoreInsignificantTimeChanges(): Flow<T> {
     return distinctUntilChanged { old, new -> new.canBeIgnoredAfter(old) }
-
 }
 
 private fun EraRewardCalculatorComparable.canBeIgnoredAfter(previous: EraRewardCalculatorComparable): Boolean {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/EraCalculatorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/common/EraCalculatorFactory.kt
@@ -1,6 +1,5 @@
 package io.novafoundation.nova.feature_staking_impl.domain.common
 
-import android.util.Log
 import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
 import io.novafoundation.nova.common.utils.toDuration
 import io.novafoundation.nova.feature_staking_api.domain.api.StakingRepository
@@ -11,11 +10,9 @@ import io.novafoundation.nova.feature_staking_impl.data.repository.consensus.Ele
 import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import java.math.BigInteger
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
 
 class EraTimeCalculator(
     private val startTimeStamp: BigInteger,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/MythosStakingEraInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/MythosStakingEraInteractor.kt
@@ -1,24 +1,41 @@
 package io.novafoundation.nova.feature_staking_impl.domain.era
 
 import io.novafoundation.nova.common.data.memory.ComputationalScope
+import io.novafoundation.nova.common.utils.flowOfAll
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
+import io.novafoundation.nova.feature_staking_impl.data.chain
+import io.novafoundation.nova.feature_staking_impl.data.mythos.duration.MythosSessionDurationCalculator
+import io.novafoundation.nova.feature_staking_impl.data.mythos.duration.sessionsDuration
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosStakingRepository
+import io.novafoundation.nova.feature_staking_impl.domain.mythos.common.MythosSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.landing.model.StartStakingEraInfo
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlin.time.Duration
 
 class MythosStakingEraInteractor(
+    private val mythosSharedComputation: MythosSharedComputation,
+    private val mythosStakingRepository: MythosStakingRepository,
     private val stakingOption: StakingOption,
     private val computationalScope: ComputationalScope
-): StakingEraInteractor {
+) : StakingEraInteractor, ComputationalScope by computationalScope {
 
     override fun observeEraInfo(): Flow<StartStakingEraInfo> {
-       return flowOf(
-           StartStakingEraInfo(
-               unstakeTime = Duration.ZERO,
-               eraDuration = Duration.ZERO,
-               firstRewardReceivingDuration = Duration.ZERO
-           )
-       )
+        return flowOfAll {
+            val chainId = stakingOption.chain.id
+            val unstakingSessions = mythosStakingRepository.unstakeDurationInSessions(chainId)
+
+            mythosSharedComputation.eraDurationCalculatorFlow(stakingOption).map { sessionDurationCalculator ->
+                StartStakingEraInfo(
+                    unstakeTime = sessionDurationCalculator.sessionsDuration(unstakingSessions),
+                    eraDuration = sessionDurationCalculator.sessionDuration(),
+                    firstRewardReceivingDuration = sessionDurationCalculator.firstRewardDelay()
+                )
+            }
+        }
+    }
+
+    private fun MythosSessionDurationCalculator.firstRewardDelay(): Duration {
+        return remainingSessionDuration() + sessionDuration()
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/MythosStakingEraInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/MythosStakingEraInteractor.kt
@@ -1,0 +1,24 @@
+package io.novafoundation.nova.feature_staking_impl.domain.era
+
+import io.novafoundation.nova.common.data.memory.ComputationalScope
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
+import io.novafoundation.nova.feature_staking_impl.domain.staking.start.landing.model.StartStakingEraInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlin.time.Duration
+
+class MythosStakingEraInteractor(
+    private val stakingOption: StakingOption,
+    private val computationalScope: ComputationalScope
+): StakingEraInteractor {
+
+    override fun observeEraInfo(): Flow<StartStakingEraInfo> {
+       return flowOf(
+           StartStakingEraInfo(
+               unstakeTime = Duration.ZERO,
+               eraDuration = Duration.ZERO,
+               firstRewardReceivingDuration = Duration.ZERO
+           )
+       )
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/StakingEraInteractorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/StakingEraInteractorFactory.kt
@@ -3,9 +3,11 @@ package io.novafoundation.nova.feature_staking_impl.domain.era
 import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.createStakingOption
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosStakingRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.RoundDurationEstimator
 import io.novafoundation.nova.feature_staking_impl.data.repository.StakingConstantsRepository
 import io.novafoundation.nova.feature_staking_impl.domain.common.StakingSharedComputation
+import io.novafoundation.nova.feature_staking_impl.domain.mythos.common.MythosSharedComputation
 import io.novafoundation.nova.runtime.ext.StakingTypeGroup
 import io.novafoundation.nova.runtime.ext.group
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -15,7 +17,9 @@ import kotlinx.coroutines.CoroutineScope
 class StakingEraInteractorFactory(
     private val roundDurationEstimator: RoundDurationEstimator,
     private val stakingSharedComputation: StakingSharedComputation,
-    private val stakingConstantsRepository: StakingConstantsRepository
+    private val stakingConstantsRepository: StakingConstantsRepository,
+    private val mythosSharedComputation: MythosSharedComputation,
+    private val mythosStakingRepository: MythosStakingRepository,
 ) {
 
     private val creators = mapOf(
@@ -54,6 +58,6 @@ class StakingEraInteractorFactory(
     }
 
     private fun createMythos(stakingOption: StakingOption, computationScope: ComputationalScope): StakingEraInteractor {
-        return MythosStakingEraInteractor(stakingOption, computationScope)
+        return MythosStakingEraInteractor(mythosSharedComputation, mythosStakingRepository, stakingOption, computationScope)
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/mythos/common/MythosSharedComputation.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/mythos/common/MythosSharedComputation.kt
@@ -5,8 +5,10 @@ import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.common.data.memory.SharedComputation
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.model.UserStakeInfo
+import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosStakingRepository
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.SessionValidators
 import io.novafoundation.nova.feature_staking_impl.data.repository.SessionRepository
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import kotlinx.coroutines.flow.Flow
@@ -15,9 +17,17 @@ import javax.inject.Inject
 @FeatureScope
 class MythosSharedComputation @Inject constructor(
     private val userStakeRepository: MythosUserStakeUseCase,
+    private val mythosStakingRepository: MythosStakingRepository,
     private val sessionRepository: SessionRepository,
     computationalCache: ComputationalCache
 ) : SharedComputation(computationalCache) {
+
+    context(ComputationalScope)
+    fun minStakeFlow(chainId: ChainId): Flow<Balance> {
+        return cachedFlow("MythosSharedComputation.minStakeFlow", chainId) {
+            mythosStakingRepository.minStakeFlow(chainId)
+        }
+    }
 
     context(ComputationalScope)
     fun userStakeFlow(chain: Chain): Flow<UserStakeInfo> {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/mythos/common/MythosSharedComputation.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/mythos/common/MythosSharedComputation.kt
@@ -4,6 +4,10 @@ import io.novafoundation.nova.common.data.memory.ComputationalCache
 import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.common.data.memory.SharedComputation
 import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.feature_staking_impl.data.StakingOption
+import io.novafoundation.nova.feature_staking_impl.data.chain
+import io.novafoundation.nova.feature_staking_impl.data.mythos.duration.MythosSessionDurationCalculator
+import io.novafoundation.nova.feature_staking_impl.data.mythos.duration.MythosSessionDurationCalculatorFactory
 import io.novafoundation.nova.feature_staking_impl.data.mythos.network.blockchain.model.UserStakeInfo
 import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosStakingRepository
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.bindings.SessionValidators
@@ -19,8 +23,16 @@ class MythosSharedComputation @Inject constructor(
     private val userStakeRepository: MythosUserStakeUseCase,
     private val mythosStakingRepository: MythosStakingRepository,
     private val sessionRepository: SessionRepository,
+    private val mythosSessionDurationCalculatorFactory: MythosSessionDurationCalculatorFactory,
     computationalCache: ComputationalCache
 ) : SharedComputation(computationalCache) {
+
+    context(ComputationalScope)
+    fun eraDurationCalculatorFlow(stakingOption: StakingOption): Flow<MythosSessionDurationCalculator> {
+        return cachedFlow("MythosSharedComputation.eraDurationCalculatorFlow", stakingOption.chain.id) {
+            mythosSessionDurationCalculatorFactory.create(stakingOption)
+        }
+    }
 
     context(ComputationalScope)
     fun minStakeFlow(chainId: ChainId): Flow<Balance> {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/common/rewards/NominationPoolRewardCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/common/rewards/NominationPoolRewardCalculator.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.nominationPools.common.rewards
 
 import io.novafoundation.nova.common.utils.Fraction
-import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.feature_staking_api.domain.nominationPool.model.PoolId
 
 interface NominationPoolRewardCalculator {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/common/rewards/NominationPoolRewardCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/common/rewards/NominationPoolRewardCalculator.kt
@@ -1,11 +1,12 @@
 package io.novafoundation.nova.feature_staking_impl.domain.nominationPools.common.rewards
 
+import io.novafoundation.nova.common.utils.Fraction
 import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.feature_staking_api.domain.nominationPool.model.PoolId
 
 interface NominationPoolRewardCalculator {
 
-    val maxAPY: Perbill
+    val maxAPY: Fraction
 
-    fun apyFor(poolId: PoolId): Perbill?
+    fun apyFor(poolId: PoolId): Fraction?
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/common/rewards/RealNominationPoolRewardCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/common/rewards/RealNominationPoolRewardCalculator.kt
@@ -5,7 +5,6 @@ import io.novafoundation.nova.common.address.intoKey
 import io.novafoundation.nova.common.utils.Fraction
 import io.novafoundation.nova.common.utils.Fraction.Companion.fractions
 import io.novafoundation.nova.common.utils.Perbill
-import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.common.utils.mapValuesNotNull
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.utils.reversed

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/common/rewards/RealNominationPoolRewardCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/common/rewards/RealNominationPoolRewardCalculator.kt
@@ -2,6 +2,8 @@ package io.novafoundation.nova.feature_staking_impl.domain.nominationPools.commo
 
 import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.address.intoKey
+import io.novafoundation.nova.common.utils.Fraction
+import io.novafoundation.nova.common.utils.Fraction.Companion.fractions
 import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.common.utils.mapValuesNotNull
@@ -53,18 +55,18 @@ private class RealNominationPoolRewardCalculator(
 
     private val poolIdsByStashes: AccountIdKeyMap<PoolId> = poolStashesById.reversed()
 
-    private val apyByPoolStash: Map<PoolId, Perbill> = constructPoolsApy()
+    private val apyByPoolStash: Map<PoolId, Fraction> = constructPoolsApy()
 
-    override val maxAPY: Perbill = apyByPoolStash
+    override val maxAPY: Fraction = apyByPoolStash
         .values
         .maxOrNull()
         .orZero()
 
-    override fun apyFor(poolId: PoolId): Perbill? {
+    override fun apyFor(poolId: PoolId): Fraction? {
         return apyByPoolStash[poolId]
     }
 
-    private fun constructPoolsApy(): Map<PoolId, Perbill> {
+    private fun constructPoolsApy(): Map<PoolId, Fraction> {
         val activeValidatorsByPoolStash = exposures.findPoolsValidators(poolIdsByStashes.keys)
 
         return activeValidatorsByPoolStash.mapValuesNotNull { (poolStash, nominators) ->
@@ -72,7 +74,7 @@ private class RealNominationPoolRewardCalculator(
         }
     }
 
-    private fun calculatePoolApy(poolId: PoolId, poolValidatorsIdsHex: List<String>): Perbill? {
+    private fun calculatePoolApy(poolId: PoolId, poolValidatorsIdsHex: List<String>): Fraction? {
         if (poolValidatorsIdsHex.isEmpty()) return null
 
         val commission = commissions[poolId]?.value.orZero()
@@ -83,7 +85,7 @@ private class RealNominationPoolRewardCalculator(
 
         val apy = maxApyAcrossValidators * (1.0 - commission)
 
-        return apy.asPerbill()
+        return apy.fractions
     }
 
     private fun AccountIdMap<Exposure>.findPoolsValidators(poolStashes: Set<AccountIdKey>): Map<PoolId, List<String>> {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/model/NominationPool.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/model/NominationPool.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.nominationPools.model
 
 import io.novafoundation.nova.common.utils.Fraction
-import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.common.utils.images.Icon
 import io.novafoundation.nova.feature_staking_api.domain.nominationPool.model.PoolId
 import io.novafoundation.nova.feature_staking_impl.data.nominationPools.network.blockhain.models.PoolMetadata

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/model/NominationPool.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/nominationPools/model/NominationPool.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.nominationPools.model
 
+import io.novafoundation.nova.common.utils.Fraction
 import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.common.utils.images.Icon
 import io.novafoundation.nova.feature_staking_api.domain.nominationPool.model.PoolId
@@ -21,13 +22,13 @@ class NominationPool(
 
     sealed class Status {
 
-        class Active(val apy: Perbill) : Status()
+        class Active(val apy: Fraction) : Status()
 
         object Inactive : Status()
     }
 }
 
-val NominationPool.apy: Perbill?
+val NominationPool.apy: Fraction?
     get() = when (status) {
         is NominationPool.Status.Active -> status.apy
         NominationPool.Status.Inactive -> null

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/selection/StartMultiStakingSelection.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/selection/StartMultiStakingSelection.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.selection
 
 import io.novafoundation.nova.common.utils.Fraction
-import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.asset

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/selection/StartMultiStakingSelection.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/selection/StartMultiStakingSelection.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.selection
 
+import io.novafoundation.nova.common.utils.Fraction
 import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
@@ -14,7 +15,7 @@ interface StartMultiStakingSelection {
 
     val stakingOption: StakingOption
 
-    val apy: Perbill?
+    val apy: Fraction?
 
     val stake: Balance
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/CompoundStakingTypeDetailsProvider.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/CompoundStakingTypeDetailsProvider.kt
@@ -3,7 +3,6 @@ package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.
 import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.common.utils.combine
 import io.novafoundation.nova.feature_staking_impl.data.createStakingOption
-import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupAmount.SingleStakingRecommendation
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.direct.EditingStakingTypePayload
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.direct.EditingStakingTypeValidationSystem
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.model.ValidatedStakingTypeDetails
@@ -11,7 +10,6 @@ import io.novafoundation.nova.runtime.ext.StakingTypeGroup
 import io.novafoundation.nova.runtime.ext.group
 import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 class CompoundStakingTypeDetailsProvidersFactory(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/CompoundStakingTypeDetailsProvider.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/CompoundStakingTypeDetailsProvider.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types
 
+import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.common.utils.combine
 import io.novafoundation.nova.feature_staking_impl.data.createStakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupAmount.SingleStakingRecommendation
@@ -18,13 +19,13 @@ class CompoundStakingTypeDetailsProvidersFactory(
 ) {
 
     suspend fun create(
-        coroutineScope: CoroutineScope,
+        computationalScope: ComputationalScope,
         chainWithAsset: ChainWithAsset,
         availableStakingTypes: List<Chain.Asset.StakingType>
     ): CompoundStakingTypeDetailsProviders {
         val providers = chainWithAsset.asset.staking.mapNotNull { stakingType ->
             val supportedFactory = factories[stakingType.group()]
-            supportedFactory?.create(createStakingOption(chainWithAsset, stakingType), coroutineScope, availableStakingTypes)
+            supportedFactory?.create(createStakingOption(chainWithAsset, stakingType), computationalScope, availableStakingTypes)
         }
 
         return CompoundStakingTypeDetailsProviders(providers)
@@ -36,11 +37,6 @@ class CompoundStakingTypeDetailsProviders(private val providers: List<StakingTyp
     fun getStakingTypeDetails(): Flow<List<ValidatedStakingTypeDetails>> {
         return providers.map { it.stakingTypeDetails }
             .combine()
-    }
-
-    fun getRecommendationProvider(stakingType: Chain.Asset.StakingType): SingleStakingRecommendation {
-        return providers.first { it.stakingType == stakingType }
-            .recommendationProvider
     }
 
     fun getValidationSystem(stakingType: Chain.Asset.StakingType): EditingStakingTypeValidationSystem {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/StakingTypeDetails.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/StakingTypeDetails.kt
@@ -1,12 +1,13 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types
 
+import io.novafoundation.nova.common.utils.Fraction
 import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.feature_staking_impl.domain.model.PayoutType
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigInteger
 
 class StakingTypeDetails(
-    val maxEarningRate: Perbill,
+    val maxEarningRate: Fraction,
     val minStake: BigInteger,
     val payoutType: PayoutType,
     val participationInGovernance: Boolean,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/StakingTypeDetails.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/StakingTypeDetails.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types
 
 import io.novafoundation.nova.common.utils.Fraction
-import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.feature_staking_impl.domain.model.PayoutType
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigInteger

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/StakingTypeDetailsProvider.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/StakingTypeDetailsProvider.kt
@@ -1,19 +1,19 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types
 
+import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupAmount.SingleStakingRecommendation
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.direct.EditingStakingTypePayload
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.direct.EditingStakingTypeValidationSystem
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.model.ValidatedStakingTypeDetails
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface StakingTypeDetailsProviderFactory {
 
     suspend fun create(
         stakingOption: StakingOption,
-        coroutineScope: CoroutineScope,
+        computationalScope: ComputationalScope,
         availableStakingTypes: List<Chain.Asset.StakingType>
     ): StakingTypeDetailsProvider
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/MythosStakingTypeDetailsInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/MythosStakingTypeDetailsInteractor.kt
@@ -7,15 +7,12 @@ import io.novafoundation.nova.feature_staking_impl.data.chain
 import io.novafoundation.nova.feature_staking_impl.data.stakingType
 import io.novafoundation.nova.feature_staking_impl.domain.model.PayoutType
 import io.novafoundation.nova.feature_staking_impl.domain.mythos.common.MythosSharedComputation
-import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.main.ParachainNetworkInfoInteractor
-import io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.rewards.ParachainStakingRewardCalculatorFactory
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.StakingTypeDetails
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.StakingTypeDetailsInteractor
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.math.BigInteger
-import kotlinx.coroutines.CoroutineScope
 
 class MythosStakingTypeDetailsInteractorFactory(
     private val mythosSharedComputation: MythosSharedComputation,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/ParachainStakingTypeDetailsInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/ParachainStakingTypeDetailsInteractor.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.
 
 import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.common.utils.Fraction.Companion.fractions
-import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.chain
 import io.novafoundation.nova.feature_staking_impl.data.stakingType
@@ -17,7 +16,6 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.math.BigInteger
-import kotlinx.coroutines.CoroutineScope
 
 class ParachainStakingTypeDetailsInteractorFactory(
     private val parachainNetworkInfoInteractor: ParachainNetworkInfoInteractor,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/ParachainStakingTypeDetailsInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/ParachainStakingTypeDetailsInteractor.kt
@@ -1,5 +1,7 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.direct
 
+import io.novafoundation.nova.common.data.memory.ComputationalScope
+import io.novafoundation.nova.common.utils.Fraction.Companion.fractions
 import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.chain
@@ -24,7 +26,7 @@ class ParachainStakingTypeDetailsInteractorFactory(
 
     override suspend fun create(
         stakingOption: StakingOption,
-        coroutineScope: CoroutineScope
+        computationalScope: ComputationalScope
     ): ParachainStakingTypeDetailsInteractor {
         return ParachainStakingTypeDetailsInteractor(
             parachainNetworkInfoInteractor,
@@ -45,9 +47,9 @@ class ParachainStakingTypeDetailsInteractor(
 
         return parachainNetworkInfoInteractor.observeRoundInfo(chain.id).map { activeEraInfo ->
             StakingTypeDetails(
-                maxEarningRate = parachainStakingRewardCalculator.maximumGain(DAYS_IN_YEAR).asPerbill(),
+                maxEarningRate = parachainStakingRewardCalculator.maximumGain(DAYS_IN_YEAR).fractions,
                 minStake = activeEraInfo.minimumStake,
-                payoutType = getPayoutType(),
+                payoutType = PayoutType.Automatically.Payout,
                 participationInGovernance = chain.governance.isNotEmpty(),
                 advancedOptionsAvailable = true,
                 stakingType = stakingOption.stakingType
@@ -57,9 +59,5 @@ class ParachainStakingTypeDetailsInteractor(
 
     override suspend fun getAvailableBalance(asset: Asset): BigInteger {
         return asset.freeInPlanks
-    }
-
-    private fun getPayoutType(): PayoutType {
-        return PayoutType.Automatically.Payout
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/StakingTypeDetailsInteractorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/StakingTypeDetailsInteractorFactory.kt
@@ -3,7 +3,6 @@ package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.
 import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.StakingTypeDetailsInteractor
-import kotlinx.coroutines.CoroutineScope
 
 interface StakingTypeDetailsInteractorFactory {
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/StakingTypeDetailsInteractorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/direct/StakingTypeDetailsInteractorFactory.kt
@@ -1,10 +1,11 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.direct
 
+import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.StakingTypeDetailsInteractor
 import kotlinx.coroutines.CoroutineScope
 
 interface StakingTypeDetailsInteractorFactory {
 
-    suspend fun create(stakingOption: StakingOption, coroutineScope: CoroutineScope): StakingTypeDetailsInteractor
+    suspend fun create(stakingOption: StakingOption, computationalScope: ComputationalScope): StakingTypeDetailsInteractor
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/pools/PoolStakingTypeDetailsInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/pools/PoolStakingTypeDetailsInteractor.kt
@@ -12,7 +12,6 @@ import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.t
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.StakingTypeDetailsInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.direct.StakingTypeDetailsInteractorFactory
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import java.math.BigInteger
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/pools/PoolStakingTypeDetailsInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/common/types/pools/PoolStakingTypeDetailsInteractor.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.pools
 
+import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.common.utils.flowOf
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.chain
@@ -22,13 +23,13 @@ class PoolStakingTypeDetailsInteractorFactory(
 
     override suspend fun create(
         stakingOption: StakingOption,
-        coroutineScope: CoroutineScope
+        computationalScope: ComputationalScope
     ): PoolStakingTypeDetailsInteractor {
         return PoolStakingTypeDetailsInteractor(
             nominationPoolSharedComputation,
             poolsAvailableBalanceResolver,
             stakingOption,
-            coroutineScope
+            computationalScope
         )
     }
 }
@@ -37,7 +38,7 @@ class PoolStakingTypeDetailsInteractor(
     private val nominationPoolSharedComputation: NominationPoolSharedComputation,
     private val poolsAvailableBalanceResolver: NominationPoolsAvailableBalanceResolver,
     private val stakingOption: StakingOption,
-    private val scope: CoroutineScope,
+    private val scope: ComputationalScope,
 ) : StakingTypeDetailsInteractor {
 
     override fun observeData(): Flow<StakingTypeDetails> {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/landing/RealStakingTypeDetailsCompoundInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/landing/RealStakingTypeDetailsCompoundInteractor.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.landing
 
 import io.novafoundation.nova.common.utils.Fraction
-import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.validation.ValidationSystem
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/landing/RealStakingTypeDetailsCompoundInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/landing/RealStakingTypeDetailsCompoundInteractor.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.landing
 
+import io.novafoundation.nova.common.utils.Fraction
 import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.validation.ValidationSystem
@@ -35,7 +36,7 @@ class Payouts(
 class StartStakingCompoundData(
     val chain: Chain,
     val asset: Asset,
-    val maxEarningRate: Perbill,
+    val maxEarningRate: Fraction,
     val minStake: BigInteger,
     val eraInfo: StartStakingEraInfo,
     val participationInGovernance: ParticipationInGovernance,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/landing/StakingTypeDetailsCompoundInteractorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/landing/StakingTypeDetailsCompoundInteractorFactory.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.landing
 
+import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.MultiStakingOptionIds
 import io.novafoundation.nova.feature_staking_impl.data.createStakingOption
@@ -24,11 +25,11 @@ class StakingTypeDetailsCompoundInteractorFactory(
 
     suspend fun create(
         multiStakingOptionIds: MultiStakingOptionIds,
-        coroutineScope: CoroutineScope
+        computationalScope: ComputationalScope
     ): StakingTypeDetailsCompoundInteractor {
         val (chain, chainAsset) = chainRegistry.chainWithAsset(multiStakingOptionIds.chainId, multiStakingOptionIds.chainAssetId)
-        val interactors = createInteractors(chain, chainAsset, multiStakingOptionIds.stakingTypes, coroutineScope)
-        val stakingEraInteractor = stakingEraInteractorFactory.create(chain, chainAsset, coroutineScope)
+        val interactors = createInteractors(chain, chainAsset, multiStakingOptionIds.stakingTypes, computationalScope)
+        val stakingEraInteractor = stakingEraInteractorFactory.create(chain, chainAsset, computationalScope)
 
         return RealStakingTypeDetailsCompoundInteractor(
             chain = chain,
@@ -44,13 +45,13 @@ class StakingTypeDetailsCompoundInteractorFactory(
         chain: Chain,
         asset: Chain.Asset,
         stakingTypes: List<Chain.Asset.StakingType>,
-        coroutineScope: CoroutineScope
+        computationalScope: ComputationalScope
     ): List<StakingTypeDetailsInteractor> {
         return stakingTypes.mapNotNull { stakingType ->
             val stakingOption = createStakingOption(chain, asset, stakingType)
 
             val supportedInteractorFactory = stakingTypeDetailsInteractorFactories[stakingType.group()]
-            supportedInteractorFactory?.create(stakingOption, coroutineScope)
+            supportedInteractorFactory?.create(stakingOption, computationalScope)
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/landing/StakingTypeDetailsCompoundInteractorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/landing/StakingTypeDetailsCompoundInteractorFactory.kt
@@ -13,7 +13,6 @@ import io.novafoundation.nova.runtime.ext.group
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chainWithAsset
-import kotlinx.coroutines.CoroutineScope
 
 class StakingTypeDetailsCompoundInteractorFactory(
     private val walletRepository: WalletRepository,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/direct/DirectStakingSelection.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/direct/DirectStakingSelection.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupAmount.direct
 
 import io.novafoundation.nova.common.utils.Fraction.Companion.fractions
-import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
 import io.novafoundation.nova.feature_staking_api.domain.model.RewardDestination

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/direct/DirectStakingSelection.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupAmount/direct/DirectStakingSelection.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupAmount.direct
 
+import io.novafoundation.nova.common.utils.Fraction.Companion.fractions
 import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
@@ -22,7 +23,7 @@ data class DirectStakingSelection(
     override val stake: Balance,
 ) : StartMultiStakingSelection {
 
-    override val apy = validators.mapNotNull { it.electedInfo?.apy?.asPerbill() }
+    override val apy = validators.mapNotNull { it.electedInfo?.apy?.fractions }
         .maxOrNull()
 
     override fun ExtrinsicBuilder.startStaking(metaAccount: MetaAccount) {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupStakingType/pool/RealStakingTypeDetailsProvider.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/staking/start/setupStakingType/pool/RealStakingTypeDetailsProvider.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.pool
 
+import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.common.validation.ValidationSystem
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
@@ -30,18 +31,19 @@ class RealStakingTypeDetailsProviderFactory(
 
     override suspend fun create(
         stakingOption: StakingOption,
-        coroutineScope: CoroutineScope,
+        computationalScope: ComputationalScope,
         availableStakingTypes: List<Chain.Asset.StakingType>
     ): StakingTypeDetailsProvider {
-        val singleStakingProperties = singleStakingPropertiesFactory.createProperties(coroutineScope, stakingOption)
+        val singleStakingProperties = singleStakingPropertiesFactory.createProperties(computationalScope, stakingOption)
         val validationSystem = ValidationSystem.editingStakingType(availableStakingTypes)
+
         return RealStakingTypeDetailsProvider(
             validationSystem,
-            poolStakingTypeDetailsInteractorFactory.create(stakingOption, coroutineScope),
+            poolStakingTypeDetailsInteractorFactory.create(stakingOption, computationalScope),
             stakingOption.stakingType,
             singleStakingProperties,
             currentSelectionStoreProvider,
-            coroutineScope
+            computationalScope
         )
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/mappers/Pool.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/mappers/Pool.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.mappers
 
 import io.novafoundation.nova.common.resources.ResourceManager
-import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.common.utils.colorSpan
 import io.novafoundation.nova.common.utils.formatAsSpannable
 import io.novafoundation.nova.common.utils.formatting.format

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/mappers/Pool.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/mappers/Pool.kt
@@ -5,6 +5,8 @@ import io.novafoundation.nova.common.utils.asPerbill
 import io.novafoundation.nova.common.utils.colorSpan
 import io.novafoundation.nova.common.utils.formatAsSpannable
 import io.novafoundation.nova.common.utils.formatting.format
+import io.novafoundation.nova.common.utils.formatting.formatPercents
+import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.utils.toSpannable
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.domain.nominationPools.model.NominationPool
@@ -35,8 +37,8 @@ private fun getSubtitle(
     resourceManager: ResourceManager,
 ): CharSequence {
     val apyColor = resourceManager.getColor(R.color.text_positive)
-    val apy = pool.apy ?: 0.0.asPerbill()
-    val apyString = apy.format().toSpannable(colorSpan(apyColor))
+    val apy = pool.apy.orZero()
+    val apyString = apy.formatPercents().toSpannable(colorSpan(apyColor))
     return resourceManager.getString(R.string.common_per_year_format)
         .formatAsSpannable(apyString)
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
@@ -31,6 +31,7 @@ import io.novafoundation.nova.common.utils.formatting.duration.DayDurationFormat
 import io.novafoundation.nova.common.utils.formatting.duration.DayDurationShortcut
 import io.novafoundation.nova.common.utils.formatting.duration.DurationFormatter
 import io.novafoundation.nova.common.utils.formatting.duration.HoursDurationFormatter
+import io.novafoundation.nova.common.utils.formatting.duration.MinutesDurationFormatter
 import io.novafoundation.nova.common.utils.formatting.duration.ShortcutDurationFormatter
 import io.novafoundation.nova.common.utils.formatting.duration.wrapInto
 import io.novafoundation.nova.common.utils.formatting.format
@@ -445,11 +446,10 @@ class StartStakingLandingViewModel(
                 shortcuts = listOf(durationShortcut),
                 nestedFormatter = createDayDurationFormatter()
             ),
-            hoursDurationFormatter = ShortcutDurationFormatter(
-                shortcuts = listOf(durationShortcut),
-                nestedFormatter = HoursDurationFormatter(context)
-                    .wrapInto(context, R.string.start_staking_fragment_reward_frequency_condition_duration)
-            )
+            hoursDurationFormatter = HoursDurationFormatter(context)
+                .wrapInto(context, R.string.start_staking_fragment_reward_frequency_condition_duration),
+            minutesDurationFormatter = MinutesDurationFormatter(context)
+                .wrapInto(context, R.string.start_staking_fragment_reward_frequency_condition_duration)
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
@@ -16,6 +16,7 @@ import io.novafoundation.nova.common.mixin.api.Validatable
 import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
+import io.novafoundation.nova.common.utils.Fraction
 import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.common.utils.clickableSpan
 import io.novafoundation.nova.common.utils.colorSpan
@@ -33,6 +34,7 @@ import io.novafoundation.nova.common.utils.formatting.duration.HoursDurationForm
 import io.novafoundation.nova.common.utils.formatting.duration.ShortcutDurationFormatter
 import io.novafoundation.nova.common.utils.formatting.duration.wrapInto
 import io.novafoundation.nova.common.utils.formatting.format
+import io.novafoundation.nova.common.utils.formatting.formatPercents
 import io.novafoundation.nova.common.utils.formatting.spannable.SpannableFormatter
 import io.novafoundation.nova.common.utils.setEndSpan
 import io.novafoundation.nova.common.utils.setFullSpan
@@ -113,7 +115,7 @@ class StartStakingLandingViewModel(
     private val startStakingInteractor = flowOf {
         stakingTypeDetailsCompoundInteractorFactory.create(
             multiStakingOptionIds = stakingOptionIds,
-            coroutineScope = this
+            computationalScope = this
         )
     }.shareInBackground()
 
@@ -228,10 +230,10 @@ class StartStakingLandingViewModel(
         }
     }
 
-    private fun createTitle(chainAsset: Chain.Asset, earning: Perbill, themeColor: Int): CharSequence {
+    private fun createTitle(chainAsset: Chain.Asset, earning: Fraction, themeColor: Int): CharSequence {
         val apy = resourceManager.getString(
             R.string.start_staking_fragment_title_APY,
-            earning.format()
+            earning.formatPercents()
         ).toSpannable(colorSpan(themeColor))
 
         return SpannableFormatter.format(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
@@ -17,7 +17,6 @@ import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.Fraction
-import io.novafoundation.nova.common.utils.Perbill
 import io.novafoundation.nova.common.utils.clickableSpan
 import io.novafoundation.nova.common.utils.colorSpan
 import io.novafoundation.nova.common.utils.drawableSpan

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupAmount/SetupAmountMultiStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupAmount/SetupAmountMultiStakingViewModel.kt
@@ -6,7 +6,6 @@ import io.novafoundation.nova.common.mixin.api.Validatable
 import io.novafoundation.nova.common.presentation.DescriptiveButtonState
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.combineToPair
-import io.novafoundation.nova.common.utils.formatting.format
 import io.novafoundation.nova.common.utils.formatting.formatPercents
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.validation.ValidationExecutor

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupAmount/SetupAmountMultiStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupAmount/SetupAmountMultiStakingViewModel.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.common.presentation.DescriptiveButtonState
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.combineToPair
 import io.novafoundation.nova.common.utils.formatting.format
+import io.novafoundation.nova.common.utils.formatting.formatPercents
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.validation.ValidationExecutor
 import io.novafoundation.nova.common.validation.progressConsumer
@@ -108,7 +109,7 @@ class SetupAmountMultiStakingViewModel(
             currentSelection == null -> StakingPropertiesModel.Loading
             else -> {
                 val content = StakingPropertiesModel.Content(
-                    estimatedReward = currentSelection.selection.apy.orZero().format(),
+                    estimatedReward = currentSelection.selection.apy.orZero().formatPercents(),
                     selection = multiStakingTargetSelectionFormatter.formatForSetupAmount(currentSelection)
                 )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeViewModel.kt
@@ -68,9 +68,9 @@ class SetupStakingTypeViewModel(
 
     private val compoundStakingTypeDetailsProviderFlow = chainWithAssetFlow.map {
         compoundStakingTypeDetailsProvidersFactory.create(
-            viewModelScope,
-            it,
-            payload.availableStakingOptions.stakingTypes
+            computationalScope = this,
+            chainWithAsset = it,
+            availableStakingTypes = payload.availableStakingOptions.stakingTypes
         )
     }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/ChainRegistry.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/ChainRegistry.kt
@@ -37,7 +37,6 @@ import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeProviderPool
 import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeSubscriptionPool
 import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeSyncService
 import io.novafoundation.nova.runtime.multiNetwork.runtime.types.BaseTypeSynchronizer
-import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
 import io.novasama.substrate_sdk_android.wsrpc.SocketService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/ChainRegistry.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/ChainRegistry.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.runtime.multiNetwork
 import android.util.Log
 import com.google.gson.Gson
 import io.novafoundation.nova.common.utils.LOG_TAG
+import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novafoundation.nova.common.utils.diffed
 import io.novafoundation.nova.common.utils.filterList
 import io.novafoundation.nova.common.utils.inBackground
@@ -306,8 +307,8 @@ fun ChainsById.assets(ids: Collection<FullChainAssetId>): List<Chain.Asset> {
     }
 }
 
-suspend inline fun <R> ChainRegistry.withRuntime(chainId: ChainId, action: RuntimeSnapshot.() -> R): R {
-    return with(getRuntime(chainId)) {
+suspend inline fun <R> ChainRegistry.withRuntime(chainId: ChainId, action: RuntimeContext.() -> R): R {
+    return with(RuntimeContext(getRuntime(chainId))) {
         action()
     }
 }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
@@ -41,6 +41,7 @@ private const val FEE_VIA_RUNTIME_CALL = "feeViaRuntimeCall"
 private const val SUPPORT_GENERIC_LEDGER_APP = "supportsGenericLedgerApp"
 private const val IDENTITY_CHAIN = "identityChain"
 private const val DISABLED_CHECK_METADATA_HASH = "disabledCheckMetadataHash"
+private const val SESSION_LENGTH = "sessionLength"
 
 fun mapRemoteChainToLocal(
     chainRemote: ChainRemote,
@@ -66,7 +67,8 @@ fun mapRemoteChainToLocal(
             feeViaRuntimeCall = it[FEE_VIA_RUNTIME_CALL] as? Boolean,
             supportLedgerGenericApp = it[SUPPORT_GENERIC_LEDGER_APP] as? Boolean,
             identityChain = it[IDENTITY_CHAIN] as? ChainId,
-            disabledCheckMetadataHash = it[DISABLED_CHECK_METADATA_HASH] as? Boolean
+            disabledCheckMetadataHash = it[DISABLED_CHECK_METADATA_HASH] as? Boolean,
+            sessionLength = it[SESSION_LENGTH].asGsonParsedIntOrNull()
         )
     }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
@@ -59,7 +59,8 @@ data class Chain(
         val feeViaRuntimeCall: Boolean?,
         val supportLedgerGenericApp: Boolean?,
         val identityChain: ChainId?,
-        val disabledCheckMetadataHash: Boolean?
+        val disabledCheckMetadataHash: Boolean?,
+        val sessionLength: Int?
     )
 
     data class Types(

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/XcmVersionDetector.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/multiLocation/XcmVersionDetector.kt
@@ -88,7 +88,7 @@ class RealXcmVersionDetector(
         argumentName: String,
     ): DictEnum? {
         return chainRegistry.withRuntime(chainId) {
-            val call = getCall(metadata) ?: return@withRuntime null
+            val call = getCall(runtime.metadata) ?: return@withRuntime null
             val argument = call.arguments.find { it.name == argumentName } ?: return@withRuntime null
             argument.type?.skipAliases() as? DictEnum
         }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/StorageQueryContext.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/StorageQueryContext.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.runtime.storage.source.query
 
 import io.novafoundation.nova.common.utils.ComponentHolder
+import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.storage.source.multi.MultiQueryBuilder
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
@@ -17,13 +18,11 @@ typealias StorageKeyComponents = ComponentHolder
 typealias DynamicInstanceBinder<V> = (dynamicInstance: Any?) -> V
 typealias DynamicInstanceBinderWithKey<K, V> = (dynamicInstance: Any?, key: K) -> V
 
-interface StorageQueryContext {
+interface StorageQueryContext : RuntimeContext {
 
     val chainId: ChainId
 
-    val runtime: RuntimeSnapshot
-
-    fun StorageEntry.createStorageKey(vararg keyArguments: Any?): String
+    override val runtime: RuntimeSnapshot
 
     suspend fun StorageEntry.keys(vararg prefixArgs: Any?): List<StorageKeyComponents>
 
@@ -123,5 +122,6 @@ suspend fun StorageQueryContext.multi(
 
 fun Iterable<*>.wrapSingleArgumentKeys(): List<List<Any?>> = map(::listOf)
 
+@Deprecated("Use RuntimeContext.metadata")
 val StorageQueryContext.metadata: RuntimeMetadata
     get() = runtime.metadata

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableModule.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableModule.kt
@@ -1,6 +1,6 @@
 package io.novafoundation.nova.runtime.storage.source.query.api
 
-import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
+import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novasama.substrate_sdk_android.runtime.metadata.module.Module
 import io.novasama.substrate_sdk_android.runtime.metadata.storage
 
@@ -12,20 +12,21 @@ interface QueryableModule {
     val module: Module
 }
 
-context(StorageQueryContext)
+context(RuntimeContext)
 fun <T : Any> QueryableModule.storage0(name: String, binding: QueryableStorageBinder0<T>): QueryableStorageEntry0<T> {
-    return RealQueryableStorageEntry0(module.storage(name), binding)
+    return RealQueryableStorageEntry0(module.storage(name), binding, this@RuntimeContext)
 }
 
-context(StorageQueryContext)
+context(RuntimeContext)
 fun <I, T> QueryableModule.storage1(
     name: String,
     binding: QueryableStorageBinder1<I, T>,
     keyBinding: QueryableStorageKeyBinder<I>? = null
 ): QueryableStorageEntry1<I, T> {
-    return RealQueryableStorageEntry1(module.storage(name), binding, keyBinding)
+    return RealQueryableStorageEntry1(module.storage(name), binding, this@RuntimeContext, keyBinding)
 }
-context(StorageQueryContext)
+
+context(RuntimeContext)
 fun <I1, I2, T : Any> QueryableModule.storage2(
     name: String,
     binding: QueryableStorageBinder2<I1, I2, T>,

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry0.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry0.kt
@@ -1,7 +1,10 @@
 package io.novafoundation.nova.runtime.storage.source.query.api
 
+import io.novafoundation.nova.common.utils.RuntimeContext
+import io.novafoundation.nova.common.utils.createStorageKey
 import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.runtime.storage.source.query.WithRawValue
+import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
 import io.novasama.substrate_sdk_android.runtime.metadata.module.StorageEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
@@ -22,7 +25,6 @@ interface QueryableStorageEntry0<T : Any> {
     context(StorageQueryContext)
     fun observeWithRaw(): Flow<WithRawValue<T?>>
 
-    context(StorageQueryContext)
     fun storageKey(): String
 }
 
@@ -34,8 +36,9 @@ suspend fun <T : Any> QueryableStorageEntry0<T>.queryNonNull(): T = requireNotNu
 
 internal class RealQueryableStorageEntry0<T : Any>(
     private val storageEntry: StorageEntry,
-    private val binding: QueryableStorageBinder0<T>
-) : QueryableStorageEntry0<T> {
+    private val binding: QueryableStorageBinder0<T>,
+    runtimeContext: RuntimeContext
+) : QueryableStorageEntry0<T>, RuntimeContext by runtimeContext {
 
     context(StorageQueryContext)
     override suspend fun query(): T? {
@@ -56,7 +59,6 @@ internal class RealQueryableStorageEntry0<T : Any>(
         return storageEntry.queryRaw()
     }
 
-    context(StorageQueryContext)
     override fun storageKey(): String {
         return storageEntry.createStorageKey()
     }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry0.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry0.kt
@@ -4,7 +4,6 @@ import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novafoundation.nova.common.utils.createStorageKey
 import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.runtime.storage.source.query.WithRawValue
-import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
 import io.novasama.substrate_sdk_android.runtime.metadata.module.StorageEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry1.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry1.kt
@@ -1,5 +1,7 @@
 package io.novafoundation.nova.runtime.storage.source.query.api
 
+import io.novafoundation.nova.common.utils.RuntimeContext
+import io.novafoundation.nova.common.utils.createStorageKey
 import io.novafoundation.nova.runtime.storage.source.query.StorageKeyComponents
 import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.runtime.storage.source.query.WithRawValue
@@ -36,7 +38,6 @@ interface QueryableStorageEntry1<I, T> {
     context(StorageQueryContext)
     fun observeWithRaw(argument: I): Flow<WithRawValue<T?>>
 
-    context(StorageQueryContext)
     fun storageKey(argument: I): String
 }
 
@@ -49,8 +50,9 @@ suspend fun <I, T : Any> QueryableStorageEntry1<I, T>.queryNonNull(argument: I):
 internal class RealQueryableStorageEntry1<I, T>(
     private val storageEntry: StorageEntry,
     private val binding: QueryableStorageBinder1<I, T>,
+    runtimeContext: RuntimeContext,
     @Suppress("UNCHECKED_CAST") private val keyBinding: QueryableStorageKeyBinder<I>? = null
-) : QueryableStorageEntry1<I, T> {
+) : QueryableStorageEntry1<I, T>, RuntimeContext by runtimeContext {
 
     context(StorageQueryContext)
     override suspend fun query(argument: I): T? {
@@ -67,7 +69,6 @@ internal class RealQueryableStorageEntry1<I, T>(
         return storageEntry.queryRaw(argument)
     }
 
-    context(StorageQueryContext)
     override fun storageKey(argument: I): String {
         return storageEntry.createStorageKey(argument)
     }


### PR DESCRIPTION
Start staking landing data for Mythos

* Replaces some usages of Perbill (deprecated) with Fraction
* Allow limited use of QuerableStorageEntries in any context that has access to runtime (`RuntimeContext`) rather than only in a context of storage query. This is usefull for updaters to construct storage keys using the same typed apy that is later used to subscribe to the values from db

<img width="258" alt="image" src="https://github.com/user-attachments/assets/a1f898f4-810f-47dc-95fd-430a4f9a22e8" />
