### PR TITLE
Fix staking landing duration calculations

### DIFF
--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/duration/MythosSessionDurationCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/duration/MythosSessionDurationCalculator.kt
@@ -27,10 +27,6 @@ interface MythosSessionDurationCalculator : EraRewardCalculatorComparable {
     fun remainingSessionDuration(): Duration
 }
 
-fun MythosSessionDurationCalculator.sessionsDuration(numberOfSessions: Int): Duration {
-    return sessionDuration() * numberOfSessions
-}
-
 @FeatureScope
 class MythosSessionDurationCalculatorFactory @Inject constructor(
     private val mythosSessionRepository: RealMythosSessionRepository,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/duration/MythosSessionDurationCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/duration/MythosSessionDurationCalculator.kt
@@ -17,6 +17,8 @@ import kotlin.time.Duration
 
 interface MythosSessionDurationCalculator : EraRewardCalculatorComparable {
 
+    val blockTime: BigInteger
+
     fun sessionDuration(): Duration
 
     /**
@@ -56,7 +58,7 @@ class MythosSessionDurationCalculatorFactory @Inject constructor(
 }
 
 private class RealMythosSessionDurationCalculator(
-    private val blockTime: BigInteger,
+    override val blockTime: BigInteger,
     private val currentSlot: BigInteger,
     private val slotsInSession: BigInteger
 ) : MythosSessionDurationCalculator {
@@ -66,7 +68,8 @@ private class RealMythosSessionDurationCalculator(
     }
 
     override fun remainingSessionDuration(): Duration {
-        return (slotsInSession - sessionProgress()).toDuration()
+        val remainingBlocks = slotsInSession - sessionProgress()
+        return (remainingBlocks * blockTime).toDuration()
     }
 
     override fun derivedTimestamp(): Duration {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosStakingRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/mythos/repository/MythosStakingRepository.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.data.mythos.repository
 
+import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.utils.Fraction
 import io.novafoundation.nova.common.utils.collatorStaking
@@ -31,7 +32,7 @@ interface MythosStakingRepository {
 
     suspend fun maxDelegatorsPerCollator(chainId: ChainId): Int
 
-    suspend fun unstakeDurationInSessions(chainId: ChainId): Int
+    suspend fun unstakeDurationInBlocks(chainId: ChainId): BlockNumber
 
     suspend fun maxReleaseRequests(chainId: ChainId): Int
 
@@ -71,9 +72,9 @@ class RealMythosStakingRepository @Inject constructor(
         }
     }
 
-    override suspend fun unstakeDurationInSessions(chainId: ChainId): Int {
+    override suspend fun unstakeDurationInBlocks(chainId: ChainId): BlockNumber {
         return chainRegistry.withRuntime(chainId) {
-            metadata.collatorStaking().numberConstant("StakeUnlockDelay").toInt()
+            metadata.collatorStaking().numberConstant("StakeUnlockDelay")
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/MythosStakingEraInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/MythosStakingEraInteractor.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.domain.era
 
 import io.novafoundation.nova.common.data.memory.ComputationalScope
 import io.novafoundation.nova.common.utils.flowOfAll
+import io.novafoundation.nova.common.utils.toDuration
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.chain
 import io.novafoundation.nova.feature_staking_impl.data.mythos.duration.MythosSessionDurationCalculator
@@ -23,11 +24,11 @@ class MythosStakingEraInteractor(
     override fun observeEraInfo(): Flow<StartStakingEraInfo> {
         return flowOfAll {
             val chainId = stakingOption.chain.id
-            val unstakingSessions = mythosStakingRepository.unstakeDurationInSessions(chainId)
+            val unstakingDurationInBlocks = mythosStakingRepository.unstakeDurationInBlocks(chainId)
 
             mythosSharedComputation.eraDurationCalculatorFlow(stakingOption).map { sessionDurationCalculator ->
                 StartStakingEraInfo(
-                    unstakeTime = sessionDurationCalculator.sessionsDuration(unstakingSessions),
+                    unstakeTime = (unstakingDurationInBlocks * sessionDurationCalculator.blockTime).toDuration(),
                     eraDuration = sessionDurationCalculator.sessionDuration(),
                     firstRewardReceivingDuration = sessionDurationCalculator.firstRewardDelay()
                 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/MythosStakingEraInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/era/MythosStakingEraInteractor.kt
@@ -6,7 +6,6 @@ import io.novafoundation.nova.common.utils.toDuration
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
 import io.novafoundation.nova.feature_staking_impl.data.chain
 import io.novafoundation.nova.feature_staking_impl.data.mythos.duration.MythosSessionDurationCalculator
-import io.novafoundation.nova.feature_staking_impl.data.mythos.duration.sessionsDuration
 import io.novafoundation.nova.feature_staking_impl.data.mythos.repository.MythosStakingRepository
 import io.novafoundation.nova.feature_staking_impl.domain.mythos.common.MythosSharedComputation
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.landing.model.StartStakingEraInfo


### PR DESCRIPTION
* Fix landing unstake calculation (UnstakeDelay stores blocks, not sessions)
* Fix first reward delay calculation (Forgot to multiply number of blocks by block duration)