### PR TITLE
Upgrade Gradle and AGP

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -157,6 +157,7 @@ android {
         resources.excludes.add("META-INF/versions/9/previous-compilation-data.bin")
         resources.excludes.add("META-INF/DEPENDENCIES")
     }
+    namespace 'io.novafoundation.nova.app'
 }
 
 void createBindReleaseFileTask(String destination) {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="io.novafoundation.nova.app">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/bindings/hydra-dx-math/build.gradle
+++ b/bindings/hydra-dx-math/build.gradle
@@ -30,6 +30,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.hydra_dx_math'
 }
 
 dependencies {

--- a/bindings/hydra-dx-math/src/main/AndroidManifest.xml
+++ b/bindings/hydra-dx-math/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.novafoundation.nova.hydra_dx_math" />
+<manifest />

--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.google.gms:google-services:4.3.14'
         classpath 'org.mozilla.rust-android-gradle:plugin:0.9.3'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -72,6 +72,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.common'
 }
 
 dependencies {

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.novafoundation.nova.common" />
+<manifest />

--- a/core-api/build.gradle
+++ b/core-api/build.gradle
@@ -21,6 +21,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.core'
 }
 
 dependencies {

--- a/core-api/src/main/AndroidManifest.xml
+++ b/core-api/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.core">
+<manifest>
 
 </manifest>

--- a/core-db/build.gradle
+++ b/core-db/build.gradle
@@ -39,6 +39,7 @@ android {
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
+    namespace 'io.novafoundation.nova.core_db'
 }
 
 dependencies {

--- a/core-db/src/main/AndroidManifest.xml
+++ b/core-db/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.novafoundation.nova.core_db" />
+<manifest />

--- a/feature-account-api/build.gradle
+++ b/feature-account-api/build.gradle
@@ -23,6 +23,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_account_api'
 }
 
 dependencies {

--- a/feature-account-api/src/main/AndroidManifest.xml
+++ b/feature-account-api/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_account_api">
+<manifest>
 
 </manifest>

--- a/feature-account-impl/build.gradle
+++ b/feature-account-impl/build.gradle
@@ -31,6 +31,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_account_impl'
 }
 
 dependencies {

--- a/feature-account-impl/src/main/AndroidManifest.xml
+++ b/feature-account-impl/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.novafoundation.nova.feature_account_impl" />
+<manifest />

--- a/feature-assets/build.gradle
+++ b/feature-assets/build.gradle
@@ -31,6 +31,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_assets'
 }
 
 dependencies {

--- a/feature-assets/src/main/AndroidManifest.xml
+++ b/feature-assets/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova.feature_assets">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature-crowdloan-api/build.gradle
+++ b/feature-crowdloan-api/build.gradle
@@ -21,6 +21,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_crowdloan_api'
 }
 
 dependencies {

--- a/feature-crowdloan-api/src/main/AndroidManifest.xml
+++ b/feature-crowdloan-api/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_crowdloan_api">
+<manifest>
 
 </manifest>

--- a/feature-crowdloan-impl/build.gradle
+++ b/feature-crowdloan-impl/build.gradle
@@ -44,6 +44,7 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    namespace 'io.novafoundation.nova.feature_crowdloan_impl'
 }
 
 dependencies {

--- a/feature-crowdloan-impl/src/main/AndroidManifest.xml
+++ b/feature-crowdloan-impl/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_crowdloan_impl">
+<manifest>
 
 </manifest>

--- a/feature-currency-api/build.gradle
+++ b/feature-currency-api/build.gradle
@@ -21,6 +21,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_currency_api'
 }
 
 dependencies {

--- a/feature-currency-api/src/main/AndroidManifest.xml
+++ b/feature-currency-api/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_currency_api"/>
+<manifest />

--- a/feature-currency-impl/build.gradle
+++ b/feature-currency-impl/build.gradle
@@ -29,6 +29,7 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    namespace 'io.novafoundation.nova.feature_currency_impl'
 }
 
 dependencies {

--- a/feature-currency-impl/src/main/AndroidManifest.xml
+++ b/feature-currency-impl/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_currency_impl"/>
+<manifest />

--- a/feature-dapp-api/build.gradle
+++ b/feature-dapp-api/build.gradle
@@ -22,6 +22,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_dapp_api'
 }
 
 dependencies {

--- a/feature-dapp-api/src/main/AndroidManifest.xml
+++ b/feature-dapp-api/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova.feature_dapp_api">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature-dapp-impl/build.gradle
+++ b/feature-dapp-impl/build.gradle
@@ -35,6 +35,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_dapp_impl'
 }
 
 task actualizeJsScripts(type: Exec) {

--- a/feature-dapp-impl/src/main/AndroidManifest.xml
+++ b/feature-dapp-impl/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova.feature_dapp_impl">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature-deep-linking/build.gradle
+++ b/feature-deep-linking/build.gradle
@@ -30,6 +30,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_deep_linking'
 }
 
 dependencies {

--- a/feature-deep-linking/src/main/AndroidManifest.xml
+++ b/feature-deep-linking/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_deep_linking" />
+<manifest />

--- a/feature-ledger-api/build.gradle
+++ b/feature-ledger-api/build.gradle
@@ -21,6 +21,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_ledger_api'
 }
 
 dependencies {

--- a/feature-ledger-api/src/main/AndroidManifest.xml
+++ b/feature-ledger-api/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_ledger_api" />
+<manifest />

--- a/feature-ledger-impl/build.gradle
+++ b/feature-ledger-impl/build.gradle
@@ -29,6 +29,7 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    namespace 'io.novafoundation.nova.feature_ledger_impl'
 }
 
 dependencies {

--- a/feature-ledger-impl/src/main/AndroidManifest.xml
+++ b/feature-ledger-impl/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_ledger_impl" />
+<manifest />

--- a/feature-nft-api/build.gradle
+++ b/feature-nft-api/build.gradle
@@ -18,6 +18,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_nft_api'
 }
 
 dependencies {

--- a/feature-nft-api/src/main/AndroidManifest.xml
+++ b/feature-nft-api/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova.feature_nft_api">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature-nft-impl/build.gradle
+++ b/feature-nft-impl/build.gradle
@@ -31,6 +31,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_nft_impl'
 }
 
 dependencies {

--- a/feature-nft-impl/src/main/AndroidManifest.xml
+++ b/feature-nft-impl/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova.feature_nft_impl">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/feature-onboarding-api/build.gradle
+++ b/feature-onboarding-api/build.gradle
@@ -21,6 +21,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_onboarding_api'
 }
 
 dependencies {

--- a/feature-onboarding-api/src/main/AndroidManifest.xml
+++ b/feature-onboarding-api/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_onboarding_api">
+<manifest>
 
 </manifest>

--- a/feature-onboarding-impl/build.gradle
+++ b/feature-onboarding-impl/build.gradle
@@ -31,6 +31,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_onboarding_impl'
 }
 
 dependencies {

--- a/feature-onboarding-impl/src/main/AndroidManifest.xml
+++ b/feature-onboarding-impl/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.novafoundation.nova.feature_onboarding_impl" />
+<manifest />

--- a/feature-proxy-api/build.gradle
+++ b/feature-proxy-api/build.gradle
@@ -21,6 +21,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_proxy_api'
 }
 
 dependencies {

--- a/feature-proxy-api/src/main/AndroidManifest.xml
+++ b/feature-proxy-api/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova.feature_proxy_api"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/feature-push-notifications/build.gradle
+++ b/feature-push-notifications/build.gradle
@@ -31,6 +31,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_push_notifications'
 }
 
 dependencies {

--- a/feature-push-notifications/src/main/AndroidManifest.xml
+++ b/feature-push-notifications/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.novafoundation.nova.feature_push_notifications" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/feature-splash/build.gradle
+++ b/feature-splash/build.gradle
@@ -30,6 +30,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.splash'
 }
 
 dependencies {

--- a/feature-splash/src/main/AndroidManifest.xml
+++ b/feature-splash/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="io.novafoundation.nova.splash">
+<manifest>
 </manifest>

--- a/feature-staking-api/build.gradle
+++ b/feature-staking-api/build.gradle
@@ -21,6 +21,7 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    namespace 'io.novafoundation.nova.feature_staking_api'
 }
 
 dependencies {

--- a/feature-staking-api/src/main/AndroidManifest.xml
+++ b/feature-staking-api/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_staking_api">
+<manifest>
 
 </manifest>

--- a/feature-staking-impl/build.gradle
+++ b/feature-staking-impl/build.gradle
@@ -37,6 +37,7 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    namespace 'io.novafoundation.nova.feature_staking_impl'
 }
 
 dependencies {

--- a/feature-staking-impl/src/main/AndroidManifest.xml
+++ b/feature-staking-impl/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_staking_impl">
+<manifest>
 
 </manifest>

--- a/feature-versions-api/build.gradle
+++ b/feature-versions-api/build.gradle
@@ -31,6 +31,7 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    namespace 'io.novafoundation.nova.feature_versions_api'
 }
 
 dependencies {

--- a/feature-versions-api/src/main/AndroidManifest.xml
+++ b/feature-versions-api/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_versions_api"/>
+<manifest />

--- a/feature-versions-impl/build.gradle
+++ b/feature-versions-impl/build.gradle
@@ -37,6 +37,7 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    namespace 'io.novafoundation.nova.feature_versions_impl'
 }
 
 dependencies {

--- a/feature-versions-impl/src/main/AndroidManifest.xml
+++ b/feature-versions-impl/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_versions_impl"/>
+<manifest />

--- a/feature-wallet-api/build.gradle
+++ b/feature-wallet-api/build.gradle
@@ -18,6 +18,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_wallet_api'
 }
 
 dependencies {

--- a/feature-wallet-api/src/main/AndroidManifest.xml
+++ b/feature-wallet-api/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.feature_wallet_api">
+<manifest>
 
 </manifest>

--- a/feature-wallet-impl/build.gradle
+++ b/feature-wallet-impl/build.gradle
@@ -39,6 +39,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.feature_wallet_impl'
 }
 
 dependencies {

--- a/feature-wallet-impl/src/main/AndroidManifest.xml
+++ b/feature-wallet-impl/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="io.novafoundation.nova.feature_wallet_impl">
+<manifest>
 </manifest>

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -37,8 +37,6 @@ afterEvaluate {
         if (!file.exists()) file.mkdirs()
 
         reports {
-            xml.enabled = true
-            html.enabled = true
             html.setDestination(new File(outputFileNameHtml))
             xml.setDestination(new File(outputFileName))
         }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -44,6 +44,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.runtime'
 }
 
 dependencies {

--- a/runtime/src/main/AndroidManifest.xml
+++ b/runtime/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.novafoundation.nova.runtime">
+<manifest>
 
 </manifest>

--- a/test-shared/build.gradle
+++ b/test-shared/build.gradle
@@ -23,6 +23,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs = ["-Xcontext-receivers"]
     }
+    namespace 'io.novafoundation.nova.test_shared'
 }
 
 

--- a/test-shared/src/main/AndroidManifest.xml
+++ b/test-shared/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.novafoundation.nova.test_shared" />
+<manifest />


### PR DESCRIPTION
Upgrade Gradle & AGP to the latest versions

This is needed to run android tests from Android Studio

Scope:

* Moves namespace from AndroidManifest to gradle files
* Enables a banch of flags like nonTransitiveR=false to remain the current configuration