### PR TITLE
Fix swap quote loading on a fresh install

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/data/memory/LazyAsyncCache.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/memory/LazyAsyncCache.kt
@@ -1,0 +1,72 @@
+package io.novafoundation.nova.common.data.memory
+
+import io.novafoundation.nova.common.utils.invokeOnCompletion
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+
+interface LazyAsyncCache<K, V> {
+
+    suspend fun getOrCompute(key: K): V
+}
+
+/**
+ * In-memory cache primitive that caches asynchronously computed value
+ * Lifetime of the cache itself is determine by supplied [CoroutineScope]
+ */
+fun <K, V> LazyAsyncCache(coroutineScope: CoroutineScope, compute: AsyncCacheCompute<K, V>): LazyAsyncCache<K, V> {
+    return RealLazyAsyncCache(coroutineScope, compute)
+}
+
+/**
+ * Specialization of [LazyAsyncCache] that's cached value is a [SharedFlow] shared in the supplied [coroutineScope]
+ */
+inline fun <K, V> SharedFlowCache(
+    coroutineScope: CoroutineScope,
+    crossinline compute: suspend (key: K) -> Flow<V>
+): LazyAsyncCache<K, SharedFlow<V>> {
+    return LazyAsyncCache(coroutineScope) { key, scope ->
+        compute(key).shareIn(scope, SharingStarted.Eagerly, replay = 1)
+    }
+}
+
+typealias AsyncCacheCompute<K, V> = suspend (key: K, scope: CoroutineScope) -> V
+
+private class RealLazyAsyncCache<K, V>(
+    private val lifetime: CoroutineScope,
+    private val compute: AsyncCacheCompute<K, V>,
+): LazyAsyncCache<K, V> {
+
+    private val mutex = Mutex()
+    private val cache = mutableMapOf<K, V>()
+
+    override suspend fun getOrCompute(key: K): V {
+        mutex.withLock {
+            if (key in cache) return cache.getValue(key)
+
+            return compute(key, lifetime).also {
+                cache[key] = it
+            }
+        }
+    }
+
+    init {
+        lifetime.invokeOnCompletion {
+            clearCache()
+        }
+    }
+
+    // GlobalScope job is fine here since it just for clearing the map
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun clearCache() = GlobalScope.launch {
+        mutex.withLock { cache.clear() }
+    }
+}

--- a/common/src/main/java/io/novafoundation/nova/common/data/memory/LazyAsyncCache.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/memory/LazyAsyncCache.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-
 interface LazyAsyncCache<K, V> {
 
     suspend fun getOrCompute(key: K): V
@@ -43,7 +42,7 @@ typealias AsyncCacheCompute<K, V> = suspend (key: K, scope: CoroutineScope) -> V
 private class RealLazyAsyncCache<K, V>(
     private val lifetime: CoroutineScope,
     private val compute: AsyncCacheCompute<K, V>,
-): LazyAsyncCache<K, V> {
+) : LazyAsyncCache<K, V> {
 
     private val mutex = Mutex()
     private val cache = mutableMapOf<K, V>()

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/types/hydra/HydraDxQuoteSharedComputation.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/types/hydra/HydraDxQuoteSharedComputation.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_account_impl.data.fee.types.hydra
 
 import io.novafoundation.nova.common.data.memory.ComputationalCache
-import io.novafoundation.nova.common.data.memory.LazyAsyncCache
 import io.novafoundation.nova.common.data.memory.SharedFlowCache
 import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
 import io.novafoundation.nova.common.utils.graph.Graph
@@ -14,13 +13,11 @@ import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuot
 import io.novafoundation.nova.runtime.ethereum.StorageSharedRequestsBuilderFactory
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
-import io.novafoundation.nova.runtime.network.updaters.BlockNumberUpdater
 import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novasama.substrate_sdk_android.extensions.toHexString
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/types/hydra/HydraDxQuoteSharedComputation.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/types/hydra/HydraDxQuoteSharedComputation.kt
@@ -1,18 +1,26 @@
 package io.novafoundation.nova.feature_account_impl.data.fee.types.hydra
 
 import io.novafoundation.nova.common.data.memory.ComputationalCache
+import io.novafoundation.nova.common.data.memory.LazyAsyncCache
+import io.novafoundation.nova.common.data.memory.SharedFlowCache
+import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
 import io.novafoundation.nova.common.utils.graph.Graph
 import io.novafoundation.nova.common.utils.graph.create
 import io.novafoundation.nova.feature_swap_core_api.data.paths.PathQuoter
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuotingSubscriptions
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuoting
 import io.novafoundation.nova.runtime.ethereum.StorageSharedRequestsBuilderFactory
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.network.updaters.BlockNumberUpdater
+import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novasama.substrate_sdk_android.extensions.toHexString
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 
@@ -21,7 +29,7 @@ class HydraDxQuoteSharedComputation(
     private val quotingFactory: HydraDxQuoting.Factory,
     private val pathQuoterFactory: PathQuoter.Factory,
     private val storageSharedRequestsBuilderFactory: StorageSharedRequestsBuilderFactory,
-    private val blockNumberUpdater: BlockNumberUpdater
+    private val chainStateRepository: ChainStateRepository,
 ) {
 
     suspend fun getQuoter(
@@ -48,12 +56,12 @@ class HydraDxQuoteSharedComputation(
         val key = "HydraDxAssetConversion:${chain.id}:${accountId.toHexString()}"
 
         return computationalCache.useCache(key, scope) {
-            val subscriptionBuilder = storageSharedRequestsBuilderFactory.create(chain.id)
-            val hydraDxQuoting = quotingFactory.create(chain)
+            val sharedSubscriptions = RealSwapQuotingSubscriptions(scope)
+            val host = RealQuotingHost(sharedSubscriptions)
 
-            // Required at least for stable swap
-            blockNumberUpdater.listenForUpdates(subscriptionBuilder, chain)
-                .launchIn(this)
+            val subscriptionBuilder = storageSharedRequestsBuilderFactory.create(chain.id)
+
+            val hydraDxQuoting = quotingFactory.create(chain, host)
 
             hydraDxQuoting.sync()
             hydraDxQuoting.runSubscriptions(accountId, subscriptionBuilder)
@@ -62,6 +70,21 @@ class HydraDxQuoteSharedComputation(
             subscriptionBuilder.subscribe(this)
 
             hydraDxQuoting
+        }
+    }
+
+    private class RealQuotingHost(
+        override val sharedSubscriptions: SwapQuotingSubscriptions,
+    ) : SwapQuoting.QuotingHost
+
+    private inner class RealSwapQuotingSubscriptions(scope: CoroutineScope) : SwapQuotingSubscriptions {
+
+        private val blockNumberCache = SharedFlowCache<ChainId, BlockNumber>(scope) { chainId ->
+            chainStateRepository.currentRemoteBlockNumberFlow(chainId)
+        }
+
+        override suspend fun blockNumber(chainId: ChainId): Flow<BlockNumber> {
+            return blockNumberCache.getOrCompute(chainId)
         }
     }
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureDependencies.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureDependencies.kt
@@ -60,6 +60,7 @@ import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.Multi
 import io.novafoundation.nova.runtime.multiNetwork.qr.MultiChainQrSharingFactory
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
 import io.novafoundation.nova.runtime.network.rpc.RpcCalls
+import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novafoundation.nova.web3names.domain.networking.Web3NamesInteractor
 import io.novasama.substrate_sdk_android.icon.IconGenerator
@@ -195,4 +196,6 @@ interface AccountFeatureDependencies {
     val eventsRepository: EventsRepository
 
     val xcmVersionDetector: XcmVersionDetector
+
+    val chainStateRepository: ChainStateRepository
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/modules/CustomFeeModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/modules/CustomFeeModule.kt
@@ -25,6 +25,7 @@ import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.XcmVersionDetector
 import io.novafoundation.nova.runtime.multiNetwork.multiLocation.converter.MultiLocationConverterFactory
 import io.novafoundation.nova.runtime.network.updaters.BlockNumberUpdater
+import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import javax.inject.Named
 
@@ -50,14 +51,14 @@ class CustomFeeModule {
         quotingFactory: HydraDxQuoting.Factory,
         pathQuoterFactory: PathQuoter.Factory,
         storageSharedRequestsBuilderFactory: StorageSharedRequestsBuilderFactory,
-        blockNumberUpdater: BlockNumberUpdater
+        chainStateRepository: ChainStateRepository
     ): HydraDxQuoteSharedComputation {
         return HydraDxQuoteSharedComputation(
             computationalCache = computationalCache,
             quotingFactory = quotingFactory,
             pathQuoterFactory = pathQuoterFactory,
             storageSharedRequestsBuilderFactory = storageSharedRequestsBuilderFactory,
-            blockNumberUpdater = blockNumberUpdater
+            chainStateRepository = chainStateRepository
         )
     }
 

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/primitive/SwapQuoting.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/primitive/SwapQuoting.kt
@@ -8,6 +8,11 @@ import kotlinx.coroutines.flow.Flow
 
 interface SwapQuoting {
 
+    interface QuotingHost {
+
+        val sharedSubscriptions: SwapQuotingSubscriptions
+    }
+
     /**
      * Perform initial data sync needed to later perform [runSubscriptions]
      * This is separated from [runSubscriptions] since [runSubscriptions] might be io-intense

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/primitive/SwapQuotingSubscriptions.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/primitive/SwapQuotingSubscriptions.kt
@@ -1,0 +1,10 @@
+package io.novafoundation.nova.feature_swap_core_api.data.primitive
+
+import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import kotlinx.coroutines.flow.Flow
+
+interface SwapQuotingSubscriptions {
+
+    suspend fun blockNumber(chainId: ChainId): Flow<BlockNumber>
+}

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/types/hydra/HydraDxQuoting.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/types/hydra/HydraDxQuoting.kt
@@ -7,7 +7,7 @@ interface HydraDxQuoting : SwapQuoting {
 
     interface Factory {
 
-        fun create(chain: Chain): HydraDxQuoting
+        fun create(chain: Chain, host: SwapQuoting.QuotingHost): HydraDxQuoting
     }
 
     fun getSource(id: String): HydraDxQuotingSource<*>

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/types/hydra/HydraDxQuotingSource.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/types/hydra/HydraDxQuotingSource.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_swap_core_api.data.types.hydra
 
 import io.novafoundation.nova.common.utils.Identifiable
 import io.novafoundation.nova.core.updater.SharedRequestsBuilder
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -20,6 +21,6 @@ interface HydraDxQuotingSource<E : QuotableEdge> : Identifiable {
 
     interface Factory<S : HydraDxQuotingSource<*>> {
 
-        fun create(chain: Chain): S
+        fun create(chain: Chain, host: SwapQuoting.QuotingHost): S
     }
 }

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/RealHydraDxQuoting.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/RealHydraDxQuoting.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.core.updater.SharedRequestsBuilder
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdConverter
 import io.novafoundation.nova.feature_swap_core_api.data.network.isSystemAsset
 import io.novafoundation.nova.feature_swap_core_api.data.network.toOnChainIdOrThrow
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
@@ -22,12 +23,13 @@ class RealHydraDxQuotingFactory(
     private val hydraDxAssetIdConverter: HydraDxAssetIdConverter,
 ) : HydraDxQuoting.Factory {
 
-    override fun create(chain: Chain): HydraDxQuoting {
+    override fun create(chain: Chain, host: SwapQuoting.QuotingHost): HydraDxQuoting {
         return RealHydraDxQuoting(
             chain = chain,
             remoteStorageSource = remoteStorageSource,
             quotingSourceFactories = conversionSourceFactories,
-            hydraDxAssetIdConverter = hydraDxAssetIdConverter
+            hydraDxAssetIdConverter = hydraDxAssetIdConverter,
+            host = host
         )
     }
 }
@@ -37,6 +39,7 @@ private class RealHydraDxQuoting(
     private val remoteStorageSource: StorageDataSource,
     private val quotingSourceFactories: Iterable<HydraDxQuotingSource.Factory<*>>,
     private val hydraDxAssetIdConverter: HydraDxAssetIdConverter,
+    private val host: SwapQuoting.QuotingHost,
 ) : HydraDxQuoting {
 
     private val quotingSources: Map<String, HydraDxQuotingSource<*>> = createSources()
@@ -72,7 +75,7 @@ private class RealHydraDxQuoting(
     }
 
     private fun createSources(): Map<String, HydraDxQuotingSource<*>> {
-        return quotingSourceFactories.map { it.create(chain) }
+        return quotingSourceFactories.map { it.create(chain, host) }
             .associateBy { it.identifier }
     }
 }

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/omnipool/RealOmniPoolQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/omnipool/RealOmniPoolQuotingSource.kt
@@ -19,6 +19,7 @@ import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.ty
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.subscribeToTransferableBalance
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetId
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdConverter
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.errors.SwapQuoteException
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
@@ -51,7 +52,7 @@ class OmniPoolQuotingSourceFactory(
         const val SOURCE_ID = "OmniPool"
     }
 
-    override fun create(chain: Chain): OmniPoolQuotingSource {
+    override fun create(chain: Chain, host: SwapQuoting.QuotingHost): OmniPoolQuotingSource {
         return RealOmniPoolQuotingSource(
             remoteStorageSource = remoteStorageSource,
             chainRegistry = chainRegistry,

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.stableswap
 
+import android.util.Log
 import com.google.gson.Gson
 import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
 import io.novafoundation.nova.common.data.network.runtime.binding.orEmpty
@@ -21,13 +22,13 @@ import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.ty
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.stableswap.model.quote
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetId
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdConverter
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.errors.SwapQuoteException
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
 import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
-import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novafoundation.nova.runtime.storage.source.query.metadata
 import io.novasama.substrate_sdk_android.encrypt.json.asLittleEndianBytes
@@ -50,7 +51,6 @@ class StableSwapQuotingSourceFactory(
     private val remoteStorageSource: StorageDataSource,
     private val hydraDxAssetIdConverter: HydraDxAssetIdConverter,
     private val gson: Gson,
-    private val chainStateRepository: ChainStateRepository
 ) : HydraDxQuotingSource.Factory<StableSwapQuotingSource> {
 
     companion object {
@@ -58,13 +58,13 @@ class StableSwapQuotingSourceFactory(
         const val ID = "StableSwap"
     }
 
-    override fun create(chain: Chain): StableSwapQuotingSource {
+    override fun create(chain: Chain, host: SwapQuoting.QuotingHost): StableSwapQuotingSource {
         return RealStableSwapQuotingSource(
             remoteStorageSource = remoteStorageSource,
             hydraDxAssetIdConverter = hydraDxAssetIdConverter,
             chain = chain,
             gson = gson,
-            chainStateRepository = chainStateRepository
+            host = host
         )
     }
 }
@@ -74,7 +74,7 @@ private class RealStableSwapQuotingSource(
     private val hydraDxAssetIdConverter: HydraDxAssetIdConverter,
     override val chain: Chain,
     private val gson: Gson,
-    private val chainStateRepository: ChainStateRepository,
+    private val host: SwapQuoting.QuotingHost,
 ) : StableSwapQuotingSource {
 
     override val identifier: String = StableSwapQuotingSourceFactory.ID
@@ -112,6 +112,7 @@ private class RealStableSwapQuotingSource(
                 }
             }
         }.toMultiSubscription(initialPoolsInfo.size)
+            .onEach { Log.d("StableSwap", "poolInfoSubscriptions loaded") }
 
         val omniPoolAccountId = omniPoolAccountId()
 
@@ -122,6 +123,7 @@ private class RealStableSwapQuotingSource(
                 sharedAssetRemoteId to it
             }
         }.toMultiSubscription(initialPoolsInfo.size)
+            .onEach { Log.d("StableSwap", "poolSharedAssetBalanceSubscriptions loaded") }
 
         val totalPooledAssets = initialPoolsInfo.sumOf { it.poolAssets.size }
 
@@ -135,6 +137,7 @@ private class RealStableSwapQuotingSource(
                 }
             }
         }.toMultiSubscription(totalPooledAssets)
+            .onEach { Log.d("StableSwap", "poolParticipatingAssetsBalanceSubscription loaded") }
 
         val totalIssuanceSubscriptions = initialPoolsInfo.map { poolInfo ->
             remoteStorageSource.subscribe(chain.id, subscriptionBuilder) {
@@ -143,6 +146,10 @@ private class RealStableSwapQuotingSource(
                 }
             }
         }.toMultiSubscription(initialPoolsInfo.size)
+            .onEach { Log.d("StableSwap", "totalIssuanceSubscriptions loaded") }
+
+        val blockNumber = host.sharedSubscriptions.blockNumber(chain.id)
+            .onEach { Log.d("StableSwap", "Block number loaded") }
 
         val precisions = fetchAssetsPrecisionsAsync()
 
@@ -151,8 +158,9 @@ private class RealStableSwapQuotingSource(
             poolSharedAssetBalanceSubscriptions,
             poolParticipatingAssetsBalanceSubscription,
             totalIssuanceSubscriptions,
-            chainStateRepository.currentBlockNumberFlow(chain.id),
+            blockNumber,
         ) { poolInfos, poolSharedAssetBalances, poolParticipatingAssetBalances, totalIssuances, currentBlock ->
+            Log.d("StableSwap", "!!! Pool construction triggered")
             createStableSwapPool(poolInfos, poolSharedAssetBalances, poolParticipatingAssetBalances, totalIssuances, currentBlock, precisions.await())
         }
             .onEach(stablePools::emit)

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
@@ -1,6 +1,5 @@
 package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.stableswap
 
-import android.util.Log
 import com.google.gson.Gson
 import io.novafoundation.nova.common.data.network.runtime.binding.BlockNumber
 import io.novafoundation.nova.common.data.network.runtime.binding.orEmpty

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
@@ -123,7 +123,6 @@ private class RealStableSwapQuotingSource(
                 sharedAssetRemoteId to it
             }
         }.toMultiSubscription(initialPoolsInfo.size)
-            .onEach { Log.d("StableSwap", "poolSharedAssetBalanceSubscriptions loaded") }
 
         val totalPooledAssets = initialPoolsInfo.sumOf { it.poolAssets.size }
 
@@ -137,7 +136,6 @@ private class RealStableSwapQuotingSource(
                 }
             }
         }.toMultiSubscription(totalPooledAssets)
-            .onEach { Log.d("StableSwap", "poolParticipatingAssetsBalanceSubscription loaded") }
 
         val totalIssuanceSubscriptions = initialPoolsInfo.map { poolInfo ->
             remoteStorageSource.subscribe(chain.id, subscriptionBuilder) {
@@ -146,10 +144,6 @@ private class RealStableSwapQuotingSource(
                 }
             }
         }.toMultiSubscription(initialPoolsInfo.size)
-            .onEach { Log.d("StableSwap", "totalIssuanceSubscriptions loaded") }
-
-        val blockNumber = host.sharedSubscriptions.blockNumber(chain.id)
-            .onEach { Log.d("StableSwap", "Block number loaded") }
 
         val precisions = fetchAssetsPrecisionsAsync()
 
@@ -158,9 +152,8 @@ private class RealStableSwapQuotingSource(
             poolSharedAssetBalanceSubscriptions,
             poolParticipatingAssetsBalanceSubscription,
             totalIssuanceSubscriptions,
-            blockNumber,
+            host.sharedSubscriptions.blockNumber(chain.id),
         ) { poolInfos, poolSharedAssetBalances, poolParticipatingAssetBalances, totalIssuances, currentBlock ->
-            Log.d("StableSwap", "!!! Pool construction triggered")
             createStableSwapPool(poolInfos, poolSharedAssetBalances, poolParticipatingAssetBalances, totalIssuances, currentBlock, precisions.await())
         }
             .onEach(stablePools::emit)

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
@@ -112,7 +112,6 @@ private class RealStableSwapQuotingSource(
                 }
             }
         }.toMultiSubscription(initialPoolsInfo.size)
-            .onEach { Log.d("StableSwap", "poolInfoSubscriptions loaded") }
 
         val omniPoolAccountId = omniPoolAccountId()
 

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/xyk/RealXYKSwapQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/xyk/RealXYKSwapQuotingSource.kt
@@ -16,6 +16,7 @@ import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.ty
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.xyk.model.poolFeesConstant
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetId
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdConverter
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.errors.SwapQuoteException
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
@@ -43,7 +44,7 @@ class XYKSwapQuotingSourceFactory(
         const val ID = "XYK"
     }
 
-    override fun create(chain: Chain): XYKSwapQuotingSource {
+    override fun create(chain: Chain, host: SwapQuoting.QuotingHost): XYKSwapQuotingSource {
         return RealXYKSwapQuotingSource(
             remoteStorageSource = remoteStorageSource,
             hydraDxAssetIdConverter = hydraDxAssetIdConverter,

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/di/conversions/HydraDxConversionModule.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/di/conversions/HydraDxConversionModule.kt
@@ -41,13 +41,11 @@ class HydraDxConversionModule {
         @Named(REMOTE_STORAGE_SOURCE) remoteStorageSource: StorageDataSource,
         hydraDxAssetIdConverter: HydraDxAssetIdConverter,
         gson: Gson,
-        chainStateRepository: ChainStateRepository
     ): HydraDxQuotingSource.Factory<*> {
         return StableSwapQuotingSourceFactory(
             remoteStorageSource = remoteStorageSource,
             hydraDxAssetIdConverter = hydraDxAssetIdConverter,
             gson = gson,
-            chainStateRepository = chainStateRepository
         )
     }
 

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/di/conversions/HydraDxConversionModule.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/di/conversions/HydraDxConversionModule.kt
@@ -14,7 +14,6 @@ import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuot
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
 import io.novafoundation.nova.runtime.di.REMOTE_STORAGE_SOURCE
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
-import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import javax.inject.Named
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/AssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/AssetExchange.kt
@@ -5,6 +5,8 @@ import io.novafoundation.nova.feature_account_api.data.fee.FeePaymentProvider
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapGraphEdge
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting.QuotingHost
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -23,9 +25,11 @@ interface AssetExchange {
         suspend fun create(swapHost: SwapHost): AssetExchange
     }
 
-    interface SwapHost {
+    interface SwapHost: QuotingHost {
 
         val scope: CoroutineScope
+
+        override val sharedSubscriptions: SharedSwapSubscriptions
 
         suspend fun quote(quoteArgs: ParentQuoterArgs): Balance
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/AssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/AssetExchange.kt
@@ -5,7 +5,6 @@ import io.novafoundation.nova.feature_account_api.data.fee.FeePaymentProvider
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapGraphEdge
-import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuoting.QuotingHost
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
@@ -25,7 +24,7 @@ interface AssetExchange {
         suspend fun create(swapHost: SwapHost): AssetExchange
     }
 
-    interface SwapHost: QuotingHost {
+    interface SwapHost : QuotingHost {
 
         val scope: CoroutineScope
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/SharedSwapSubscriptions.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/SharedSwapSubscriptions.kt
@@ -1,0 +1,5 @@
+package io.novafoundation.nova.feature_swap_impl.data.assetExchange
+
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuotingSubscriptions
+
+interface SharedSwapSubscriptions: SwapQuotingSubscriptions

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/SharedSwapSubscriptions.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/SharedSwapSubscriptions.kt
@@ -2,4 +2,4 @@ package io.novafoundation.nova.feature_swap_impl.data.assetExchange
 
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.SwapQuotingSubscriptions
 
-interface SharedSwapSubscriptions: SwapQuotingSubscriptions
+interface SharedSwapSubscriptions : SwapQuotingSubscriptions

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxAssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxAssetExchange.kt
@@ -110,7 +110,7 @@ class HydraDxExchangeFactory(
             swapSourceFactories = swapSourceFactories,
             swapHost = swapHost,
             hydrationFeeInjector = hydrationFeeInjector,
-            delegate = quotingFactory.create(chain),
+            delegate = quotingFactory.create(chain, swapHost),
             chainStateRepository = chainStateRepository,
             swapDeductionUseCase = swapDeductionUseCase
         )

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/network/blockhain/updaters/SwapUpdateSystemFactory.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/network/blockhain/updaters/SwapUpdateSystemFactory.kt
@@ -1,9 +1,7 @@
 package io.novafoundation.nova.feature_swap_impl.data.network.blockhain.updaters
 
 import io.novafoundation.nova.common.utils.shareInBackground
-import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.core.updater.UpdateSystem
-import io.novafoundation.nova.core.updater.Updater
 import io.novafoundation.nova.feature_account_api.domain.updaters.ChainUpdateScope
 import io.novafoundation.nova.feature_swap_api.presentation.state.SwapSettingsState
 import io.novafoundation.nova.feature_swap_api.presentation.state.SwapSettingsStateProvider
@@ -13,7 +11,6 @@ import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import io.novafoundation.nova.runtime.network.updaters.SharedAssetBlockNumberUpdater
 import io.novafoundation.nova.runtime.network.updaters.ConstantSingleChainUpdateSystem
 import io.novafoundation.nova.runtime.state.SelectedAssetOptionSharedState
 import io.novafoundation.nova.runtime.state.SupportedAssetOption

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/network/blockhain/updaters/SwapUpdateSystemFactory.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/network/blockhain/updaters/SwapUpdateSystemFactory.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.mapNotNull
 class SwapUpdateSystemFactory(
     private val swapSettingsStateProvider: SwapSettingsStateProvider,
     private val chainRegistry: ChainRegistry,
-    private val storageCache: StorageCache,
     private val storageSharedRequestsBuilderFactory: StorageSharedRequestsBuilderFactory,
     private val accountInfoUpdaterFactory: AccountInfoUpdaterFactory
 ) {
@@ -36,7 +35,6 @@ class SwapUpdateSystemFactory(
         val sharedStateAdapter = SwapSharedStateAdapter(swapSettingsState, chainRegistry, coroutineScope)
 
         val updaters = listOf(
-            blockNumberUpdater(sharedStateAdapter),
             accountInfoUpdaterFactory.create(ChainUpdateScope(chainFlow), sharedStateAdapter)
         )
 
@@ -46,10 +44,6 @@ class SwapUpdateSystemFactory(
             storageSharedRequestsBuilderFactory = storageSharedRequestsBuilderFactory,
             updaters = updaters
         )
-    }
-
-    private fun blockNumberUpdater(sharedStateAdapter: SwapSharedStateAdapter): Updater<*> {
-        return SharedAssetBlockNumberUpdater(chainRegistry, sharedStateAdapter, storageCache)
     }
 }
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureModule.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureModule.kt
@@ -53,6 +53,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.updater.AccountInfoUpdat
 import io.novafoundation.nova.feature_wallet_api.domain.validation.context.AssetsValidationContext
 import io.novafoundation.nova.runtime.ethereum.StorageSharedRequestsBuilderFactory
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.repository.ChainStateRepository
 
 @Module(includes = [HydraDxExchangeModule::class, AssetConversionExchangeModule::class, CrossChainTransferExchangeModule::class])
 class SwapFeatureModule {
@@ -70,7 +71,8 @@ class SwapFeatureModule {
         defaultFeePaymentRegistry: FeePaymentProviderRegistry,
         tokenRepository: TokenRepository,
         accountRepository: AccountRepository,
-        assetSourceRegistry: AssetSourceRegistry
+        assetSourceRegistry: AssetSourceRegistry,
+        chainStateRepository: ChainStateRepository
     ): SwapService {
         return RealSwapService(
             assetConversionFactory = assetConversionFactory,
@@ -83,7 +85,8 @@ class SwapFeatureModule {
             defaultFeePaymentProviderRegistry = defaultFeePaymentRegistry,
             tokenRepository = tokenRepository,
             assetSourceRegistry = assetSourceRegistry,
-            accountRepository = accountRepository
+            accountRepository = accountRepository,
+            chainStateRepository = chainStateRepository
         )
     }
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureModule.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureModule.kt
@@ -187,14 +187,12 @@ class SwapFeatureModule {
     fun provideSwapUpdateSystemFactory(
         swapSettingsStateProvider: SwapSettingsStateProvider,
         chainRegistry: ChainRegistry,
-        storageCache: StorageCache,
         storageSharedRequestsBuilderFactory: StorageSharedRequestsBuilderFactory,
         accountInfoUpdaterFactory: AccountInfoUpdaterFactory
     ): SwapUpdateSystemFactory {
         return SwapUpdateSystemFactory(
             swapSettingsStateProvider = swapSettingsStateProvider,
             chainRegistry = chainRegistry,
-            storageCache = storageCache,
             storageSharedRequestsBuilderFactory = storageSharedRequestsBuilderFactory,
             accountInfoUpdaterFactory = accountInfoUpdaterFactory
         )

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
@@ -22,9 +22,7 @@ import io.novafoundation.nova.common.utils.isZero
 import io.novafoundation.nova.common.utils.mapAsync
 import io.novafoundation.nova.common.utils.measureExecution
 import io.novafoundation.nova.common.utils.mergeIfMultiple
-import io.novafoundation.nova.common.utils.metadata
 import io.novafoundation.nova.common.utils.orZero
-import io.novafoundation.nova.common.utils.shareInBackground
 import io.novafoundation.nova.common.utils.withFlowScope
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_account_api.data.fee.FeePaymentCurrency
@@ -100,15 +98,10 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import io.novafoundation.nova.runtime.multiNetwork.chainWithAssetOrNull
 import io.novafoundation.nova.runtime.multiNetwork.chainsById
 import io.novafoundation.nova.runtime.repository.ChainStateRepository
-import io.novafoundation.nova.runtime.storage.source.RemoteStorageSource
-import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNull
-import io.novafoundation.nova.runtime.storage.typed.number
-import io.novafoundation.nova.runtime.storage.typed.system
 import io.novasama.substrate_sdk_android.hash.isPositive
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
@@ -116,9 +109,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.runningFold
-import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.math.BigInteger

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/di/RuntimeModule.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/di/RuntimeModule.kt
@@ -128,9 +128,10 @@ class RuntimeModule {
     @ApplicationScope
     fun provideChainStateRepository(
         @Named(LOCAL_STORAGE_SOURCE) localStorageSource: StorageDataSource,
+        @Named(REMOTE_STORAGE_SOURCE) remoteStorageSource: StorageDataSource,
         sampledBlockTimeStorage: SampledBlockTimeStorage,
         chainRegistry: ChainRegistry
-    ) = ChainStateRepository(localStorageSource, sampledBlockTimeStorage, chainRegistry)
+    ) = ChainStateRepository(localStorageSource, remoteStorageSource, sampledBlockTimeStorage, chainRegistry)
 
     @Provides
     @ApplicationScope


### PR DESCRIPTION
**Core issue:** `BlockNumberUpdater` was running only on origin chain, preventing `StableSwapSource` to construct its internal data structures since it was waiting for block number to arrive. This might result in quoting to be completely blocked in case block number for Hydratin was never synced (e.g. if you open DOT Polkadot -> PAH on a fresh start)

**Fix:** completely get rid of necessity of running BlockTimeUpdater by subscribing directly to the remote storage. Of course we need to thing about reusing such sort of common subscribtions and requesting them in a lazy way. This is implemented by introducing `SharedSwapSubscriptions` abstraction and `LazyAsyncCache` that is used in its implementation

**Future work:** I also wanted to get rid of SwapUpdateSystem entirely to simplify the model even further but it is harder to do since `SwapUpdateSystem` syncs `system.account` which is used in `canBalanceDropBelowEd` which is used in multiple places, including validations


#86981r3fn