### PR TITLE
Fix - signing request was considered as pairing

### DIFF
--- a/feature-deep-linking/src/main/java/io/novafoundation/nova/feature_deep_linking/presentation/handling/handlers/WalletConnectPairDeeplinkHandler.kt
+++ b/feature-deep-linking/src/main/java/io/novafoundation/nova/feature_deep_linking/presentation/handling/handlers/WalletConnectPairDeeplinkHandler.kt
@@ -18,10 +18,12 @@ class WalletConnectPairDeeplinkHandler(
 
     override suspend fun matches(data: Uri): Boolean {
         val newLinkMatch = data.scheme == "novawallet" && data.host == "wc"
-        // Older version of wc send both pair and sign requests through `wc:` deeplink so we additionally check for `symKey` which is only present in pairing url
-        val oldLinkMatch = data.scheme == "wc" && "symKey" in data.toString()
+        val oldLinkMatch = data.scheme == "wc"
+        val linkMatch = newLinkMatch || oldLinkMatch
 
-        return newLinkMatch || oldLinkMatch
+        val isPairing = "symKey" in data.toString()
+
+        return linkMatch && isPairing
     }
 
     override suspend fun handleDeepLink(data: Uri) {


### PR DESCRIPTION
We should check for inclusion of `symKey` for both `wc://` and `novawallet://` deeplinks. Otherwise we will try to pair by the signing url