### PR TITLE
Send max via transferAll

### DIFF
--- a/app/src/androidTest/java/io/novafoundation/nova/MoonbaseSendIntagrationTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/MoonbaseSendIntagrationTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.default
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.TransferMode
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.nativeTransfer
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.runtime.di.RuntimeApi
@@ -88,7 +89,7 @@ class MoonbaseSendIntagrationTest {
         val signer = TestSigner {_ ->}
 
         val extrinsic = extrinsicBuilderFactory.create(chain, signer, accountId)
-            .nativeTransfer(accountId, chain.utilityAsset.planksFromAmount(BigDecimal.ONE), keepAlive = true)
+            .nativeTransfer(accountId, chain.utilityAsset.planksFromAmount(BigDecimal.ONE), TransferMode.KEEP_ALIVE)
             .buildExtrinsic()
 
         val hash = rpcCalls.submitExtrinsic(chain.id, extrinsic)

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/TransferDraft.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/TransferDraft.kt
@@ -9,11 +9,12 @@ import java.math.BigDecimal
 @Parcelize
 class TransferDraft(
     val amount: BigDecimal,
+    val transferringMaxAmount: Boolean,
     val origin: AssetPayload,
     val feePaymentCurrency: FeePaymentCurrencyParcel,
     val destination: AssetPayload,
     val recipientAddress: String,
-    val openAssetDetailsOnCompletion: Boolean,
+    val openAssetDetailsOnCompletion: Boolean
 ) : Parcelable
 
 val TransferDraft.isCrossChain

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/amount/SelectSendViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/amount/SelectSendViewModel.kt
@@ -44,6 +44,7 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.t
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.CrossChainTransfersUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.isMaxAction
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.PaymentCurrencySelectionMode
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.awaitFee
@@ -197,11 +198,13 @@ class SelectSendViewModel(
         sendInProgressFlow.value = true
 
         val fee = feeMixin.awaitFee()
+        val amountState = amountChooserMixin.amountState.first()
 
         val transfer = buildTransfer(
             origin = originChainWithAsset.first(),
             destination = destinationChainWithAsset.first(),
-            amount = amountChooserMixin.amountState.first().value ?: return@launch,
+            amount = amountState.value ?: return@launch,
+            transferringMaxAmount = amountState.inputKind.isMaxAction(),
             feePaymentCurrency = feeMixin.feePaymentCurrency(),
             address = addressInputMixin.getAddress(),
         )
@@ -321,14 +324,15 @@ class SelectSendViewModel(
             originChainWithAsset,
             destinationChainWithAsset,
             addressInputMixin.inputFlow,
-            amountChooserMixin.backPressuredAmount,
-        ) { paymentCurrency, originAsset, destinationAsset, address, amount ->
+            amountChooserMixin.backPressuredAmountState,
+        ) { paymentCurrency, originAsset, destinationAsset, address, amountState ->
             val assetTransfer = buildTransfer(
                 origin = originAsset,
                 destination = destinationAsset,
-                amount = amount,
+                amount = amountState.value,
                 feePaymentCurrency = paymentCurrency,
-                address = address
+                address = address,
+                transferringMaxAmount = amountState.inputKind.isMaxAction()
             )
 
             sendInteractor.getFee(assetTransfer, viewModelScope)
@@ -355,6 +359,7 @@ class SelectSendViewModel(
     private fun openConfirmScreen(validPayload: AssetTransferPayload) = launch {
         val transferDraft = TransferDraft(
             amount = validPayload.transfer.amount,
+            transferringMaxAmount = validPayload.transfer.transferringMaxAmount,
             origin = AssetPayload(
                 chainId = validPayload.transfer.originChain.id,
                 chainAssetId = validPayload.transfer.originChainAsset.id
@@ -376,6 +381,7 @@ class SelectSendViewModel(
         feePaymentCurrency: FeePaymentCurrency,
         destination: ChainWithAsset,
         amount: BigDecimal,
+        transferringMaxAmount: Boolean,
         address: String,
     ): AssetTransfer {
         return buildAssetTransfer(
@@ -384,6 +390,7 @@ class SelectSendViewModel(
             origin = origin,
             destination = destination,
             amount = amount,
+            transferringMaxAmount = transferringMaxAmount,
             address = address
         )
     }

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/common/AssetTransferExt.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/common/AssetTransferExt.kt
@@ -13,6 +13,7 @@ fun buildAssetTransfer(
     origin: ChainWithAsset,
     destination: ChainWithAsset,
     amount: BigDecimal,
+    transferringMaxAmount: Boolean,
     address: String,
 ): AssetTransfer {
     return BaseAssetTransfer(
@@ -23,6 +24,7 @@ fun buildAssetTransfer(
         destinationChain = destination.chain,
         destinationChainAsset = destination.asset,
         amount = amount,
+        transferringMaxAmount = transferringMaxAmount,
         feePaymentCurrency = feePaymentCurrency
     )
 }

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmSendViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmSendViewModel.kt
@@ -221,7 +221,8 @@ class ConfirmSendViewModel(
             origin = originChainWithAsset,
             destination = destinationChainWithAsset,
             amount = amount,
-            address = address
+            address = address,
+            transferringMaxAmount = transferDraft.transferringMaxAmount
         )
     }
 
@@ -281,6 +282,7 @@ class ConfirmSendViewModel(
                 amount = transferDraft.amount,
                 feePaymentCurrency = transferDraft.feePaymentCurrency.toDomain(),
                 fee = fee.originFee,
+                transferringMaxAmount = transferDraft.transferringMaxAmount
             ),
             originFee = fee.originFee,
             originCommissionAsset = feeMixin.feeAsset(),

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/ExtrinsicBuilderExt.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/ExtrinsicBuilderExt.kt
@@ -3,15 +3,41 @@ package io.novafoundation.nova.feature_wallet_api.data.network.blockhain
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.balances
 import io.novafoundation.nova.common.utils.firstExistingCallName
+import io.novafoundation.nova.common.utils.hasCall
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.runtime.definitions.types.instances.AddressInstanceConstructor
 import io.novasama.substrate_sdk_android.runtime.extrinsic.ExtrinsicBuilder
 import java.math.BigInteger
 
-fun ExtrinsicBuilder.nativeTransfer(accountId: AccountId, amount: BigInteger, keepAlive: Boolean = false): ExtrinsicBuilder {
-    val callName = if (keepAlive) "transfer_keep_alive" else runtime.metadata.balances().firstExistingCallName("transfer_allow_death", "transfer")
+enum class TransferMode {
+    KEEP_ALIVE, ALLOW_DEATH, ALL
+}
 
-    return call(
+fun ExtrinsicBuilder.nativeTransfer(accountId: AccountId, amount: BigInteger, mode: TransferMode = TransferMode.ALLOW_DEATH): ExtrinsicBuilder {
+    when (mode) {
+        TransferMode.KEEP_ALIVE -> transferKeepAlive(accountId, amount)
+        TransferMode.ALLOW_DEATH -> transferAllowDeath(accountId, amount)
+        TransferMode.ALL -> transferAll(accountId, amount)
+    }
+
+    return this
+}
+
+private fun ExtrinsicBuilder.transferKeepAlive(accountId: AccountId, amount: BigInteger) {
+    call(
+        moduleName = Modules.BALANCES,
+        callName = "transfer_keep_alive",
+        arguments = mapOf(
+            "dest" to AddressInstanceConstructor.constructInstance(runtime.typeRegistry, accountId),
+            "value" to amount
+        )
+    )
+}
+
+private fun ExtrinsicBuilder.transferAllowDeath(accountId: AccountId, amount: BigInteger) {
+    val callName = runtime.metadata.balances().firstExistingCallName("transfer_allow_death", "transfer")
+
+    call(
         moduleName = Modules.BALANCES,
         callName = callName,
         arguments = mapOf(
@@ -19,4 +45,21 @@ fun ExtrinsicBuilder.nativeTransfer(accountId: AccountId, amount: BigInteger, ke
             "value" to amount
         )
     )
+}
+
+private fun ExtrinsicBuilder.transferAll(accountId: AccountId, amount: BigInteger) {
+    val transferAllPresent = runtime.metadata.balances().hasCall("transfer_all")
+
+    if (transferAllPresent) {
+        call(
+            moduleName = Modules.BALANCES,
+            callName = "transfer_all",
+            arguments = mapOf(
+                "dest" to AddressInstanceConstructor.constructInstance(runtime.typeRegistry, accountId),
+                "keep_alive" to false
+            )
+        )
+    } else {
+        transferAllowDeath(accountId, amount)
+    }
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransfers.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransfers.kt
@@ -50,6 +50,8 @@ interface AssetTransfer : AssetTransferBase {
 
     val amount: BigDecimal
 
+    val transferringMaxAmount: Boolean
+
     override val amountPlanks: Balance
         get() = originChainAsset.planksFromAmount(amount)
 }
@@ -97,6 +99,7 @@ class BaseAssetTransfer(
     override val destinationChainAsset: Chain.Asset,
     override val feePaymentCurrency: FeePaymentCurrency,
     override val amount: BigDecimal,
+    override val transferringMaxAmount: Boolean
 ) : AssetTransfer
 
 data class WeightedAssetTransfer(
@@ -108,6 +111,7 @@ data class WeightedAssetTransfer(
     override val destinationChainAsset: Chain.Asset,
     override val feePaymentCurrency: FeePaymentCurrency,
     override val amount: BigDecimal,
+    override val transferringMaxAmount: Boolean,
     val fee: OriginFee,
 ) : AssetTransfer {
 
@@ -120,6 +124,7 @@ data class WeightedAssetTransfer(
         destinationChainAsset = assetTransfer.destinationChainAsset,
         feePaymentCurrency = assetTransfer.feePaymentCurrency,
         amount = assetTransfer.amount,
+        transferringMaxAmount = assetTransfer.transferringMaxAmount,
         fee = fee
     )
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserMixin.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/AmountChooserMixin.kt
@@ -47,7 +47,7 @@ interface AmountChooserMixinBase : CoroutineScope {
 
         val amountState: Flow<InputState<BigDecimal?>>
 
-        val backPressuredAmount: Flow<BigDecimal>
+        val backPressuredAmountState: Flow<InputState<BigDecimal>>
 
         val backPressuredPlanks: Flow<Balance>
     }
@@ -121,4 +121,16 @@ fun InputKind.isInputBlocked(): Boolean {
 
 fun InputKind.isInputAllowed(): Boolean {
     return !isInputBlocked()
+}
+
+fun InputKind.isMaxAction(): Boolean {
+    return this == InputKind.MAX_ACTION
+}
+
+fun <T, R> InputState<T>.map(transform: (T) -> R): InputState<R> {
+    return InputState(
+        value = transform(value),
+        inputKind = inputKind,
+        initiatedByUser = initiatedByUser
+    )
 }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/utility/NativeAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/utility/NativeAssetHistory.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.asset
 
 import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdentifier
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
+import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.balances
 import io.novafoundation.nova.common.utils.oneOf
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.history.realtime.RealtimeHistoryUpdate
@@ -20,6 +21,7 @@ import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.getRuntime
+import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.findEvent
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 import io.novasama.substrate_sdk_android.runtime.metadata.callOrNull
@@ -67,12 +69,13 @@ class NativeAssetHistory(
             val call = extrinsicVisit.call
             if (!call.isTransfer(runtime)) return null
 
-            val amount = bindNumber(call.arguments["value"])
+            val transferEvent = extrinsicVisit.events.findEvent(Modules.BALANCES, "Transfer") ?: return null
+            val (_, toRaw, amountRaw) = transferEvent.arguments
 
             return RealtimeHistoryUpdate.Type.Transfer(
                 senderId = extrinsicVisit.origin,
-                recipientId = bindAccountIdentifier(call.arguments["dest"]),
-                amountInPlanks = amount,
+                recipientId = bindAccountIdentifier(toRaw),
+                amountInPlanks = bindNumber(amountRaw),
                 chainAsset = chainAsset,
             )
         }
@@ -83,7 +86,8 @@ class NativeAssetHistory(
             return oneOf(
                 balances.callOrNull("transfer"),
                 balances.callOrNull("transfer_keep_alive"),
-                balances.callOrNull("transfer_allow_death")
+                balances.callOrNull("transfer_allow_death"),
+                balances.callOrNull("transfer_all")
             )
         }
     }


### PR DESCRIPTION
* Use `transferAll` when transferring max amount of native token
* Support `tranfserAll` in realtime history updates