### PR TITLE
Fix TransferFee.maxAmountDeductionFor to work for non-native tokens

### DIFF
--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/domain/send/model/TransferFee.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/domain/send/model/TransferFee.kt
@@ -28,8 +28,11 @@ data class TransferFee(
     }
 
     override fun maxAmountDeductionFor(amountAsset: Chain.Asset): Balance {
-        val submission = originFee.submissionFee.getAmount(amountAsset)
+        // Delegate submission calculation to submission fee itself
+        val submission = originFee.submissionFee.maxAmountDeductionFor(amountAsset)
+        // Delivery is always paid from executing account
         val delivery = originFee.deliveryFee?.getAmount(amountAsset).orZero()
+        // Execution is paid from the sending amount itself, so we subtract it as well since we later add it on top of sending amount
         val execution = crossChainFee?.getAmount(amountAsset).orZero()
 
         return submission + delivery + execution

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/domain/send/model/TransferFee.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/domain/send/model/TransferFee.kt
@@ -28,8 +28,10 @@ data class TransferFee(
     }
 
     override fun maxAmountDeductionFor(amountAsset: Chain.Asset): Balance {
-        return originFee.submissionFee.amount +
-            originFee.deliveryFee?.amount.orZero() +
-            crossChainFee?.getAmount(amountAsset).orZero()
+        val submission = originFee.submissionFee.getAmount(amountAsset)
+        val delivery = originFee.deliveryFee?.getAmount(amountAsset).orZero()
+        val execution = crossChainFee?.getAmount(amountAsset).orZero()
+
+        return submission + delivery + execution
     }
 }


### PR DESCRIPTION
We should use `FeeBase.getAmount(ChainAsset)` to cover cases when used asset != fee asset 