### PR TITLE
Allow to vote with total balance in OpenGov

### DIFF
--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/confirm/ConfirmContributeViewModel.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/confirm/ConfirmContributeViewModel.kt
@@ -75,7 +75,7 @@ class ConfirmContributeViewModel(
         .share()
 
     val assetModelFlow = assetFlow
-        .map { mapAssetToAssetModel(assetIconProvider, it, resourceManager) }
+        .map { mapAssetToAssetModel(assetIconProvider, it, resourceManager, it.transferableInPlanks) }
         .inBackground()
         .share()
 

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/select/CrowdloanContributeViewModel.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/contribute/select/CrowdloanContributeViewModel.kt
@@ -98,7 +98,7 @@ class CrowdloanContributeViewModel(
         .share()
 
     val assetModelFlow = assetFlow
-        .map { mapAssetToAssetModel(assetIconProvider, it, resourceManager) }
+        .map { mapAssetToAssetModel(assetIconProvider, it, resourceManager, it.transferableInPlanks) }
         .inBackground()
         .share()
 

--- a/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/main/CrowdloanViewModel.kt
+++ b/feature-crowdloan-impl/src/main/java/io/novafoundation/nova/feature_crowdloan_impl/presentation/main/CrowdloanViewModel.kt
@@ -66,7 +66,7 @@ class CrowdloanViewModel(
 
     override val assetSelectorMixin = assetSelectorFactory.create(
         scope = this,
-        amountProvider = Asset::transferable,
+        amountProvider = { option -> option.asset.transferableInPlanks },
     )
 
     val mainDescription = assetSelectorMixin.selectedAssetFlow.map {

--- a/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/data/repository/ConvictionVotingRepository.kt
+++ b/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/data/repository/ConvictionVotingRepository.kt
@@ -11,6 +11,7 @@ import io.novafoundation.nova.feature_governance_api.data.network.blockhain.mode
 import io.novafoundation.nova.feature_governance_api.data.network.offchain.model.referendum.OffChainReferendumVotingDetails
 import io.novafoundation.nova.feature_governance_api.domain.locks.ClaimSchedule
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.domain.model.BalanceLockId
 import io.novafoundation.nova.runtime.extrinsic.multi.CallBuilder
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -24,6 +25,8 @@ import java.math.BigInteger
 interface ConvictionVotingRepository {
 
     val voteLockId: BalanceLockId
+
+    suspend fun maxAvailableForVote(asset: Asset): Balance
 
     suspend fun voteLockingPeriod(chainId: ChainId): BlockNumber
 

--- a/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/delegation/delegation/create/chooseAmount/NewDelegationChooseAmountInteractor.kt
+++ b/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/delegation/delegation/create/chooseAmount/NewDelegationChooseAmountInteractor.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.common.utils.multiResult.RetriableMultiResult
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.TrackId
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicStatus
 import io.novafoundation.nova.runtime.multiNetwork.runtime.types.custom.vote.Conviction
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -11,6 +12,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface NewDelegationChooseAmountInteractor {
+
+    suspend fun maxAvailableBalanceToDelegate(asset: Asset): Balance
 
     fun delegateAssistantFlow(
         coroutineScope: CoroutineScope

--- a/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/referendum/list/ReferendaListInteractor.kt
+++ b/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/referendum/list/ReferendaListInteractor.kt
@@ -4,11 +4,17 @@ import io.novafoundation.nova.common.domain.ExtendedLoadingState
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_governance_api.data.source.SupportedGovernanceOption
 import io.novafoundation.nova.feature_governance_api.domain.referendum.filters.ReferendumTypeFilter
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.domain.SelectableAssetAndOption
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.runtime.state.SelectedAssetOptionSharedState
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface ReferendaListInteractor {
+
+    suspend fun availableVoteAmount(option: SelectableAssetAndOption): Balance
 
     fun searchReferendaListStateFlow(
         metaAccount: MetaAccount,

--- a/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/referendum/list/ReferendaListInteractor.kt
+++ b/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/referendum/list/ReferendaListInteractor.kt
@@ -6,8 +6,6 @@ import io.novafoundation.nova.feature_governance_api.data.source.SupportedGovern
 import io.novafoundation.nova.feature_governance_api.domain.referendum.filters.ReferendumTypeFilter
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.SelectableAssetAndOption
-import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
-import io.novafoundation.nova.runtime.state.SelectedAssetOptionSharedState
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/referendum/vote/VoteReferendumInteractor.kt
+++ b/feature-governance-api/src/main/java/io/novafoundation/nova/feature_governance_api/domain/referendum/vote/VoteReferendumInteractor.kt
@@ -5,11 +5,15 @@ import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmis
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.AccountVote
 import io.novafoundation.nova.feature_governance_api.data.network.blockhain.model.ReferendumId
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface VoteReferendumInteractor {
+
+    suspend fun maxAvailableForVote(asset: Asset): Balance
 
     fun voteAssistantFlow(referendumId: ReferendumId, scope: CoroutineScope): Flow<GovernanceVoteAssistant>
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/data/repository/v1/GovV1ConvictionVotingRepository.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/data/repository/v1/GovV1ConvictionVotingRepository.kt
@@ -21,6 +21,7 @@ import io.novafoundation.nova.feature_governance_impl.data.repository.common.bin
 import io.novafoundation.nova.feature_governance_impl.data.repository.common.votersFor
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.data.repository.BalanceLocksRepository
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.runtime.extrinsic.multi.CallBuilder
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.asset
@@ -43,6 +44,10 @@ class GovV1ConvictionVotingRepository(
 ) : ConvictionVotingRepository {
 
     override val voteLockId = DEMOCRACY_ID
+
+    override suspend fun maxAvailableForVote(asset: Asset): Balance {
+       return asset.freeInPlanks
+    }
 
     override suspend fun voteLockingPeriod(chainId: ChainId): BlockNumber {
         val runtime = chainRegistry.getRuntime(chainId)

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/data/repository/v1/GovV1ConvictionVotingRepository.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/data/repository/v1/GovV1ConvictionVotingRepository.kt
@@ -46,7 +46,7 @@ class GovV1ConvictionVotingRepository(
     override val voteLockId = DEMOCRACY_ID
 
     override suspend fun maxAvailableForVote(asset: Asset): Balance {
-       return asset.freeInPlanks
+        return asset.freeInPlanks
     }
 
     override suspend fun voteLockingPeriod(chainId: ChainId): BlockNumber {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/data/repository/v2/GovV2ConvictionVotingRepository.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/data/repository/v2/GovV2ConvictionVotingRepository.kt
@@ -37,6 +37,7 @@ import io.novafoundation.nova.feature_governance_impl.data.repository.common.bin
 import io.novafoundation.nova.feature_governance_impl.data.repository.common.toOffChainVotes
 import io.novafoundation.nova.feature_governance_impl.data.repository.common.votersFor
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.domain.model.BalanceLockId
 import io.novafoundation.nova.runtime.ext.accountIdOf
 import io.novafoundation.nova.runtime.ext.externalApi
@@ -63,6 +64,10 @@ class GovV2ConvictionVotingRepository(
 ) : ConvictionVotingRepository {
 
     override val voteLockId = BalanceLockId.fromFullId("pyconvot")
+
+    override suspend fun maxAvailableForVote(asset: Asset): Balance {
+        return asset.totalInPlanks
+    }
 
     override suspend fun voteLockingPeriod(chainId: ChainId): BlockNumber {
         val runtime = chainRegistry.getRuntime(chainId)

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/modules/screens/TinderGovModule.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/modules/screens/TinderGovModule.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.common.data.network.NetworkApiCreator
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.core_db.dao.TinderGovDao
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_governance_api.data.source.GovernanceSourceRegistry
 import io.novafoundation.nova.feature_governance_impl.domain.summary.ReferendaSummaryInteractor
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.tindergov.TinderGovBasketInteractor
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.tindergov.TinderGovInteractor
@@ -77,7 +78,8 @@ class TinderGovModule {
         preImageParser: ReferendumPreImageParser,
         tinderGovVotingPowerRepository: TinderGovVotingPowerRepository,
         referendaFilteringProvider: ReferendaFilteringProvider,
-        assetUseCase: AssetUseCase
+        assetUseCase: AssetUseCase,
+        governanceSourceRegistry: GovernanceSourceRegistry,
     ): TinderGovInteractor = RealTinderGovInteractor(
         governanceSharedState,
         referendaSharedComputation,
@@ -85,7 +87,8 @@ class TinderGovModule {
         preImageParser,
         tinderGovVotingPowerRepository,
         referendaFilteringProvider,
-        assetUseCase
+        governanceSourceRegistry,
+        assetUseCase,
     )
 
     @Provides
@@ -114,21 +117,19 @@ class TinderGovModule {
     @FeatureScope
     fun provideTinderGovBasketInteractor(
         governanceSharedState: GovernanceSharedState,
-        referendaSharedComputation: ReferendaSharedComputation,
         accountRepository: AccountRepository,
         tinderGovBasketRepository: TinderGovBasketRepository,
         tinderGovVotingPowerRepository: TinderGovVotingPowerRepository,
-        referendaFilteringProvider: ReferendaFilteringProvider,
         assetUseCase: AssetUseCase,
-        tinderGovInteractor: TinderGovInteractor
+        tinderGovInteractor: TinderGovInteractor,
+        governanceSourceRegistry: GovernanceSourceRegistry,
     ): TinderGovBasketInteractor = RealTinderGovBasketInteractor(
         governanceSharedState = governanceSharedState,
-        referendaSharedComputation = referendaSharedComputation,
         accountRepository = accountRepository,
         tinderGovBasketRepository = tinderGovBasketRepository,
         tinderGovVotingPowerRepository = tinderGovVotingPowerRepository,
-        referendaFilteringProvider = referendaFilteringProvider,
         assetUseCase = assetUseCase,
-        tinderGovInteractor = tinderGovInteractor
+        tinderGovInteractor = tinderGovInteractor,
+        governanceSourceRegistry = governanceSourceRegistry
     )
 }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/RealNewDelegationChooseAmountInteractor.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/RealNewDelegationChooseAmountInteractor.kt
@@ -18,6 +18,7 @@ import io.novafoundation.nova.feature_governance_api.domain.delegation.delegatio
 import io.novafoundation.nova.feature_governance_impl.data.GovernanceSharedState
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.data.repository.BalanceLocksRepository
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicStatus
 import io.novafoundation.nova.runtime.extrinsic.multi.CallBuilder
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -41,6 +42,11 @@ class RealNewDelegationChooseAmountInteractor(
     private val computationalCache: ComputationalCache,
     private val accountRepository: AccountRepository,
 ) : NewDelegationChooseAmountInteractor {
+
+    override suspend fun maxAvailableBalanceToDelegate(asset: Asset): Balance {
+        val (_, source) = useSelectedGovernance()
+        return source.convictionVoting.maxAvailableForVote(asset)
+    }
 
     override fun delegateAssistantFlow(coroutineScope: CoroutineScope): Flow<DelegateAssistant> {
         return computationalCache.useSharedFlow(DELEGATION_ASSISTANT_CACHE_KEY, coroutineScope) {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationPayload.kt
@@ -9,5 +9,6 @@ class ChooseDelegationAmountValidationPayload(
     val fee: Fee,
     val asset: Asset,
     val amount: BigDecimal,
+    val maxAvailableAmount: BigDecimal,
     val delegate: AccountId
 )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationSystem.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.validation.ValidationSystem
 import io.novafoundation.nova.common.validation.ValidationSystemBuilder
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_governance_impl.data.GovernanceSharedState
+import io.novafoundation.nova.feature_wallet_api.domain.validation.hasEnoughBalance
 import io.novafoundation.nova.feature_wallet_api.domain.validation.hasEnoughFreeBalance
 import io.novafoundation.nova.feature_wallet_api.domain.validation.sufficientBalance
 
@@ -29,9 +30,9 @@ fun ValidationSystem.Companion.chooseDelegationAmount(
         }
     )
 
-    hasEnoughFreeBalance(
-        asset = { it.asset },
-        fee = { it.fee },
+    hasEnoughBalance(
+        availableBalance = { it.maxAvailableAmount },
+        chainAsset = { it.asset.token.configuration },
         requestedAmount = { it.amount },
         error = ChooseDelegationAmountValidationFailure::AmountIsTooBig
     )

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/delegation/delegation/create/chooseAmount/validation/ChooseDelegationAmountValidationSystem.kt
@@ -6,7 +6,6 @@ import io.novafoundation.nova.common.validation.ValidationSystemBuilder
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_governance_impl.data.GovernanceSharedState
 import io.novafoundation.nova.feature_wallet_api.domain.validation.hasEnoughBalance
-import io.novafoundation.nova.feature_wallet_api.domain.validation.hasEnoughFreeBalance
 import io.novafoundation.nova.feature_wallet_api.domain.validation.sufficientBalance
 
 typealias ChooseDelegationAmountValidationSystem = ValidationSystem<ChooseDelegationAmountValidationPayload, ChooseDelegationAmountValidationFailure>

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/list/RealReferendaListInteractor.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/list/RealReferendaListInteractor.kt
@@ -35,7 +35,6 @@ import io.novafoundation.nova.feature_governance_impl.domain.referendum.list.rep
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.list.sorting.ReferendaSortingProvider
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.SelectableAssetAndOption
-import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.state.selectedOption
 import io.novasama.substrate_sdk_android.hash.isPositive

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/RealVoteReferendumInteractor.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/RealVoteReferendumInteractor.kt
@@ -19,7 +19,9 @@ import io.novafoundation.nova.feature_governance_api.data.source.SupportedGovern
 import io.novafoundation.nova.feature_governance_api.domain.referendum.vote.GovernanceVoteAssistant
 import io.novafoundation.nova.feature_governance_api.domain.referendum.vote.VoteReferendumInteractor
 import io.novafoundation.nova.feature_governance_impl.data.GovernanceSharedState
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.data.repository.BalanceLocksRepository
+import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicStatus
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -45,6 +47,13 @@ class RealVoteReferendumInteractor(
     private val locksRepository: BalanceLocksRepository,
     private val computationalCache: ComputationalCache,
 ) : VoteReferendumInteractor {
+
+    override suspend fun maxAvailableForVote(asset: Asset): Balance {
+        val governanceOption = selectedChainState.selectedOption()
+        val governanceSource = governanceSourceRegistry.sourceFor(governanceOption)
+
+        return governanceSource.convictionVoting.maxAvailableForVote(asset)
+    }
 
     override fun voteAssistantFlow(referendumId: ReferendumId, scope: CoroutineScope): Flow<GovernanceVoteAssistant> {
         return voteAssistantFlow(listOf(referendumId), scope)

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/common/VoteValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/common/VoteValidationPayload.kt
@@ -14,7 +14,9 @@ interface VoteValidationPayload {
 
     val trackVoting: List<Voting>
 
-    val maxAmount: BigDecimal
+    val amount: BigDecimal
+
+    val maxAvailableAmount: BigDecimal
 
     val fee: Fee
 }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/referendum/VoteReferendaValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/referendum/VoteReferendaValidationPayload.kt
@@ -13,8 +13,9 @@ data class VoteReferendaValidationPayload(
     override val onChainReferenda: List<OnChainReferendum>,
     override val asset: Asset,
     override val trackVoting: List<Voting>,
-    override val maxAmount: BigDecimal,
+    override val amount: BigDecimal,
     val voteType: VoteType?,
     val conviction: Conviction?,
-    override val fee: Fee
+    override val fee: Fee,
+    override val maxAvailableAmount: BigDecimal
 ) : VoteValidationPayload

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/referendum/VoteReferendumValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/referendum/VoteReferendumValidationSystem.kt
@@ -8,7 +8,7 @@ import io.novafoundation.nova.feature_governance_impl.data.GovernanceSharedState
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.vote.validations.common.MaximumTrackVotesNotReachedValidation
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.vote.validations.common.NotDelegatingInTrackValidation
 import io.novafoundation.nova.feature_governance_impl.domain.referendum.vote.validations.common.ReferendumIsOngoingValidation
-import io.novafoundation.nova.feature_wallet_api.domain.validation.hasEnoughFreeBalance
+import io.novafoundation.nova.feature_wallet_api.domain.validation.hasEnoughBalance
 import io.novafoundation.nova.feature_wallet_api.domain.validation.sufficientBalance
 
 typealias VoteReferendumValidationSystem = ValidationSystem<VoteReferendaValidationPayload, VoteReferendumValidationFailure>
@@ -19,10 +19,10 @@ fun ValidationSystem.Companion.voteReferendumValidationSystem(
     governanceSourceRegistry: GovernanceSourceRegistry,
     governanceSharedState: GovernanceSharedState,
 ): VoteReferendumValidationSystem = ValidationSystem {
-    hasEnoughFreeBalance(
-        asset = { it.asset },
-        fee = { it.fee },
-        requestedAmount = { it.maxAmount },
+    hasEnoughBalance(
+        availableBalance = { it.maxAvailableAmount },
+        requestedAmount = { it.amount },
+        chainAsset = { it.asset.token.configuration },
         error = VoteReferendumValidationFailure::AmountIsTooBig
     )
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/tindergov/VoteTinderGovValidationPayload.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/tindergov/VoteTinderGovValidationPayload.kt
@@ -14,10 +14,11 @@ data class VoteTinderGovValidationPayload(
     override val asset: Asset,
     override val trackVoting: List<Voting>,
     override val fee: Fee,
+    override val maxAvailableAmount: BigDecimal,
     val basket: List<TinderGovBasketItem>
 ) : VoteValidationPayload {
 
-    override val maxAmount: BigDecimal
+    override val amount: BigDecimal
         get() {
             val amount = basket.maxOf { it.amount }
             return asset.token.amountFromPlanks(amount)

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/tindergov/VoteTinderGovValidationSystem.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/domain/referendum/vote/validations/tindergov/VoteTinderGovValidationSystem.kt
@@ -20,7 +20,7 @@ fun ValidationSystem.Companion.voteTinderGovValidationSystem(
     hasEnoughFreeBalance(
         asset = { it.asset },
         fee = { it.fee },
-        requestedAmount = { it.maxAmount },
+        requestedAmount = { it.amount },
         error = VoteTinderGovValidationFailure::AmountIsTooBig
     )
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/chooseAmount/NewDelegationChooseAmountViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/chooseAmount/NewDelegationChooseAmountViewModel.kt
@@ -27,6 +27,7 @@ import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vot
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.maxAction.actualAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.setAmountInput
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
@@ -34,8 +35,6 @@ import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.await
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.connectWith
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.createDefault
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.maxAction.MaxActionProviderFactory
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.maxAction.MaxBalanceType
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.maxAction.create
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -82,7 +81,7 @@ class NewDelegationChooseAmountViewModel(
         viewModelScope = viewModelScope,
         assetInFlow = selectedAsset,
         feeLoaderMixin = originFeeMixin,
-        maxBalanceType = MaxBalanceType.FREE
+        balance = interactor::maxAvailableBalanceToDelegate
     )
 
     val amountChooserMixin = amountChooserMixinFactory.create(
@@ -175,7 +174,8 @@ class NewDelegationChooseAmountViewModel(
             asset = selectedAsset.first(),
             fee = originFeeMixin.awaitFee(),
             amount = amountChooserMixin.amount.first(),
-            delegate = payload.delegate
+            delegate = payload.delegate,
+            maxAvailableAmount = maxActionProvider.maxAvailableBalance.first().actualAmount
         )
 
         validationExecutor.requireValid(

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/confirm/NewDelegationConfirmViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/delegation/delegation/create/confirm/NewDelegationConfirmViewModel.kt
@@ -40,6 +40,7 @@ import io.novafoundation.nova.feature_governance_impl.presentation.track.TrackMo
 import io.novafoundation.nova.feature_governance_impl.presentation.track.formatTracks
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.WithFeeLoaderMixin
@@ -166,11 +167,14 @@ class NewDelegationConfirmViewModel(
     fun confirmClicked() = launch {
         val asset = assetFlow.first()
         val amountPlanks = asset.token.planksFromAmount(payload.amount)
+        val maxAmount = interactor.maxAvailableBalanceToDelegate(asset)
+        val maxPlanks = asset.token.amountFromPlanks(maxAmount)
         val validationPayload = ChooseDelegationAmountValidationPayload(
             asset = asset,
             fee = decimalFee,
             amount = payload.amount,
-            delegate = payload.delegate
+            delegate = payload.delegate,
+            maxAvailableAmount = maxPlanks
         )
 
         validationExecutor.requireValid(

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/list/ReferendaListViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/list/ReferendaListViewModel.kt
@@ -79,7 +79,7 @@ class ReferendaListViewModel(
 
     override val assetSelectorMixin = assetSelectorFactory.create(
         scope = this,
-        amountProvider = Asset::free
+        amountProvider = referendaListInteractor::availableVoteAmount
     )
 
     private val selectedMetaAccount = selectedAccountUseCase.selectedMetaAccountFlow()

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/search/di/ReferendaSearchModule.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/search/di/ReferendaSearchModule.kt
@@ -15,6 +15,7 @@ import io.novafoundation.nova.feature_governance_impl.data.GovernanceSharedState
 import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRouter
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.common.ReferendumFormatter
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.search.ReferendaSearchViewModel
+import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.assetSelector.AssetSelectorFactory
 
 @Module(includes = [ViewModelModule::class])
@@ -24,7 +25,7 @@ class ReferendaSearchModule {
     @IntoMap
     @ViewModelKey(ReferendaSearchViewModel::class)
     fun provideViewModel(
-        assetSelectorFactory: AssetSelectorFactory,
+        tokenUseCase: TokenUseCase,
         referendaListInteractor: ReferendaListInteractor,
         selectedAccountUseCase: SelectedAccountUseCase,
         selectedAssetSharedState: GovernanceSharedState,
@@ -33,7 +34,7 @@ class ReferendaSearchModule {
         resourceManager: ResourceManager
     ): ViewModel {
         return ReferendaSearchViewModel(
-            assetSelectorFactory = assetSelectorFactory,
+            tokenUseCase = tokenUseCase,
             referendaListInteractor = referendaListInteractor,
             selectedAccountUseCase = selectedAccountUseCase,
             selectedAssetSharedState = selectedAssetSharedState,

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/search/di/ReferendaSearchModule.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/search/di/ReferendaSearchModule.kt
@@ -16,7 +16,6 @@ import io.novafoundation.nova.feature_governance_impl.presentation.GovernanceRou
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.common.ReferendumFormatter
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.search.ReferendaSearchViewModel
 import io.novafoundation.nova.feature_wallet_api.domain.TokenUseCase
-import io.novafoundation.nova.feature_wallet_api.presentation.mixin.assetSelector.AssetSelectorFactory
 
 @Module(includes = [ViewModelModule::class])
 class ReferendaSearchModule {

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmReferendumVoteViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmReferendumVoteViewModel.kt
@@ -26,6 +26,7 @@ import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vot
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.hints.ReferendumVoteHintsMixinFactory
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitFee
@@ -150,15 +151,19 @@ class ConfirmReferendumVoteViewModel(
 
     private suspend fun getValidationPayload(): VoteReferendaValidationPayload {
         val voteAssistant = voteAssistantFlow.first()
+        val asset = assetFlow.first()
+        val maxAmount = interactor.maxAvailableForVote(asset)
+        val maxPlanks = asset.token.amountFromPlanks(maxAmount)
 
         return VoteReferendaValidationPayload(
             onChainReferenda = voteAssistant.onChainReferenda,
-            asset = assetFlow.first(),
+            asset = asset,
             trackVoting = voteAssistant.trackVoting,
-            maxAmount = payload.vote.amount,
+            amount = payload.vote.amount,
             conviction = payload.vote.conviction,
             voteType = payload.vote.voteType,
-            fee = originFeeMixin.awaitFee()
+            fee = originFeeMixin.awaitFee(),
+            maxAvailableAmount = maxPlanks
         )
     }
 }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/confirm/ConfirmTinderGovVoteViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/tindergov/confirm/ConfirmTinderGovVoteViewModel.kt
@@ -25,6 +25,7 @@ import io.novafoundation.nova.feature_governance_impl.presentation.common.confir
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.common.LocksChangeFormatter
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.vote.hints.ReferendumVoteHintsMixinFactory
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeLoaderMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.awaitFee
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AmountModel
@@ -164,13 +165,17 @@ class ConfirmTinderGovVoteViewModel(
     private suspend fun getValidationPayload(): VoteTinderGovValidationPayload {
         val voteAssistant = voteAssistantFlow.first()
         val basket = basketFlow.first().values.toList()
+        val asset = assetFlow.first()
+        val maxAvailablePlanks = interactor.maxAvailableForVote(asset)
+        val maxAvailableAmount = asset.token.amountFromPlanks(maxAvailablePlanks)
 
         return VoteTinderGovValidationPayload(
             onChainReferenda = voteAssistant.onChainReferenda,
-            asset = assetFlow.first(),
+            asset = asset,
             trackVoting = voteAssistant.trackVoting,
             fee = originFeeMixin.awaitFee(),
-            basket = basket
+            basket = basket,
+            maxAvailableAmount = maxAvailableAmount
         )
     }
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/mappers/Asset.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/mappers/Asset.kt
@@ -6,7 +6,9 @@ import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.images.Icon
 import io.novafoundation.nova.feature_account_api.presenatation.chain.getAssetIconOrFallback
 import io.novafoundation.nova.feature_wallet_api.R
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetModel
 import java.math.BigDecimal
@@ -15,11 +17,11 @@ fun mapAssetToAssetModel(
     assetIconProvider: AssetIconProvider,
     asset: Asset,
     resourceManager: ResourceManager,
+    balance: Balance,
     icon: Icon = assetIconProvider.getAssetIconOrFallback(asset.token.configuration),
-    retrieveAmount: (Asset) -> BigDecimal = Asset::transferable,
     @StringRes patternId: Int? = R.string.common_available_format
 ): AssetModel {
-    val amount = retrieveAmount(asset).formatTokenAmount(asset.token.configuration)
+    val amount = balance.formatPlanks(asset.token.configuration)
     val formattedAmount = patternId?.let { resourceManager.getString(patternId, amount) } ?: amount
 
     return with(asset) {

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/mappers/Asset.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/mappers/Asset.kt
@@ -9,9 +9,7 @@ import io.novafoundation.nova.feature_wallet_api.R
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
-import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AssetModel
-import java.math.BigDecimal
 
 fun mapAssetToAssetModel(
     assetIconProvider: AssetIconProvider,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/Asset.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/Asset.kt
@@ -88,7 +88,3 @@ fun Asset.transferableReplacingFrozen(newFrozen: Balance): Balance {
 fun Asset.regularTransferableBalance(): Balance {
     return TransferableMode.REGULAR.calculateTransferable(freeInPlanks, frozenInPlanks, reservedInPlanks)
 }
-
-fun Asset.availableToVote(): Balance {
-    return freeInPlanks
-}

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/HasEnoughBalanceValidation.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/HasEnoughBalanceValidation.kt
@@ -11,7 +11,6 @@ import io.novafoundation.nova.common.validation.ValidationSystemBuilder
 import io.novafoundation.nova.common.validation.isTrueOrError
 import io.novafoundation.nova.feature_account_api.data.model.decimalAmountByExecutingAccount
 import io.novafoundation.nova.feature_wallet_api.R
-import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/HasEnoughBalanceValidation.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/HasEnoughBalanceValidation.kt
@@ -11,6 +11,7 @@ import io.novafoundation.nova.common.validation.ValidationSystemBuilder
 import io.novafoundation.nova.common.validation.isTrueOrError
 import io.novafoundation.nova.feature_account_api.data.model.decimalAmountByExecutingAccount
 import io.novafoundation.nova.feature_wallet_api.R
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatTokenAmount
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -23,18 +24,18 @@ interface NotEnoughFreeBalanceError {
     val freeAfterFees: BigDecimal
 }
 
-class HasEnoughFreeBalanceValidation<P, E>(
-    private val asset: (P) -> Asset,
-    private val fee: SimpleFeeProducer<P>,
+class HasEnoughBalanceValidation<P, E>(
+    private val chainAsset: (P) -> Chain.Asset,
+    private val availableBalance: AmountProducer<P>,
     private val requestedAmount: AmountProducer<P>,
     private val error: HasEnoughFreeBalanceErrorProducer<E>
 ) : Validation<P, E> {
 
     override suspend fun validate(value: P): ValidationStatus<E> {
-        val freeBalanceAfterFees = asset(value).free - fee(value)?.decimalAmountByExecutingAccount.orZero()
+        val balanceAfterFees = availableBalance(value)
 
-        return (freeBalanceAfterFees >= requestedAmount(value)) isTrueOrError {
-            error(asset(value).token.configuration, freeBalanceAfterFees.atLeastZero())
+        return (balanceAfterFees >= requestedAmount(value)) isTrueOrError {
+            error(chainAsset(value), balanceAfterFees.atLeastZero())
         }
     }
 }
@@ -45,7 +46,28 @@ fun <P, E> ValidationSystemBuilder<P, E>.hasEnoughFreeBalance(
     requestedAmount: AmountProducer<P>,
     error: HasEnoughFreeBalanceErrorProducer<E>
 ) {
-    validate(HasEnoughFreeBalanceValidation(asset, fee, requestedAmount, error))
+    hasEnoughBalance(
+        chainAsset = { asset(it).token.configuration },
+        requestedAmount = requestedAmount,
+        error = error,
+        availableBalance = { asset(it).free - fee(it)?.decimalAmountByExecutingAccount.orZero() }
+    )
+}
+
+fun <P, E> ValidationSystemBuilder<P, E>.hasEnoughBalance(
+    chainAsset: (P) -> Chain.Asset,
+    availableBalance: AmountProducer<P>,
+    requestedAmount: AmountProducer<P>,
+    error: HasEnoughFreeBalanceErrorProducer<E>
+) {
+    validate(
+        HasEnoughBalanceValidation(
+            chainAsset = chainAsset,
+            availableBalance = availableBalance,
+            requestedAmount = requestedAmount,
+            error = error
+        )
+    )
 }
 
 fun handleNotEnoughFreeBalanceError(

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/maxAction/AssetMaxActionProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/maxAction/AssetMaxActionProvider.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.map
 
 class AssetMaxActionProvider(
     private val assetFlow: Flow<Asset>,
-    private val assetField: (Asset) -> Balance,
+    private val assetField: suspend (Asset) -> Balance,
 ) : MaxActionProvider {
 
     override val maxAvailableBalance: Flow<MaxAvailableBalance> = assetFlow.map { asset ->

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/maxAction/MaxActionProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/amountChooser/maxAction/MaxActionProvider.kt
@@ -28,6 +28,10 @@ interface MaxActionProviderDsl {
 
     companion object : MaxActionProviderDsl
 
+    fun Flow<Asset>.providingMaxOf(field: suspend (Asset) -> Balance): MaxActionProvider {
+        return AssetMaxActionProvider(this, field)
+    }
+
     fun Flow<Asset>.providingMaxOf(field: (Asset) -> Balance): MaxActionProvider {
         return AssetMaxActionProvider(this, field)
     }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/assetSelector/AssetSelectorProvider.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/assetSelector/AssetSelectorProvider.kt
@@ -9,7 +9,6 @@ import io.novafoundation.nova.common.view.bottomSheet.list.dynamic.DynamicListBo
 import io.novafoundation.nova.feature_account_api.presenatation.chain.iconOrFallback
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapAssetToAssetModel
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
-import io.novafoundation.nova.feature_wallet_api.domain.AssetAndOption
 import io.novafoundation.nova.feature_wallet_api.domain.SelectableAssetAndOption
 import io.novafoundation.nova.feature_wallet_api.domain.SelectableAssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
@@ -21,7 +20,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
-import java.math.BigDecimal
 
 class AssetSelectorFactory(
     private val assetIconProvider: AssetIconProvider,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/maxAction/MaxActionProviderFactory.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/maxAction/MaxActionProviderFactory.kt
@@ -24,8 +24,8 @@ class MaxActionProviderFactory(
         viewModelScope: CoroutineScope,
         assetInFlow: Flow<Asset>,
         feeLoaderMixin: FeeLoaderMixinV2<F, *>,
-        balance: (Asset) -> BigInteger,
-        deductEd: Flow<Boolean>
+        balance: suspend (Asset) -> BigInteger,
+        deductEd: Flow<Boolean> = flowOf(false)
     ): MaxActionProvider {
         return MaxActionProvider.create(viewModelScope) {
             assetInFlow.providingMaxOf(balance)


### PR DESCRIPTION
* Use total only for OpenGov by introducing new method to `convictionVoting` repository
* Replace all hard-coded useages of "free" balance with usages of `convictionVoting.maxAvailableToVote(asset)` method
* Checked for governance selector, voting, delegating and tinder-gov (set vote, vote validation, basket cleanup), including validations
* Small refactoring in tinder-gov