### PR TITLE
Fix/dynamic xcm bugs

### DIFF
--- a/app/src/androidTest/java/io/novafoundation/nova/DryRunIntegrationTest.kt
+++ b/app/src/androidTest/java/io/novafoundation/nova/DryRunIntegrationTest.kt
@@ -76,7 +76,8 @@ class DryRunIntegrationTest : BaseIntegrationTest() {
         val dryRunEffects = dryRunApi.dryRunCall(
             originCaller = OriginCaller.System.Signed(origin),
             call = call,
-            chainId = polkadot.id
+            chainId = polkadot.id,
+            xcmResultsVersion = XcmVersion.V4
         )
             .getOrThrow()
             .toResult().getOrThrow()

--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -261,9 +261,13 @@ fun BigDecimal.coerceInOrNull(from: BigDecimal, to: BigDecimal): BigDecimal? = i
 
 fun Long.daysFromMillis() = TimeUnit.MILLISECONDS.toDays(this)
 
-inline fun <T> Collection<T>.sumByBigInteger(extractor: (T) -> BigInteger) = fold(BigInteger.ZERO) { acc, element ->
-    acc + extractor(element)
-}
+@Deprecated(
+    message = "Use sumOf from stdlib instead",
+    replaceWith = ReplaceWith(
+        expression = "this.sumOf(extractor)",
+    )
+)
+inline fun <T> Collection<T>.sumByBigInteger(extractor: (T) -> BigInteger) = sumOf { extractor(it) }
 
 fun Iterable<BigInteger>.sum() = sumOf { it }
 

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/events/model/DepositEvent.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/events/model/DepositEvent.kt
@@ -1,9 +1,10 @@
 package io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.events.model
 
+import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novasama.substrate_sdk_android.runtime.AccountId
 
 class DepositEvent(
-    val destination: AccountId,
+    val destination: AccountIdKey,
     val amount: Balance,
 )

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/events/model/DepositEvent.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/events/model/DepositEvent.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.
 
 import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
-import io.novasama.substrate_sdk_android.runtime.AccountId
 
 class DepositEvent(
     val destination: AccountIdKey,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransfers.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransfers.kt
@@ -11,8 +11,6 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Ba
 import io.novafoundation.nova.feature_wallet_api.domain.model.OriginFee
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
-import io.novafoundation.nova.runtime.ext.accountIdKeyOf
-import io.novafoundation.nova.runtime.ext.accountIdOf
 import io.novafoundation.nova.runtime.ext.accountIdOrDefault
 import io.novafoundation.nova.runtime.ext.accountIdOrNull
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransfers.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/network/blockhain/assets/tranfers/AssetTransfers.kt
@@ -1,5 +1,7 @@
 package io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.tranfers
 
+import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.address.intoKey
 import io.novafoundation.nova.common.utils.amountFromPlanks
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicSubmission
 import io.novafoundation.nova.feature_account_api.data.fee.FeePaymentCurrency
@@ -9,7 +11,9 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Ba
 import io.novafoundation.nova.feature_wallet_api.domain.model.OriginFee
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.domain.model.planksFromAmount
+import io.novafoundation.nova.runtime.ext.accountIdKeyOf
 import io.novafoundation.nova.runtime.ext.accountIdOf
+import io.novafoundation.nova.runtime.ext.accountIdOrDefault
 import io.novafoundation.nova.runtime.ext.accountIdOrNull
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -31,8 +35,8 @@ interface AssetTransferDirection {
 
 interface AssetTransferBase : AssetTransferDirection {
 
-    val recipientAccountId: AccountId
-        get() = destinationChain.accountIdOf(recipient)
+    val recipientAccountId: AccountIdKey
+        get() = destinationChain.accountIdOrDefault(recipient).intoKey()
 
     val recipient: String
 

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/repository/ParachainInfoExt.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/data/repository/ParachainInfoExt.kt
@@ -1,9 +1,18 @@
 package io.novafoundation.nova.feature_wallet_api.data.repository
 
 import io.novafoundation.nova.feature_xcm_api.chain.XcmChain
+import io.novafoundation.nova.feature_xcm_api.multiLocation.AbsoluteMultiLocation
+import io.novafoundation.nova.feature_xcm_api.multiLocation.ChainLocation
+import io.novafoundation.nova.feature_xcm_api.multiLocation.chainLocation
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.repository.ParachainInfoRepository
 
 suspend fun ParachainInfoRepository.getXcmChain(chain: Chain): XcmChain {
     return XcmChain(paraId(chain.id), chain)
+}
+
+suspend fun ParachainInfoRepository.getChainLocation(chainId: ChainId): ChainLocation {
+    val location = AbsoluteMultiLocation.chainLocation(paraId(chainId))
+    return ChainLocation(chainId, location)
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/CrossChainTransfersConfigurationExt.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/CrossChainTransfersConfigurationExt.kt
@@ -35,7 +35,7 @@ fun CrossChainTransfersConfiguration.hasDeliveryFee(
     return dynamic.hasDeliveryFee(origin, destination) ?: legacy.hasDeliveryFee(origin.chainId)
 }
 
-fun CrossChainTransfersConfiguration.transferConfiguration(
+suspend fun CrossChainTransfersConfiguration.transferConfiguration(
     originChain: XcmChain,
     originAsset: Chain.Asset,
     destinationChain: XcmChain,

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/DynamicCrossChainTransferConfiguration.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/DynamicCrossChainTransferConfiguration.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.CrossChainTransferConfigurationBase
 import io.novafoundation.nova.feature_xcm_api.multiLocation.AbsoluteMultiLocation
+import io.novafoundation.nova.feature_xcm_api.multiLocation.ChainLocation
 import io.novafoundation.nova.feature_xcm_api.multiLocation.RelativeMultiLocation
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 
@@ -15,11 +16,6 @@ class DynamicCrossChainTransferConfiguration(
     override val originChainId: ChainId = originChainLocation.chainId
     override val destinationChainId: ChainId = destinationChainLocation.chainId
     override val remoteReserveChainId: ChainId? = remoteReserveChainLocation?.chainId
-
-    class ChainLocation(
-        val chainId: ChainId,
-        val location: AbsoluteMultiLocation
-    )
 }
 
 fun DynamicCrossChainTransferConfiguration.destinationChainLocationOnOrigin(): RelativeMultiLocation {

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/DynamicCrossChainTransferConfiguration.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/DynamicCrossChainTransferConfiguration.kt
@@ -1,7 +1,6 @@
 package io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic
 
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.CrossChainTransferConfigurationBase
-import io.novafoundation.nova.feature_xcm_api.multiLocation.AbsoluteMultiLocation
 import io.novafoundation.nova.feature_xcm_api.multiLocation.ChainLocation
 import io.novafoundation.nova.feature_xcm_api.multiLocation.RelativeMultiLocation
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/DynamicCrossChainTransfersConfigurationExt.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/DynamicCrossChainTransfersConfigurationExt.kt
@@ -84,9 +84,9 @@ private fun XcmChain.shouldUseReserveTransferTo(destination: XcmChain): Boolean 
 }
 
 private fun XcmChain.shouldUseTeleportTo(destination: XcmChain): Boolean {
-    return isRelay() && destination.isSystemChain()
-        || isSystemChain() && destination.isRelay()
-        || isSystemChain() && destination.isSystemChain()
+    return isRelay() && destination.isSystemChain() ||
+        isSystemChain() && destination.isRelay() ||
+        isSystemChain() && destination.isSystemChain()
 }
 
 /**

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/DynamicCrossChainTransfersConfigurationExt.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/DynamicCrossChainTransfersConfigurationExt.kt
@@ -2,13 +2,13 @@ package io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic
 
 import io.novafoundation.nova.common.utils.graph.Edge
 import io.novafoundation.nova.common.utils.graph.SimpleEdge
-import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.DynamicCrossChainTransferConfiguration.ChainLocation
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.DynamicCrossChainTransfersConfiguration.AssetTransfers
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve.isRemote
 import io.novafoundation.nova.feature_xcm_api.chain.XcmChain
 import io.novafoundation.nova.feature_xcm_api.chain.absoluteLocation
 import io.novafoundation.nova.feature_xcm_api.chain.isRelay
 import io.novafoundation.nova.feature_xcm_api.chain.isSystemChain
+import io.novafoundation.nova.feature_xcm_api.multiLocation.ChainLocation
 import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
@@ -47,7 +47,7 @@ fun DynamicCrossChainTransfersConfiguration.availableInDestinations(): List<Edge
     }
 }
 
-fun DynamicCrossChainTransfersConfiguration.transferConfiguration(
+suspend fun DynamicCrossChainTransfersConfiguration.transferConfiguration(
     originXcmChain: XcmChain,
     originAsset: Chain.Asset,
     destinationXcmChain: XcmChain,
@@ -61,12 +61,12 @@ fun DynamicCrossChainTransfersConfiguration.transferConfiguration(
     val reserve = reserveRegistry.getReserve(originAsset)
 
     val originChainLocation = originXcmChain.absoluteLocation()
-    val assetLocationOnOrigin = reserve.location.fromPointOfViewOf(originChainLocation)
+    val assetLocationOnOrigin = reserve.tokenLocation.fromPointOfViewOf(originChainLocation)
 
     val shouldUseReserveTransfers = originXcmChain.shouldUseReserveTransferTo(destinationXcmChain)
 
     val remoteReserveChainLocation = if (shouldUseReserveTransfers && reserve.isRemote(originChain.id, destinationChain.id)) {
-        ChainLocation(reserve.chainId, reserve.location)
+        reserve.reserveChainLocation
     } else {
         null
     }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/reserve/TokenReserve.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/reserve/TokenReserve.kt
@@ -1,13 +1,14 @@
 package io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve
 
 import io.novafoundation.nova.feature_xcm_api.multiLocation.AbsoluteMultiLocation
+import io.novafoundation.nova.feature_xcm_api.multiLocation.ChainLocation
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 
 class TokenReserve(
-    val chainId: ChainId,
-    val location: AbsoluteMultiLocation
+    val reserveChainLocation: ChainLocation,
+    val tokenLocation: AbsoluteMultiLocation
 )
 
 fun TokenReserve.isRemote(origin: ChainId, destination: ChainId): Boolean {
-    return origin != chainId && destination != chainId
+    return origin != reserveChainLocation.chainId && destination != reserveChainLocation.chainId
 }

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/reserve/TokenReserveConfig.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/reserve/TokenReserveConfig.kt
@@ -1,0 +1,9 @@
+package io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve
+
+import io.novafoundation.nova.feature_xcm_api.multiLocation.AbsoluteMultiLocation
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+
+class TokenReserveConfig(
+    val reserveChainId: ChainId,
+    val tokenReserveLocation: AbsoluteMultiLocation,
+)

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/reserve/TokenReserveRegistry.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/model/xcm/dynamic/reserve/TokenReserveRegistry.kt
@@ -1,21 +1,29 @@
 package io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve
 
+import io.novafoundation.nova.feature_wallet_api.data.repository.getChainLocation
 import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.ext.normalizeSymbol
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
+import io.novafoundation.nova.runtime.repository.ParachainInfoRepository
 
 class TokenReserveRegistry(
-    private val reservesById: Map<TokenReserveId, TokenReserve>,
+    private val parachainInfoRepository: ParachainInfoRepository,
+
+    private val reservesById: Map<TokenReserveId, TokenReserveConfig>,
 
     // By default, asset reserve id is equal to its symbol
     // This mapping allows to override that for cases like multiple reserves (Statemine & Polkadot for DOT)
     private val assetToReserveIdOverrides: Map<FullChainAssetId, TokenReserveId>
 ) {
 
-    fun getReserve(chainAsset: Chain.Asset): TokenReserve {
+    suspend fun getReserve(chainAsset: Chain.Asset): TokenReserve {
         val reserveId = getReserveId(chainAsset)
-        return reservesById.getValue(reserveId)
+        val reserve = reservesById.getValue(reserveId)
+        return TokenReserve(
+            reserveChainLocation = parachainInfoRepository.getChainLocation(reserve.reserveChainId),
+            tokenLocation = reserve.tokenReserveLocation
+        )
     }
 
     private fun getReserveId(chainAsset: Chain.Asset): TokenReserveId {

--- a/feature-wallet-impl/build.gradle
+++ b/feature-wallet-impl/build.gradle
@@ -18,8 +18,8 @@ android {
         buildConfigField "String", "EHTERSCAN_API_KEY_MOONRIVER", readStringSecret("EHTERSCAN_API_KEY_MOONRIVER")
         buildConfigField "String", "EHTERSCAN_API_KEY_ETHEREUM", readStringSecret("EHTERSCAN_API_KEY_ETHEREUM")
 
-        buildConfigField "String", "LEGACY_CROSS_CHAIN_CONFIG_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/refs/heads/dynamic_transfers_base/xcm/v7/transfers_dev.json\""
-        buildConfigField "String", "DYNAMIC_CROSS_CHAIN_CONFIG_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/refs/heads/dynamic_transfers_base/xcm/v7/transfers_dynamic_dev.json\""
+        buildConfigField "String", "LEGACY_CROSS_CHAIN_CONFIG_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/refs/heads/master/xcm/v7/transfers_dev.json\""
+        buildConfigField "String", "DYNAMIC_CROSS_CHAIN_CONFIG_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/refs/heads/master/xcm/v7/transfers_dynamic_dev.json\""
     }
 
     buildTypes {

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/mappers/crosschain/Dynamic.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/mappers/crosschain/Dynamic.kt
@@ -5,25 +5,29 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.Dynami
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.DynamicCrossChainTransfersConfiguration.AssetTransfers
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.DynamicCrossChainTransfersConfiguration.TransferDestination
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve.TokenReserve
+import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve.TokenReserveConfig
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve.TokenReserveRegistry
 import io.novafoundation.nova.feature_wallet_impl.data.network.crosschain.dynamic.DynamicCrossChainOriginChainRemote
 import io.novafoundation.nova.feature_wallet_impl.data.network.crosschain.dynamic.DynamicCrossChainTransfersConfigRemote
 import io.novafoundation.nova.feature_wallet_impl.data.network.crosschain.dynamic.DynamicReserveLocationRemote
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
+import io.novafoundation.nova.runtime.repository.ParachainInfoRepository
 
-fun DynamicCrossChainTransfersConfigRemote.toDomain(): DynamicCrossChainTransfersConfiguration {
+fun DynamicCrossChainTransfersConfigRemote.toDomain(parachainInfoRepository: ParachainInfoRepository): DynamicCrossChainTransfersConfiguration {
     return DynamicCrossChainTransfersConfiguration(
-        reserveRegistry = constructReserveRegistry(assetsLocation, reserveIdOverrides),
+        reserveRegistry = constructReserveRegistry(parachainInfoRepository, assetsLocation, reserveIdOverrides),
         chains = constructChains(chains)
     )
 }
 
 private fun constructReserveRegistry(
+    parachainInfoRepository: ParachainInfoRepository,
     assetsLocation: Map<String, DynamicReserveLocationRemote>?,
     reserveIdOverrides: Map<String, Map<Int, String>>?,
 ): TokenReserveRegistry {
     return TokenReserveRegistry(
+        parachainInfoRepository = parachainInfoRepository,
         reservesById = assetsLocation.orEmpty().mapValues { (_, reserve) ->
             reserve.toDomain()
         },
@@ -54,9 +58,9 @@ private fun constructTransfersForChain(configRemote: DynamicCrossChainOriginChai
     }
 }
 
-private fun DynamicReserveLocationRemote.toDomain(): TokenReserve {
-    return TokenReserve(
-        chainId = chainId,
-        location = multiLocation.toAbsoluteLocation()
+private fun DynamicReserveLocationRemote.toDomain(): TokenReserveConfig {
+    return TokenReserveConfig(
+        reserveChainId = chainId,
+        tokenReserveLocation = multiLocation.toAbsoluteLocation()
     )
 }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/mappers/crosschain/Dynamic.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/mappers/crosschain/Dynamic.kt
@@ -4,7 +4,6 @@ import io.novafoundation.nova.common.utils.flattenKeys
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.DynamicCrossChainTransfersConfiguration
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.DynamicCrossChainTransfersConfiguration.AssetTransfers
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.DynamicCrossChainTransfersConfiguration.TransferDestination
-import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve.TokenReserve
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve.TokenReserveConfig
 import io.novafoundation.nova.feature_wallet_api.domain.model.xcm.dynamic.reserve.TokenReserveRegistry
 import io.novafoundation.nova.feature_wallet_impl.data.network.crosschain.dynamic.DynamicCrossChainOriginChainRemote

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/orml/OrmlAssetEventDetector.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/orml/OrmlAssetEventDetector.kt
@@ -1,6 +1,5 @@
 package io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.events.orml
 
-import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountId
 import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
 import io.novafoundation.nova.common.utils.Modules

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/orml/OrmlAssetEventDetector.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/orml/OrmlAssetEventDetector.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.events.orml
 
 import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountId
+import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.instanceOf
@@ -48,7 +49,7 @@ private class OrmlAssetEventDetector(
         if (currencyIdEncoded != targetCurrencyId) return null
 
         return DepositEvent(
-            destination = bindAccountId(who),
+            destination = bindAccountIdKey(who),
             amount = bindNumber(amount)
         )
     }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/statemine/StatemineAssetEventDetector.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/statemine/StatemineAssetEventDetector.kt
@@ -1,6 +1,5 @@
 package io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.events.statemine
 
-import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountId
 import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
 import io.novafoundation.nova.common.utils.instanceOf

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/statemine/StatemineAssetEventDetector.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/statemine/StatemineAssetEventDetector.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.events.statemine
 
 import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountId
+import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
 import io.novafoundation.nova.common.utils.instanceOf
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.events.AssetEventDetector
@@ -51,7 +52,7 @@ class StatemineAssetEventDetector(
         if (assetIdAsString != targetAssetId) return null
 
         return DepositEvent(
-            destination = bindAccountId(who),
+            destination = bindAccountIdKey(who),
             amount = bindNumber(amount)
         )
     }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/utility/NativeAssetEventDetector.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/events/utility/NativeAssetEventDetector.kt
@@ -1,6 +1,6 @@
 package io.novafoundation.nova.feature_wallet_impl.data.network.blockchain.assets.events.utility
 
-import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountId
+import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.instanceOf
@@ -21,7 +21,7 @@ class NativeAssetEventDetector : AssetEventDetector {
         val (who, amount) = event.arguments
 
         return DepositEvent(
-            destination = bindAccountId(who),
+            destination = bindAccountIdKey(who),
             amount = bindNumber(amount)
         )
     }
@@ -32,7 +32,7 @@ class NativeAssetEventDetector : AssetEventDetector {
         val (who, amount) = event.arguments
 
         return DepositEvent(
-            destination = bindAccountId(who),
+            destination = bindAccountIdKey(who),
             amount = bindNumber(amount)
         )
     }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/RealCrossChainTransactor.kt
@@ -227,7 +227,7 @@ class RealCrossChainTransactor(
         val eventDetector = assetSourceRegistry.getEventDetector(transfer.destinationChainAsset)
 
         val depositEvent = events.mapNotNull { event -> eventDetector.tryDetectDeposit(event) }
-            .find { it.destination.contentEquals(transfer.recipientAccountId) }
+            .find { it.destination == transfer.recipientAccountId }
 
         return depositEvent?.amount
     }
@@ -258,7 +258,7 @@ class RealCrossChainTransactor(
         return destinationAssetBalances.balance.subscribeTransferableAccountBalance(
             chain = transfer.destinationChain,
             chainAsset = transfer.destinationChainAsset,
-            accountId = transfer.recipientAccountId,
+            accountId = transfer.recipientAccountId.value,
             sharedSubscriptionBuilder = null
         )
     }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/dynamic/DynamicCrossChainWeigher.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/dynamic/DynamicCrossChainWeigher.kt
@@ -26,6 +26,7 @@ import io.novafoundation.nova.feature_xcm_api.dryRun.model.usedXcmVersion
 import io.novafoundation.nova.feature_xcm_api.message.VersionedRawXcmMessage
 import io.novafoundation.nova.feature_xcm_api.message.bindRawXcmMessage
 import io.novafoundation.nova.feature_xcm_api.multiLocation.RelativeMultiLocation
+import io.novafoundation.nova.feature_xcm_api.versions.XcmVersion
 import io.novafoundation.nova.feature_xcm_api.versions.versionedXcm
 import io.novafoundation.nova.runtime.ext.emptyAccountIdKey
 import io.novafoundation.nova.runtime.ext.isUtilityAsset
@@ -83,9 +84,10 @@ class DynamicCrossChainWeigher @Inject constructor(
         transfer: AssetTransferBase,
     ): IntermediateDryRunResult {
         val runtime = chainRegistry.getRuntime(config.originChainId)
+        val xcmResultsVersion = XcmVersion.V4
 
         val dryRunCall = constructDryRunCall(config, transfer, runtime)
-        val dryRunResult = dryRunApi.dryRunCall(OriginCaller.System.Root, dryRunCall, config.originChainId)
+        val dryRunResult = dryRunApi.dryRunCall(OriginCaller.System.Root, dryRunCall, xcmResultsVersion, config.originChainId)
             .getEffectsOrThrow(LOG_TAG)
 
         val nextHopLocation = (config.remoteReserveChainLocation ?: config.destinationChainLocation).location

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/repository/RealCrossChainTransfersRepository.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/repository/RealCrossChainTransfersRepository.kt
@@ -10,6 +10,7 @@ import io.novafoundation.nova.feature_wallet_impl.data.mappers.crosschain.toDoma
 import io.novafoundation.nova.feature_wallet_impl.data.network.crosschain.CrossChainConfigApi
 import io.novafoundation.nova.feature_wallet_impl.data.network.crosschain.dynamic.DynamicCrossChainTransfersConfigRemote
 import io.novafoundation.nova.feature_wallet_impl.data.network.crosschain.legacy.LegacyCrossChainTransfersConfigRemote
+import io.novafoundation.nova.runtime.repository.ParachainInfoRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -26,7 +27,8 @@ private const val DYNAMIC_CACHE_NAME = "RealCrossChainTransfersRepository.Dynami
 class RealCrossChainTransfersRepository(
     private val api: CrossChainConfigApi,
     private val fileCache: FileCache,
-    private val gson: Gson
+    private val gson: Gson,
+    private val parachainInfoRepository: ParachainInfoRepository,
 ) : CrossChainTransfersRepository {
 
     override suspend fun syncConfiguration() = withContext(Dispatchers.IO) {
@@ -45,7 +47,7 @@ class RealCrossChainTransfersRepository(
 
         val dynamicFlow = fileCache.observeCachedValue(DYNAMIC_CACHE_NAME).map {
             val remote = gson.fromJson<DynamicCrossChainTransfersConfigRemote>(it)
-            remote.toDomain()
+            remote.toDomain(parachainInfoRepository)
         }
 
         return dynamicFlow.zip(legacyFlow, ::CrossChainTransfersConfiguration)

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/di/WalletFeatureModule.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/di/WalletFeatureModule.kt
@@ -287,8 +287,9 @@ class WalletFeatureModule {
     fun provideCrossChainRepository(
         api: CrossChainConfigApi,
         fileCache: FileCache,
-        gson: Gson
-    ): CrossChainTransfersRepository = RealCrossChainTransfersRepository(api, fileCache, gson)
+        gson: Gson,
+        parachainInfoRepository: ParachainInfoRepository,
+    ): CrossChainTransfersRepository = RealCrossChainTransfersRepository(api, fileCache, gson, parachainInfoRepository)
 
     @Provides
     @FeatureScope

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/chain/XcmChain.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/chain/XcmChain.kt
@@ -15,3 +15,11 @@ fun XcmChain.absoluteLocation(): AbsoluteMultiLocation {
     val junctions = listOfNotNull(parachainId?.let(MultiLocation.Junction::ParachainId))
     return junctions.asLocation()
 }
+
+fun XcmChain.isRelay(): Boolean {
+    return parachainId == null
+}
+
+fun XcmChain.isSystemChain(): Boolean {
+    return parachainId != null && parachainId.toInt() in 1000 until 2000
+}

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/chain/XcmChain.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/chain/XcmChain.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_xcm_api.chain
 import io.novafoundation.nova.feature_xcm_api.multiLocation.AbsoluteMultiLocation
 import io.novafoundation.nova.feature_xcm_api.multiLocation.MultiLocation
 import io.novafoundation.nova.feature_xcm_api.multiLocation.asLocation
+import io.novafoundation.nova.feature_xcm_api.multiLocation.chainLocation
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigInteger
 
@@ -12,8 +13,7 @@ class XcmChain(
 )
 
 fun XcmChain.absoluteLocation(): AbsoluteMultiLocation {
-    val junctions = listOfNotNull(parachainId?.let(MultiLocation.Junction::ParachainId))
-    return junctions.asLocation()
+    return AbsoluteMultiLocation.chainLocation(parachainId)
 }
 
 fun XcmChain.isRelay(): Boolean {

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/chain/XcmChain.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/chain/XcmChain.kt
@@ -1,8 +1,6 @@
 package io.novafoundation.nova.feature_xcm_api.chain
 
 import io.novafoundation.nova.feature_xcm_api.multiLocation.AbsoluteMultiLocation
-import io.novafoundation.nova.feature_xcm_api.multiLocation.MultiLocation
-import io.novafoundation.nova.feature_xcm_api.multiLocation.asLocation
 import io.novafoundation.nova.feature_xcm_api.multiLocation.chainLocation
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigInteger

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/dryRun/DryRunApi.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/dryRun/DryRunApi.kt
@@ -13,7 +13,6 @@ import io.novafoundation.nova.feature_xcm_api.versions.VersionedXcmLocation
 import io.novafoundation.nova.feature_xcm_api.versions.XcmVersion
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
-import java.sql.ResultSet
 
 interface DryRunApi {
 

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/dryRun/DryRunApi.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/dryRun/DryRunApi.kt
@@ -10,8 +10,10 @@ import io.novafoundation.nova.feature_xcm_api.dryRun.model.OriginCaller
 import io.novafoundation.nova.feature_xcm_api.dryRun.model.XcmDryRunEffects
 import io.novafoundation.nova.feature_xcm_api.message.VersionedRawXcmMessage
 import io.novafoundation.nova.feature_xcm_api.versions.VersionedXcmLocation
+import io.novafoundation.nova.feature_xcm_api.versions.XcmVersion
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+import java.sql.ResultSet
 
 interface DryRunApi {
 
@@ -24,6 +26,7 @@ interface DryRunApi {
     suspend fun dryRunCall(
         originCaller: OriginCaller,
         call: GenericCall.Instance,
+        xcmResultsVersion: XcmVersion,
         chainId: ChainId
     ): Result<ScaleResult<CallDryRunEffects, DryRunEffectsResultErr>>
 }

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/dryRun/model/DryRunEffects.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/dryRun/model/DryRunEffects.kt
@@ -10,6 +10,14 @@ interface DryRunEffects {
     val forwardedXcms: ForwardedXcms
 }
 
-fun DryRunEffects.usedXcmVersion(): XcmVersion {
-    return forwardedXcms.first().first.version
+fun DryRunEffects.recipientXcmVersion(): XcmVersion {
+    // For destination messages, dry run uses recipient's xcm version
+    val (_, forwardedMessagesToDestination) = forwardedXcms.first()
+    return forwardedMessagesToDestination.first().version
+}
+
+fun DryRunEffects.senderXcmVersion(): XcmVersion {
+    // For referencing destination, dry run uses sender's xcm version
+    val (destination) = forwardedXcms.first()
+    return destination.version
 }

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/dryRun/model/DryRunEffects.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/dryRun/model/DryRunEffects.kt
@@ -10,12 +10,6 @@ interface DryRunEffects {
     val forwardedXcms: ForwardedXcms
 }
 
-fun DryRunEffects.recipientXcmVersion(): XcmVersion {
-    // For destination messages, dry run uses recipient's xcm version
-    val (_, forwardedMessagesToDestination) = forwardedXcms.first()
-    return forwardedMessagesToDestination.first().version
-}
-
 fun DryRunEffects.senderXcmVersion(): XcmVersion {
     // For referencing destination, dry run uses sender's xcm version
     val (destination) = forwardedXcms.first()

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/multiLocation/AbsoluteLocation.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/multiLocation/AbsoluteLocation.kt
@@ -1,10 +1,13 @@
 package io.novafoundation.nova.feature_xcm_api.multiLocation
 
+import io.novafoundation.nova.common.data.network.runtime.binding.ParaId
 import io.novafoundation.nova.common.utils.collectionIndexOrNull
 
 class AbsoluteMultiLocation(
     interior: Interior,
 ) : MultiLocation(interior) {
+
+    companion object;
 
     constructor(vararg junctions: Junction) : this(junctions.toList().toInterior())
 
@@ -36,4 +39,8 @@ class AbsoluteMultiLocation(
             selfJunction == otherJunction
         }.collectionIndexOrNull()
     }
+}
+
+fun AbsoluteMultiLocation.Companion.chainLocation(parachainId: ParaId?): AbsoluteMultiLocation {
+    return listOfNotNull(parachainId?.let(MultiLocation.Junction::ParachainId)).asLocation()
 }

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/multiLocation/ChainLocation.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/multiLocation/ChainLocation.kt
@@ -1,0 +1,8 @@
+package io.novafoundation.nova.feature_xcm_api.multiLocation
+
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+
+class ChainLocation(
+    val chainId: ChainId,
+    val location: AbsoluteMultiLocation
+)

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/versions/XcmVersion.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/versions/XcmVersion.kt
@@ -1,7 +1,7 @@
 package io.novafoundation.nova.feature_xcm_api.versions
 
 enum class XcmVersion(val version: Int) {
-    V0(0), V1(1), V2(2), V3(3), V4(4);
+    V0(0), V1(1), V2(2), V3(3), V4(4), V5(5);
 
     companion object {
 

--- a/feature-xcm/impl/src/main/java/io/novafoundation/nova/feature_xcm_impl/dryRun/RealDryRunApi.kt
+++ b/feature-xcm/impl/src/main/java/io/novafoundation/nova/feature_xcm_impl/dryRun/RealDryRunApi.kt
@@ -69,7 +69,7 @@ class RealDryRunApi @Inject constructor(
         originCaller: OriginCaller,
         call: GenericCall.Instance,
         xcmResultsVersion: XcmVersion,
-        ): Result<ScaleResult<CallDryRunEffects, DryRunEffectsResultErr>> {
+    ): Result<ScaleResult<CallDryRunEffects, DryRunEffectsResultErr>> {
         return runCatching {
             call(
                 section = "DryRunApi",


### PR DESCRIPTION
* Switch to master urls
* Support new version of dry run
* Support system chains teleports
* Detect deposits only to recipient account
* Always rely on forwarded xcms when retrieving xcm
* Construct reserve location separately - do not take it from token location as it may contain extra junctions

 