### PR TITLE
Take disabled chains into account in swaps

### DIFF
--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
@@ -97,6 +97,8 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import io.novafoundation.nova.runtime.multiNetwork.chainWithAssetOrNull
 import io.novafoundation.nova.runtime.multiNetwork.chainsById
+import io.novafoundation.nova.runtime.multiNetwork.enabledChainById
+import io.novafoundation.nova.runtime.multiNetwork.enabledChains
 import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novasama.substrate_sdk_android.hash.isPositive
 import kotlinx.coroutines.CoroutineScope
@@ -505,7 +507,7 @@ internal class RealSwapService(
     private suspend fun createIndividualChainExchanges(coroutineScope: CoroutineScope): Map<ChainId, AssetExchange> {
         val host = createInnerSwapHost(coroutineScope)
 
-        return chainRegistry.chainsById.first().mapValues { (_, chain) ->
+        return chainRegistry.enabledChainById().mapValues { (_, chain) ->
             createSingleExchange(chain, host)
         }
             .filterNotNull()

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/ChainRegistry.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/ChainRegistry.kt
@@ -387,6 +387,9 @@ fun ChainRegistry.enabledChainsFlow() = currentChains
 
 suspend fun ChainRegistry.enabledChains() = enabledChainsFlow().first()
 
+suspend fun ChainRegistry.disabledChains() = currentChains.filterList { it.isDisabled }
+    .first()
+
 fun ChainRegistry.enabledChainByIdFlow() = enabledChainsFlow().map { chains -> chains.associateBy { it.id } }
 
 suspend fun ChainRegistry.enabledChainById() = ChainsById(enabledChainByIdFlow().first())


### PR DESCRIPTION
* SwapService now only invokes single chain factories on enabled chains
* Cross Chain exchange filters out disabled directions