### PR TITLE
fix: Fix typo in variable name

### DIFF
--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/connection/autobalance/strategy/UniformGenerator.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/connection/autobalance/strategy/UniformGenerator.kt
@@ -4,10 +4,10 @@ import io.novafoundation.nova.common.utils.cycle
 import io.novafoundation.nova.runtime.multiNetwork.connection.NodeWithSaturatedUrl
 
 class UniformGenerator(
-    private val availabelNodes: List<NodeWithSaturatedUrl>,
+    private val availableNodes: List<NodeWithSaturatedUrl>,
 ) : NodeSequenceGenerator {
 
     override fun generateNodeSequence(): Sequence<NodeWithSaturatedUrl> {
-        return availabelNodes.shuffled().cycle()
+        return availableNodes.shuffled().cycle()
     }
 }


### PR DESCRIPTION
Rename variable "availabelNodes" to "availableNodes" to fix the spelling error.