### PR TITLE
fix: correct issuance condition — treat collections with max > 0 as Limited

### DIFF
--- a/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/data/mappers/Nft.kt
+++ b/feature-nft-impl/src/main/java/io/novafoundation/nova/feature_nft_impl/data/mappers/Nft.kt
@@ -30,7 +30,7 @@ fun nftIssuance(
         NftLocal.IssuanceType.LIMITED -> {
             val myEditionInt = issuanceMyEdition?.toIntOrNull()
 
-            if (issuanceTotal != null && issuanceTotal.isZero && myEditionInt != null) {
+            if (issuanceTotal != null && !issuanceTotal.isZero && myEditionInt != null) {
                 Nft.Issuance.Limited(max = issuanceTotal.toInt(), edition = myEditionInt)
             } else {
                 Nft.Issuance.Unlimited


### PR DESCRIPTION
Currently, **only** NFT collections with **issuanceTotal = 0** are treated as **Limited**, which seems incorrect.

Please let me know if I'm wrong and there's a reason for this logic.