### PR TITLE
Multisig/realtime calldata

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/address/AccountId.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/address/AccountId.kt
@@ -11,7 +11,7 @@ class AccountIdKey(val value: AccountId) : Comparable<AccountIdKey> {
     companion object;
 
     override fun compareTo(other: AccountIdKey): Int {
-        return value.compareTo(other.value)
+        return value.compareTo(other.value, unsigned = false)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/common/src/main/java/io/novafoundation/nova/common/data/memory/LazyAsyncMultiCache.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/memory/LazyAsyncMultiCache.kt
@@ -13,6 +13,8 @@ import java.util.Collections
 interface LazyAsyncMultiCache<K, V> {
 
     suspend fun getOrCompute(keys: List<K>): Map<K, V>
+
+    suspend fun put(key: K, value: V)
 }
 
 /**
@@ -59,6 +61,12 @@ private class RealLazyAsyncMultiCache<K, V>(
 
             // Return the view of the whole cache to avoid extra allocations of the map
             return Collections.unmodifiableMap(cache)
+        }
+    }
+
+    override suspend fun put(key: K, value: V) {
+        mutex.withLock {
+            cache[key] = value
         }
     }
 

--- a/common/src/main/java/io/novafoundation/nova/common/data/memory/LazyAsyncMultiCache.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/memory/LazyAsyncMultiCache.kt
@@ -12,9 +12,11 @@ import java.util.Collections
 
 interface LazyAsyncMultiCache<K, V> {
 
-    suspend fun getOrCompute(keys: List<K>): Map<K, V>
+    suspend fun getOrCompute(keys: Collection<K>): Map<K, V>
 
     suspend fun put(key: K, value: V)
+
+    suspend fun putAll(map: Map<K, V>)
 }
 
 /**
@@ -41,7 +43,7 @@ private class RealLazyAsyncMultiCache<K, V>(
     private val mutex = Mutex()
     private val cache = mutableMapOf<K, V>()
 
-    override suspend fun getOrCompute(keys: List<K>): Map<K, V> {
+    override suspend fun getOrCompute(keys: Collection<K>): Map<K, V> {
         mutex.withLock {
             Log.d(debugLabel, "Requested to fetch ${keys.size} keys")
 
@@ -67,6 +69,12 @@ private class RealLazyAsyncMultiCache<K, V>(
     override suspend fun put(key: K, value: V) {
         mutex.withLock {
             cache[key] = value
+        }
+    }
+
+    override suspend fun putAll(map: Map<K, V>) {
+        mutex.withLock {
+            cache.putAll(map)
         }
     }
 

--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -593,13 +593,17 @@ fun String.toUuid() = UUID.fromString(this)
 val Int.kilobytes: BigInteger
     get() = this.toBigInteger() * 1024.toBigInteger()
 
-operator fun ByteArray.compareTo(other: ByteArray): Int {
+fun ByteArray.compareTo(other: ByteArray, unsigned: Boolean): Int {
     if (size != other.size) {
         return size - other.size
     }
 
     for (i in 0 until size) {
-        val result = this[i].compareTo(other[i])
+        val result = if (unsigned) {
+            this[i].toUByte().compareTo(other[i].toUByte())
+        } else {
+            this[i].compareTo(other[i])
+        }
 
         if (result != 0) {
             return result
@@ -609,7 +613,7 @@ operator fun ByteArray.compareTo(other: ByteArray): Int {
     return 0
 }
 
-fun ByteArrayComparator() = Comparator<ByteArray> { a, b -> a.compareTo(b) }
+fun ByteArrayComparator() = Comparator<ByteArray> { a, b -> a.compareTo(b, unsigned = false) }
 
 inline fun CoroutineScope.withChildScope(action: CoroutineScope.() -> Unit) {
     val childScope = childScope()

--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -543,6 +543,10 @@ fun <T> List<T>.modified(index: Int, modification: T): List<T> {
     return newList
 }
 
+fun <K, V> MutableMap<K, V>.put(entry: Pair<K, V>) {
+    put(entry.first, entry.second)
+}
+
 fun <T> Set<T>.added(toAdd: T): Set<T> {
     return toMutableSet().apply { add(toAdd) }
 }

--- a/common/src/main/java/io/novafoundation/nova/common/utils/SubstrateSdkExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/SubstrateSdkExt.kt
@@ -30,6 +30,7 @@ import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.Extr
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.findExplicitOrNull
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.signer
 import io.novasama.substrate_sdk_android.runtime.definitions.types.skipAliases
 import io.novasama.substrate_sdk_android.runtime.extrinsic.builder.ExtrinsicBuilder
 import io.novasama.substrate_sdk_android.runtime.extrinsic.builder.getGenesisHashOrThrow
@@ -408,6 +409,10 @@ fun GenericCall.Instance.oneOf(vararg functionCandidates: MetadataFunction?): Bo
     return functionCandidates.any { candidate -> candidate != null && function == candidate }
 }
 
+fun Extrinsic.Instance.isSigned(): Boolean {
+    return signer() != null
+}
+
 fun GenericCall.Instance.instanceOf(functionCandidate: MetadataFunction): Boolean = function == functionCandidate
 
 fun GenericCall.Instance.instanceOf(moduleName: String, callName: String): Boolean = moduleName == module.name && callName == function.name
@@ -415,6 +420,8 @@ fun GenericCall.Instance.instanceOf(moduleName: String, callName: String): Boole
 fun GenericCall.Instance.instanceOf(moduleName: String, vararg callNames: String): Boolean = moduleName == module.name && function.name in callNames
 
 fun GenericEvent.Instance.instanceOf(moduleName: String, eventName: String): Boolean = moduleName == module.name && eventName == event.name
+
+fun GenericEvent.Instance.instanceOf(moduleName: String, vararg eventNames: String): Boolean = moduleName == module.name && event.name in eventNames
 
 fun GenericEvent.Instance.instanceOf(event: Event): Boolean = event.index == this.event.index
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/sync/RealExternalAccountsSyncService.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/sync/RealExternalAccountsSyncService.kt
@@ -95,6 +95,8 @@ internal class RealExternalAccountsSyncService @Inject constructor(
     private suspend fun syncInternal(chain: Chain): Result<NonReachableUniversalIds?> {
         val dataSources = dataSourceFactories.mapNotNull { it.create(chain) }
         if (dataSources.isNotEmpty()) {
+            Log.d("ExternalAccountsDiscovery", "Created data sources for ${chain.name}: ${dataSources.map { it::class.simpleName }}")
+
             val aggregateSource = dataSources.aggregate()
             return sync(chain, aggregateSource)
         }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureDependencies.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureDependencies.kt
@@ -61,6 +61,7 @@ import io.novafoundation.nova.runtime.extrinsic.ExtrinsicBuilderFactory
 import io.novafoundation.nova.runtime.extrinsic.ExtrinsicValidityUseCase
 import io.novafoundation.nova.runtime.extrinsic.MortalityConstructor
 import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerService
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicWalk
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.qr.MultiChainQrSharingFactory
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
@@ -132,6 +133,8 @@ interface AccountFeatureDependencies {
     val addressSchemeFormatter: AddressSchemeFormatter
 
     val automaticInteractionGate: AutomaticInteractionGate
+
+    val extrinsicWalk: ExtrinsicWalk
 
     fun appLinksProvider(): AppLinksProvider
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
@@ -159,6 +159,8 @@ internal class RealMultisigChainPendingOperationsSyncer(
         eventsRepository.subscribeEventRecords(chain.id).map { eventRecords ->
             val newCallHashes = eventRecords.events().findOurNewMultisigs(accountId)
             pendingCallHashesFlow.update { it + newCallHashes }
+
+
         }
             .catch { Log.e("RealMultisigChainPendingOperationsSyncer", "Failed to detect new pending operations from events", it) }
             .launchIn(this)

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
@@ -2,13 +2,19 @@ package io.novafoundation.nova.feature_account_impl.domain.multisig
 
 import android.util.Log
 import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.address.intoKey
 import io.novafoundation.nova.common.data.memory.LazyAsyncMultiCache
+import io.novafoundation.nova.common.data.network.runtime.binding.BlockHash
 import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
+import io.novafoundation.nova.common.data.network.runtime.binding.bindGenericCall
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.flowOf
+import io.novafoundation.nova.common.utils.instanceOf
+import io.novafoundation.nova.common.utils.isSigned
 import io.novafoundation.nova.common.utils.launchUnit
 import io.novafoundation.nova.common.utils.mapNotNullToSet
+import io.novafoundation.nova.common.utils.put
 import io.novafoundation.nova.common.utils.shareInBackground
 import io.novafoundation.nova.feature_account_api.data.multisig.model.PendingMultisigOperation
 import io.novafoundation.nova.feature_account_api.domain.model.MultisigMetaAccount
@@ -17,12 +23,21 @@ import io.novafoundation.nova.feature_account_api.domain.multisig.CallHash
 import io.novafoundation.nova.feature_account_api.domain.multisig.bindCallHash
 import io.novafoundation.nova.feature_account_impl.data.multisig.MultisigRepository
 import io.novafoundation.nova.feature_account_impl.data.multisig.blockhain.model.OnChainMultisig
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicWalk
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.walkToList
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.getRuntime
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
+import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.ExtrinsicWithEvents
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.events
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.findEvents
+import io.novasama.substrate_sdk_android.hash.Hasher.blake2b256
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.signer
+import io.novasama.substrate_sdk_android.runtime.definitions.types.toByteArray
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +54,8 @@ import javax.inject.Inject
 internal class MultisigChainPendingOperationsSyncerFactory @Inject constructor(
     private val eventsRepository: EventsRepository,
     private val multisigRepository: MultisigRepository,
+    private val chainRegistry: ChainRegistry,
+    private val extrinsicWalk: ExtrinsicWalk,
 ) {
 
     fun create(
@@ -52,6 +69,8 @@ internal class MultisigChainPendingOperationsSyncerFactory @Inject constructor(
             scope = scope,
             eventsRepository = eventsRepository,
             multisigRepository = multisigRepository,
+            chainRegistry = chainRegistry,
+            extrinsicWalk = extrinsicWalk
         )
     }
 }
@@ -69,9 +88,18 @@ internal class RealMultisigChainPendingOperationsSyncer(
     val scope: CoroutineScope,
     private val eventsRepository: EventsRepository,
     private val multisigRepository: MultisigRepository,
+    private val extrinsicWalk: ExtrinsicWalk,
+    private val chainRegistry: ChainRegistry,
 ) : CoroutineScope by scope, MultisigPendingOperationsSyncer {
 
-    private val pendingCallHashesFlow = MutableStateFlow<List<CallHash>>(emptyList())
+    companion object {
+
+        private const val NEW_MULTISIG = "NewMultisig"
+
+        private const val MULTISIG_APPROVAL = "MultisigApproval"
+    }
+
+    private val pendingCallHashesFlow = MutableStateFlow<Set<CallHash>>(emptySet())
 
     private val knownCallDatas = LazyAsyncMultiCache(scope, debugLabel = "CallDataCache") {
         multisigRepository.getCallDatas(chain, it)
@@ -106,7 +134,7 @@ internal class RealMultisigChainPendingOperationsSyncer(
         startDetectingNewPendingCallHashesFromEvents(accountId)
     }
 
-    private suspend fun observePendingOperations(callHashes: List<CallHash>): Flow<Map<CallHash, PendingMultisigOperation?>> {
+    private suspend fun observePendingOperations(callHashes: Set<CallHash>): Flow<Map<CallHash, PendingMultisigOperation?>> {
         val accountId = multisig.accountIdKeyIn(chain)
         if (accountId == null || callHashes.isEmpty()) return flowOf { emptyMap() }
 
@@ -153,21 +181,68 @@ internal class RealMultisigChainPendingOperationsSyncer(
         }
     }
 
-    // TODO multisig: fetch call-data from the block and note it in repository
-    // So we can display call data immediately after in-app submission, before indexer has picked it up
     private fun startDetectingNewPendingCallHashesFromEvents(accountId: AccountIdKey) {
-        eventsRepository.subscribeEventRecords(chain.id).map { eventRecords ->
+        eventsRepository.subscribeEventRecords(chain.id).map { (eventRecords, blockHash) ->
             val newCallHashes = eventRecords.events().findOurNewMultisigs(accountId)
+
+            // Important to do this first, so `pendingCallHashesFlow` will trigger list re-compute when detected call-data is already present in
+            // `knownCallDatas`
+            tryAddNewCallDatas(newCallHashes, blockHash)
+
             pendingCallHashesFlow.update { it + newCallHashes }
-
-
         }
             .catch { Log.e("RealMultisigChainPendingOperationsSyncer", "Failed to detect new pending operations from events", it) }
             .launchIn(this)
     }
 
+    private suspend fun tryAddNewCallDatas(newCallHashes: List<CallHash>, blockHash: BlockHash): Result<Unit> = runCatching {
+        if (newCallHashes.isEmpty()) return@runCatching
+
+        Log.d("RealMultisigChainPendingOperationsSyncer", "Detected own multisig at block ${blockHash}, trying to find call-data")
+
+        val blockWithEvents = eventsRepository.getBlockEvents(chain.id, blockHash)
+
+        val newCallDatas = buildMap {
+            blockWithEvents.applyExtrinsic
+                .filter { it.extrinsic.isSigned() }
+                .forEach { extrinsicWithEvents -> extrinsicWithEvents.tryAddNewCallDatas(newCallHashes) }
+        }
+
+        Log.d("RealMultisigChainPendingOperationsSyncer", "Found call-datas: ${newCallDatas.size}")
+
+        knownCallDatas.putAll(newCallDatas)
+    }.onFailure {
+        Log.e("RealMultisigChainPendingOperationsSyncer", "Error while detecting call-data from chain", it)
+    }
+
+    context(MutableMap<CallHash, GenericCall.Instance>)
+    private suspend fun ExtrinsicWithEvents.tryAddNewCallDatas(newCallHashes: List<CallHash>) {
+        val visitedEntries = extrinsicWalk.walkToList(source = this@tryAddNewCallDatas, chain.id)
+        visitedEntries.forEach {
+            val callHashAndData = it.tryFindCallDataInAsMulti(newCallHashes)
+            if (callHashAndData != null) {
+                put(callHashAndData)
+            }
+        }
+    }
+
+    private suspend fun ExtrinsicVisit.tryFindCallDataInAsMulti(callHashes: List<CallHash>): Pair<CallHash, GenericCall.Instance>? {
+        if (!call.instanceOf(Modules.MULTISIG, "as_multi")) return null
+
+        val runtime = chainRegistry.getRuntime(chain.id)
+
+        val callData = bindGenericCall(call.arguments["call"])
+        val callHash = GenericCall.toByteArray(runtime, callData).blake2b256().intoKey()
+
+        return if (callHash in callHashes) {
+            callHash to callData
+        } else {
+            null
+        }
+    }
+
     private fun List<GenericEvent.Instance>.findOurNewMultisigs(ourAccountId: AccountIdKey): List<CallHash> {
-        return findEvents(Modules.MULTISIG, "NewMultisig").mapNotNull { newMultisigEvent ->
+        return findEvents(Modules.MULTISIG, NEW_MULTISIG, MULTISIG_APPROVAL).mapNotNull { newMultisigEvent ->
             extractOurCallHash(newMultisigEvent, ourAccountId)
         }
     }
@@ -177,13 +252,23 @@ internal class RealMultisigChainPendingOperationsSyncer(
         ourAccountId: AccountIdKey
     ): CallHash? {
         return runCatching {
-            val (_, multisigRaw, callHashRaw) = newMultisigEvent.arguments
+            val multisigRaw: Any?
+            val callHashRaw: Any?
+
+            if (newMultisigEvent.instanceOf(Modules.MULTISIG, NEW_MULTISIG)) {
+                multisigRaw = newMultisigEvent.arguments[1]
+                callHashRaw = newMultisigEvent.arguments[2]
+            } else {
+                multisigRaw = newMultisigEvent.arguments[2]
+                callHashRaw = newMultisigEvent.arguments[3]
+            }
+
             val multisig = bindAccountIdKey(multisigRaw)
             val callHash = bindCallHash(callHashRaw)
 
             callHash.takeIf { multisig == ourAccountId }
         }
-            .onFailure { Log.e("RealMultisigChainPendingOperationsSyncer", "Failed to parse new NewMultisig event", it) }
+            .onFailure { Log.e("RealMultisigChainPendingOperationsSyncer", "Failed to parse new NewMultisig/MultisigApproval event", it) }
             .getOrNull()
     }
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
@@ -36,7 +36,6 @@ import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.findEvents
 import io.novasama.substrate_sdk_android.hash.Hasher.blake2b256
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
-import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.signer
 import io.novasama.substrate_sdk_android.runtime.definitions.types.toByteArray
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -198,7 +197,7 @@ internal class RealMultisigChainPendingOperationsSyncer(
     private suspend fun tryAddNewCallDatas(newCallHashes: List<CallHash>, blockHash: BlockHash): Result<Unit> = runCatching {
         if (newCallHashes.isEmpty()) return@runCatching
 
-        Log.d("RealMultisigChainPendingOperationsSyncer", "Detected own multisig at block ${blockHash}, trying to find call-data")
+        Log.d("RealMultisigChainPendingOperationsSyncer", "Detected own multisig at block $blockHash, trying to find call-data")
 
         val blockWithEvents = eventsRepository.getBlockEvents(chain.id, blockHash)
 

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -13,7 +13,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField "String", "CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v22/chains_dev.json\""
+        buildConfigField "String", "CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/a41fd96db045c299cf019e7cc0ffbf3f2a2d531c/chains/v22/chains_dev.json\""
         buildConfigField "String", "EVM_ASSETS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/assets/evm/v3/assets_dev.json\""
         buildConfigField "String", "PRE_CONFIGURED_CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v22/preConfigured/chains_dev.json\""
         buildConfigField "String", "PRE_CONFIGURED_CHAIN_DETAILS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/chains/v22/preConfigured/detailsDev\""

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/api/ExtrinsicWalk.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/api/ExtrinsicWalk.kt
@@ -46,5 +46,10 @@ class ExtrinsicVisit(
     /**
      * Origin's account id that this call has been dispatched with
      */
-    val origin: AccountId
+    val origin: AccountId,
+
+    /**
+     * Whether this visit is related to a registered node or not
+     */
+    val hasRegisteredNode: Boolean = false
 )

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/NestedCallNode.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/NestedCallNode.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.ExtrinsicW
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
 
 internal interface NestedCallNode {
 
@@ -39,10 +40,23 @@ internal interface VisitingContext {
 
     val eventQueue: MutableEventQueue
 
-    fun nestedVisit(visit: ExtrinsicVisit)
+    fun nestedVisit(visit: NestedExtrinsicVisit)
 
     fun endExclusiveToSkipInternalEvents(call: GenericCall.Instance): Int
 }
+
+/**
+ * Version of [ExtrinsicVisit] intended for nested usage
+ *
+ * @see [ExtrinsicVisit]
+ */
+internal class NestedExtrinsicVisit(
+    val rootExtrinsic: ExtrinsicWithEvents,
+    val call: GenericCall.Instance,
+    val success: Boolean,
+    val events: List<GenericEvent.Instance>,
+    val origin: AccountId,
+)
 
 internal interface EventCountingContext {
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/batch/BatchAllNode.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/batch/BatchAllNode.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.runtime.extrinsic.visitor.impl.nodes.batch
 
 import io.novafoundation.nova.common.data.network.runtime.binding.bindGenericCallList
 import io.novafoundation.nova.common.utils.Modules
-import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.EventCountingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedCallNode
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedExtrinsicVisit

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/batch/BatchAllNode.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/batch/BatchAllNode.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.EventCountingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedCallNode
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.VisitingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.indexOfLastOrThrow
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
@@ -52,7 +53,7 @@ internal class BatchAllNode : NestedCallNode {
                 context.eventQueue.popFromEnd(itemCompletedEventType)
                 val alNestedEvents = context.takeCompletedBatchItemEvents(innerCall)
 
-                ExtrinsicVisit(
+                NestedExtrinsicVisit(
                     rootExtrinsic = context.rootExtrinsic,
                     call = innerCall,
                     success = true,
@@ -60,7 +61,7 @@ internal class BatchAllNode : NestedCallNode {
                     origin = context.origin
                 )
             } else {
-                ExtrinsicVisit(
+                NestedExtrinsicVisit(
                     rootExtrinsic = context.rootExtrinsic,
                     call = innerCall,
                     success = false,

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/batch/ForceBatchNode.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/batch/ForceBatchNode.kt
@@ -3,7 +3,6 @@ package io.novafoundation.nova.runtime.extrinsic.visitor.impl.nodes.batch
 import io.novafoundation.nova.common.data.network.runtime.binding.bindGenericCallList
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.instanceOf
-import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.EventCountingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedCallNode
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedExtrinsicVisit

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/batch/ForceBatchNode.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/batch/ForceBatchNode.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.common.utils.instanceOf
 import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.EventCountingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedCallNode
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.VisitingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.indexOfLastOrThrow
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.peekItemFromEndOrThrow
@@ -73,7 +74,7 @@ internal class ForceBatchNode : NestedCallNode {
                 if (itemEvent.instanceOf(itemCompletedEventType)) {
                     val allEvents = context.takeCompletedBatchItemEvents(innerCall)
 
-                    return@map ExtrinsicVisit(
+                    return@map NestedExtrinsicVisit(
                         rootExtrinsic = context.rootExtrinsic,
                         call = innerCall,
                         success = true,
@@ -83,7 +84,7 @@ internal class ForceBatchNode : NestedCallNode {
                 }
             }
 
-            ExtrinsicVisit(
+            NestedExtrinsicVisit(
                 rootExtrinsic = context.rootExtrinsic,
                 call = innerCall,
                 success = false,

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/multisig/Common.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/multisig/Common.kt
@@ -29,7 +29,6 @@ fun generateMultisigAddress(
 
         writeCompact(sortedAccounts.size)
         sortedAccounts.forEach {
-
             directWrite(it.value)
         }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/multisig/Common.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/multisig/Common.kt
@@ -1,0 +1,46 @@
+package io.novafoundation.nova.runtime.extrinsic.visitor.impl.nodes.multisig
+
+import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.address.intoKey
+import io.novafoundation.nova.common.utils.compareTo
+import io.novafoundation.nova.common.utils.padEnd
+import io.novasama.substrate_sdk_android.hash.Hasher.blake2b256
+import io.novasama.substrate_sdk_android.runtime.definitions.types.useScaleWriter
+import io.novasama.substrate_sdk_android.scale.utils.directWrite
+
+private val PREFIX = "modlpy/utilisuba".encodeToByteArray()
+
+fun generateMultisigAddress(
+    signatory: AccountIdKey,
+    otherSignatories: List<AccountIdKey>,
+    threshold: Int
+) = generateMultisigAddress(otherSignatories + signatory, threshold)
+
+fun generateMultisigAddress(
+    signatories: List<AccountIdKey>,
+    threshold: Int
+): AccountIdKey {
+    val accountIdSize = signatories.first().value.size
+
+    val sortedAccounts = signatories.sortedWith { a, b -> a.value.compareTo(b.value, unsigned = true) }
+
+    val entropy = useScaleWriter {
+        directWrite(PREFIX)
+
+        writeCompact(sortedAccounts.size)
+        sortedAccounts.forEach {
+
+            directWrite(it.value)
+        }
+
+        writeUint16(threshold)
+    }.blake2b256()
+
+    val result = when {
+        entropy.size == accountIdSize -> entropy
+        entropy.size < accountIdSize -> entropy.padEnd(accountIdSize, 0)
+        else -> entropy.copyOf(accountIdSize)
+    }
+
+    return result.intoKey()
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/multisig/MultisigNode.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/multisig/MultisigNode.kt
@@ -1,0 +1,140 @@
+package io.novafoundation.nova.runtime.extrinsic.visitor.impl.nodes.multisig
+
+import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.address.intoKey
+import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
+import io.novafoundation.nova.common.data.network.runtime.binding.bindGenericCall
+import io.novafoundation.nova.common.data.network.runtime.binding.bindInt
+import io.novafoundation.nova.common.data.network.runtime.binding.bindList
+import io.novafoundation.nova.common.data.network.runtime.binding.castToDictEnum
+import io.novafoundation.nova.common.utils.Modules
+import io.novafoundation.nova.common.utils.instanceOf
+import io.novafoundation.nova.common.utils.multisig
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.EventCountingContext
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedCallNode
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedExtrinsicVisit
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.VisitingContext
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.peekItemFromEndOrThrow
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.takeFromEndOrThrow
+import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
+import io.novasama.substrate_sdk_android.runtime.metadata.event
+import io.novasama.substrate_sdk_android.runtime.metadata.module.Event
+
+internal class MultisigNode : NestedCallNode {
+
+    override fun canVisit(call: GenericCall.Instance): Boolean {
+        return call.module.name == Modules.MULTISIG && call.function.name == "as_multi"
+    }
+
+    override fun endExclusiveToSkipInternalEvents(call: GenericCall.Instance, context: EventCountingContext): Int {
+        var endExclusive = context.endExclusive
+        val completionEventTypes = context.runtime.multisigCompletionEvents()
+
+        val (completionEvent, completionIdx) = context.eventQueue.peekItemFromEndOrThrow(eventTypes = completionEventTypes, endExclusive = endExclusive)
+        endExclusive = completionIdx
+
+        if (completionEvent.isMultisigExecutionSucceeded()) {
+            val innerCall = this.extractInnerMultisigCall(call)
+            endExclusive = context.endExclusiveToSkipInternalEvents(innerCall, endExclusive)
+        }
+
+        return endExclusive
+    }
+
+    override fun visit(call: GenericCall.Instance, context: VisitingContext) {
+        if (!context.callSucceeded) {
+            visitFailedMultisigCall(call, context)
+            context.logger.info("asMulti - reverted by outer parent")
+            return
+        }
+
+        val completionEventTypes = context.runtime.multisigCompletionEvents()
+        val completionEvent = context.eventQueue.takeFromEndOrThrow(*completionEventTypes)
+
+        // Not visiting pending mst's
+        if (!completionEvent.isMultisigExecuted()) return
+
+        if (completionEvent.isMultisigExecutedOk()) {
+            context.logger.info("asMulti: execution succeeded")
+
+            visitSucceededMultisigCall(call, context)
+        } else {
+            context.logger.info("asMulti: execution failed")
+
+            this.visitFailedMultisigCall(call, context)
+        }
+    }
+
+    private fun visitFailedMultisigCall(call: GenericCall.Instance, context: VisitingContext) {
+        this.visitMultisigCall(call, context, success = false, events = emptyList())
+    }
+
+    private fun visitSucceededMultisigCall(call: GenericCall.Instance, context: VisitingContext) {
+        this.visitMultisigCall(call, context, success = true, events = context.eventQueue.all())
+    }
+
+    private fun visitMultisigCall(
+        call: GenericCall.Instance,
+        context: VisitingContext,
+        success: Boolean,
+        events: List<GenericEvent.Instance>
+    ) {
+        val innerOrigin = extractMultisigOrigin(call, context.origin.intoKey())
+        val innerCall = extractInnerMultisigCall(call)
+
+        val visit = NestedExtrinsicVisit(
+            rootExtrinsic = context.rootExtrinsic,
+            call = innerCall,
+            success = success,
+            events = events,
+            origin = innerOrigin.value
+        )
+
+        context.nestedVisit(visit)
+    }
+
+    private fun GenericEvent.Instance.isMultisigExecutionSucceeded(): Boolean {
+        if (!isMultisigExecuted()) {
+            // not final execution
+            return false
+        }
+
+        return isMultisigExecutedOk()
+    }
+
+    private fun GenericEvent.Instance.isMultisigExecuted(): Boolean {
+        return instanceOf(Modules.MULTISIG, "MultisigExecuted")
+    }
+
+    private fun GenericEvent.Instance.isMultisigExecutedOk(): Boolean {
+        // dispatch_result in https://github.com/paritytech/polkadot-sdk/blob/fdf3d65e4c2d9094915c7fd7927e651339171edd/substrate/frame/multisig/src/lib.rs#L260
+        return arguments[4].castToDictEnum().name == "Ok"
+    }
+
+    private fun extractInnerMultisigCall(multisigCall: GenericCall.Instance): GenericCall.Instance {
+        return bindGenericCall(multisigCall.arguments["call"])
+    }
+
+    private fun RuntimeSnapshot.multisigCompletionEvents(): Array<Event> {
+        val multisig = metadata.multisig()
+
+        return arrayOf(
+            multisig.event("MultisigExecuted"),
+            multisig.event("MultisigApproval"),
+            multisig.event("NewMultisig"),
+        )
+    }
+
+    private fun extractMultisigOrigin(call: GenericCall.Instance, parentOrigin: AccountIdKey): AccountIdKey {
+        val threshold = bindInt(call.arguments["threshold"])
+        val otherSignatories = bindList(call.arguments["other_signatories"], ::bindAccountIdKey)
+
+        return generateMultisigAddress(
+            otherSignatories = otherSignatories,
+            signatory = parentOrigin,
+            threshold = threshold
+        )
+    }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/proxy/ProxyNode.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/proxy/ProxyNode.kt
@@ -5,7 +5,6 @@ import io.novafoundation.nova.common.data.network.runtime.binding.bindGenericCal
 import io.novafoundation.nova.common.data.network.runtime.binding.castToDictEnum
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.proxy
-import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.EventCountingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedCallNode
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedExtrinsicVisit

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/proxy/ProxyNode.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/nodes/proxy/ProxyNode.kt
@@ -8,6 +8,7 @@ import io.novafoundation.nova.common.utils.proxy
 import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.EventCountingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedCallNode
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.NestedExtrinsicVisit
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.VisitingContext
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.peekItemFromEndOrThrow
 import io.novafoundation.nova.runtime.extrinsic.visitor.impl.takeFromEndOrThrow
@@ -78,7 +79,7 @@ internal class ProxyNode : NestedCallNode {
     ) {
         val (innerCall, innerOrigin) = this.callAndOriginFromProxy(call)
 
-        val visit = ExtrinsicVisit(
+        val visit = NestedExtrinsicVisit(
             rootExtrinsic = context.rootExtrinsic,
             call = innerCall,
             success = success,

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/repository/EventsRepository.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/repository/EventsRepository.kt
@@ -9,7 +9,10 @@ import io.novafoundation.nova.runtime.network.rpc.RpcCalls
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.common.utils.metadata
+import io.novafoundation.nova.runtime.storage.source.query.AtBlock
 import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNull
+import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNullWithBlockHash
+import io.novafoundation.nova.runtime.storage.source.query.api.observeWithBlockHash
 import io.novafoundation.nova.runtime.storage.typed.events
 import io.novafoundation.nova.runtime.storage.typed.system
 import io.novasama.substrate_sdk_android.extensions.tryFindNonNull
@@ -28,7 +31,7 @@ interface EventsRepository {
 
     suspend fun getExtrinsicWithEvents(chainId: ChainId, extrinsicHash: String, blockHash: BlockHash? = null): ExtrinsicWithEvents?
 
-    fun subscribeEventRecords(chainId: ChainId): Flow<List<EventRecord>>
+    fun subscribeEventRecords(chainId: ChainId): Flow<AtBlock<List<EventRecord>>>
 }
 
 internal class RemoteEventsRepository(
@@ -104,9 +107,9 @@ internal class RemoteEventsRepository(
         }
     }
 
-    override fun subscribeEventRecords(chainId: ChainId): Flow<List<EventRecord>> {
+    override fun subscribeEventRecords(chainId: ChainId): Flow<AtBlock<List<EventRecord>>> {
         return remoteStorageSource.subscribe(chainId) {
-            metadata.system.events.observeNonNull()
+            metadata.system.events.observeNonNullWithBlockHash()
         }
     }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/repository/EventsRepository.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/repository/EventsRepository.kt
@@ -10,9 +10,7 @@ import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.common.utils.metadata
 import io.novafoundation.nova.runtime.storage.source.query.AtBlock
-import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNull
 import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNullWithBlockHash
-import io.novafoundation.nova.runtime.storage.source.query.api.observeWithBlockHash
 import io.novafoundation.nova.runtime.storage.typed.events
 import io.novafoundation.nova.runtime.storage.typed.system
 import io.novasama.substrate_sdk_android.extensions.tryFindNonNull

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/repository/ExtrinsicWithEvents.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/repository/ExtrinsicWithEvents.kt
@@ -84,3 +84,8 @@ fun List<GenericEvent.Instance>.hasEvent(module: String, event: String): Boolean
 fun List<GenericEvent.Instance>.findEvents(module: String, event: String): List<GenericEvent.Instance> {
     return filter { it.instanceOf(module, event) }
 }
+
+
+fun List<GenericEvent.Instance>.findEvents(module: String, vararg events: String): List<GenericEvent.Instance> {
+    return filter { it.instanceOf(module, *events) }
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/repository/ExtrinsicWithEvents.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/runtime/repository/ExtrinsicWithEvents.kt
@@ -85,7 +85,6 @@ fun List<GenericEvent.Instance>.findEvents(module: String, event: String): List<
     return filter { it.instanceOf(module, event) }
 }
 
-
 fun List<GenericEvent.Instance>.findEvents(module: String, vararg events: String): List<GenericEvent.Instance> {
     return filter { it.instanceOf(module, *events) }
 }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/WithRawValue.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/WithRawValue.kt
@@ -5,3 +5,13 @@ import io.novafoundation.nova.core.model.StorageEntry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 
 class WithRawValue<T>(val at: BlockHash?, val raw: StorageEntry, val chainId: ChainId, val value: T)
+
+
+data class AtBlock<T>(val value: T, val at: BlockHash)
+
+fun <T> WithRawValue<T>.toAtBlock(): AtBlock<T> {
+    return AtBlock(
+        at = requireNotNull(at) { "Block hash was not specified" },
+        value = value
+    )
+}

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/WithRawValue.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/WithRawValue.kt
@@ -6,7 +6,6 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 
 class WithRawValue<T>(val at: BlockHash?, val raw: StorageEntry, val chainId: ChainId, val value: T)
 
-
 data class AtBlock<T>(val value: T, val at: BlockHash)
 
 fun <T> WithRawValue<T>.toAtBlock(): AtBlock<T> {

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry0.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry0.kt
@@ -2,11 +2,15 @@ package io.novafoundation.nova.runtime.storage.source.query.api
 
 import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novafoundation.nova.common.utils.createStorageKey
+import io.novafoundation.nova.runtime.storage.source.query.AtBlock
 import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novafoundation.nova.runtime.storage.source.query.WithRawValue
+import io.novafoundation.nova.runtime.storage.source.query.toAtBlock
 import io.novasama.substrate_sdk_android.runtime.metadata.module.StorageEntry
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 
 typealias QueryableStorageBinder0<V> = (dynamicInstance: Any) -> V
 
@@ -25,6 +29,17 @@ interface QueryableStorageEntry0<T : Any> {
     fun observeWithRaw(): Flow<WithRawValue<T?>>
 
     fun storageKey(): String
+}
+
+context(StorageQueryContext)
+fun <V: Any> QueryableStorageEntry0<V>.observeWithBlockHash(): Flow<AtBlock<V?>> {
+    return observeWithRaw().map { it.toAtBlock() }
+}
+
+context(StorageQueryContext)
+@Suppress("UNCHECKED_CAST")
+fun <V: Any> QueryableStorageEntry0<V>.observeNonNullWithBlockHash(): Flow<AtBlock<V>> {
+    return observeWithBlockHash().filter { it.value != null } as Flow<AtBlock<V>>
 }
 
 context(StorageQueryContext)

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry0.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/api/QueryableStorageEntry0.kt
@@ -32,13 +32,13 @@ interface QueryableStorageEntry0<T : Any> {
 }
 
 context(StorageQueryContext)
-fun <V: Any> QueryableStorageEntry0<V>.observeWithBlockHash(): Flow<AtBlock<V?>> {
+fun <V : Any> QueryableStorageEntry0<V>.observeWithBlockHash(): Flow<AtBlock<V?>> {
     return observeWithRaw().map { it.toAtBlock() }
 }
 
 context(StorageQueryContext)
 @Suppress("UNCHECKED_CAST")
-fun <V: Any> QueryableStorageEntry0<V>.observeNonNullWithBlockHash(): Flow<AtBlock<V>> {
+fun <V : Any> QueryableStorageEntry0<V>.observeNonNullWithBlockHash(): Flow<AtBlock<V>> {
     return observeWithBlockHash().filter { it.value != null } as Flow<AtBlock<V>>
 }
 

--- a/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/BatchAllWalkTest.kt
+++ b/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/BatchAllWalkTest.kt
@@ -79,7 +79,7 @@ internal class BatchAllWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(true, visit.success)
         assertArrayEquals(signer, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -95,7 +95,7 @@ internal class BatchAllWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(false, visit.success)
         assertArrayEquals(signer, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -121,7 +121,7 @@ internal class BatchAllWalkTest {
             events = events
         )
 
-        val visits = extrinsicWalk.walkMultiple(extrinsic, expectedSize = 2)
+        val visits = extrinsicWalk.walkMultipleIgnoringBranches(extrinsic, expectedSize = 2)
         visits.forEach { visit ->
             assertEquals(true, visit.success)
             assertArrayEquals(signer, visit.origin)
@@ -139,7 +139,7 @@ internal class BatchAllWalkTest {
             events = events
         )
 
-        val visits = extrinsicWalk.walkMultiple(extrinsic, expectedSize = 2)
+        val visits = extrinsicWalk.walkMultipleIgnoringBranches(extrinsic, expectedSize = 2)
 
         visits.forEach { visit ->
             assertEquals(false, visit.success)
@@ -199,7 +199,7 @@ internal class BatchAllWalkTest {
             events = events
         )
 
-        val visits = extrinsicWalk.walkMultiple(extrinsic, expectedSize = 5)
+        val visits = extrinsicWalk.walkMultipleIgnoringBranches(extrinsic, expectedSize = 5)
         visits.forEach { visit ->
             assertEquals(true, visit.success)
             assertArrayEquals(signer, visit.origin)

--- a/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/Common.kt
+++ b/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/Common.kt
@@ -117,16 +117,30 @@ class TestModuleMocker {
     }
 }
 
-suspend fun ExtrinsicWalk.walkSingle(extrinsicWithEvents: ExtrinsicWithEvents): ExtrinsicVisit {
-    val visits = walkToList(extrinsicWithEvents, Chain.Geneses.POLKADOT)
+suspend fun ExtrinsicWalk.walkSingleIgnoringBranches(extrinsicWithEvents: ExtrinsicWithEvents): ExtrinsicVisit {
+    val visits = walkToList(extrinsicWithEvents, Chain.Geneses.POLKADOT).ignoreBranches()
     Assert.assertEquals(1, visits.size)
 
     return visits.single()
 }
 
-suspend fun ExtrinsicWalk.walkMultiple(extrinsicWithEvents: ExtrinsicWithEvents, expectedSize: Int): List<ExtrinsicVisit> {
-    val visits = walkToList(extrinsicWithEvents, Chain.Geneses.POLKADOT)
+suspend fun ExtrinsicWalk.walkToList(extrinsicWithEvents: ExtrinsicWithEvents): List<ExtrinsicVisit> {
+   return walkToList(extrinsicWithEvents, Chain.Geneses.POLKADOT)
+}
+
+suspend fun ExtrinsicWalk.walkEmpty(extrinsicWithEvents: ExtrinsicWithEvents) {
+    val visits = walkToList(extrinsicWithEvents, Chain.Geneses.POLKADOT).ignoreBranches()
+    Assert.assertTrue(visits.isEmpty())
+}
+
+
+suspend fun ExtrinsicWalk.walkMultipleIgnoringBranches(extrinsicWithEvents: ExtrinsicWithEvents, expectedSize: Int): List<ExtrinsicVisit> {
+    val visits = walkToList(extrinsicWithEvents, Chain.Geneses.POLKADOT).ignoreBranches()
     Assert.assertEquals(expectedSize, visits.size)
 
     return visits
+}
+
+private fun List<ExtrinsicVisit>.ignoreBranches(): List<ExtrinsicVisit> {
+    return filterNot { it.hasRegisteredNode }
 }

--- a/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/ForceBatchWalkTest.kt
+++ b/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/ForceBatchWalkTest.kt
@@ -81,7 +81,7 @@ internal class ForceBatchWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(true, visit.success)
         assertArrayEquals(signer, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -98,7 +98,7 @@ internal class ForceBatchWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(false, visit.success)
         assertArrayEquals(signer, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -124,7 +124,7 @@ internal class ForceBatchWalkTest {
             events = events
         )
 
-        val visits = extrinsicWalk.walkMultiple(extrinsic, expectedSize = 2)
+        val visits = extrinsicWalk.walkMultipleIgnoringBranches(extrinsic, expectedSize = 2)
         visits.forEach { visit ->
             assertEquals(true, visit.success)
             assertArrayEquals(signer, visit.origin)
@@ -154,7 +154,7 @@ internal class ForceBatchWalkTest {
             events = events
         )
 
-        val visits = extrinsicWalk.walkMultiple(extrinsic, expectedSize = 3)
+        val visits = extrinsicWalk.walkMultipleIgnoringBranches(extrinsic, expectedSize = 3)
 
         val expected: List<Pair<Boolean, List<GenericEvent.Instance>>> = listOf(
             true to innerBatchEvents,
@@ -221,7 +221,7 @@ internal class ForceBatchWalkTest {
             events = events
         )
 
-        val visits = extrinsicWalk.walkMultiple(extrinsic, expectedSize = 5)
+        val visits = extrinsicWalk.walkMultipleIgnoringBranches(extrinsic, expectedSize = 5)
         visits.forEach { visit ->
             assertEquals(true, visit.success)
             assertArrayEquals(signer, visit.origin)

--- a/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/MultisigWalkTest.kt
+++ b/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/MultisigWalkTest.kt
@@ -1,0 +1,229 @@
+package io.novafoundation.nova.runtime.extrinsic.visitor.impl
+
+import io.novafoundation.nova.common.address.intoKey
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicWalk
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.nodes.multisig.MultisigNode
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.nodes.multisig.generateMultisigAddress
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.runtime.RuntimeProvider
+import io.novafoundation.nova.test_shared.any
+import io.novafoundation.nova.test_shared.whenever
+import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
+import io.novasama.substrate_sdk_android.runtime.metadata.RuntimeMetadata
+import io.novasama.substrate_sdk_android.runtime.metadata.module.Event
+import io.novasama.substrate_sdk_android.runtime.metadata.module.Module
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertArrayEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+internal class MultisigWalkTest {
+
+    @Mock
+    private lateinit var runtimeProvider: RuntimeProvider
+
+    @Mock
+    private lateinit var chainRegistry: ChainRegistry
+
+    @Mock
+    private lateinit var runtime: RuntimeSnapshot
+
+    @Mock
+    private lateinit var metadata: RuntimeMetadata
+
+    @Mock
+    private lateinit var multisigModule: Module
+
+    private lateinit var extrinsicWalk: ExtrinsicWalk
+
+    private val multisigExecutedEvent = Event("MultisigExecuted", index = 0 to 0, documentation = emptyList(), arguments = emptyList())
+    private val multisigApprovalEvent = Event("MultisigApproval", index = 0 to 1, documentation = emptyList(), arguments = emptyList())
+    private val multisigNewMultisigEvent = Event("NewMultisig", index = 0 to 1, documentation = emptyList(), arguments = emptyList())
+
+    private val signatory = byteArrayOf(0x00)
+    private val otherSignatories = listOf(byteArrayOf(0x01))
+    private val threshold = 2
+    private val multisig = generateMultisigAddress(
+        signatory = signatory.intoKey(),
+        otherSignatories = otherSignatories.map { it.intoKey() },
+        threshold = threshold
+    ).value
+
+    private val testModuleMocker = TestModuleMocker()
+    private val testEvent = testModuleMocker.testEvent
+    private val testInnerCall = testModuleMocker.testInnerCall
+
+    @Before
+    fun setup() = runBlocking {
+        // Explicitly using string literals instead of accessing name property as this would result in Unfinished stubbing exception
+        whenever(multisigModule.events).thenReturn(
+            mapOf(
+                "MultisigExecuted" to multisigExecutedEvent,
+                "MultisigApproval" to multisigApprovalEvent,
+                "NewMultisig" to multisigNewMultisigEvent
+            )
+        )
+        whenever(multisigModule.name).thenReturn("Multisig")
+        whenever(metadata.modules).thenReturn(mapOf("Multisig" to multisigModule))
+        whenever(runtime.metadata).thenReturn(metadata)
+        whenever(runtimeProvider.get()).thenReturn(runtime)
+        whenever(chainRegistry.getRuntimeProvider(any())).thenReturn(runtimeProvider)
+
+        extrinsicWalk = RealExtrinsicWalk(chainRegistry, knownNodes = listOf(MultisigNode()))
+    }
+
+    @Test
+    fun shouldVisitSucceededSingleMultisigCall() = runBlocking {
+        val innerMultisigEvents = listOf(testEvent)
+        val events = innerMultisigEvents + listOf(multisigExecuted(success = true), extrinsicSuccess())
+
+        val extrinsic = createExtrinsic(
+            signer = signatory,
+            call = multisig_call(
+                innerCall = testInnerCall,
+                threshold = threshold,
+                otherSignatories = otherSignatories
+            ),
+            events = events
+        )
+
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
+        assertEquals(true, visit.success)
+        assertArrayEquals(multisig, visit.origin)
+        assertEquals(testInnerCall, visit.call)
+        assertEquals(innerMultisigEvents, visit.events)
+    }
+
+    @Test
+    fun shouldVisitFailedSingleMultisigCall() = runBlocking {
+        val innerMultisigEvents = emptyList<GenericEvent.Instance>()
+        val events = listOf(multisigExecuted(success = false), extrinsicSuccess())
+
+        val extrinsic = createExtrinsic(
+            signer = signatory,
+            call = multisig_call(
+                innerCall = testInnerCall,
+                threshold = threshold,
+                otherSignatories = otherSignatories
+            ),
+            events = events
+        )
+
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
+        assertEquals(false, visit.success)
+        assertArrayEquals(multisig, visit.origin)
+        assertEquals(testInnerCall, visit.call)
+        assertEquals(innerMultisigEvents, visit.events)
+    }
+
+    @Test
+    fun shouldVisitNewMultisigCall() = runBlocking {
+        val events = listOf(newMultisig(), extrinsicSuccess())
+
+        val extrinsic = createExtrinsic(
+            signer = signatory,
+            call = multisig_call(
+                innerCall = testInnerCall,
+                threshold = threshold,
+                otherSignatories = otherSignatories
+            ),
+            events = events
+        )
+
+        extrinsicWalk.walkEmpty(extrinsic)
+    }
+
+    @Test
+    fun shouldVisitMultisigApprovalCall() = runBlocking {
+        val events = listOf(multisigApproval(), extrinsicSuccess())
+
+        val extrinsic = createExtrinsic(
+            signer = signatory,
+            call = multisig_call(
+                innerCall = testInnerCall,
+                threshold = threshold,
+                otherSignatories = otherSignatories
+            ),
+            events = events
+        )
+
+        extrinsicWalk.walkEmpty(extrinsic)
+    }
+
+    @Test
+    fun shouldVisitSucceededNestedMultisigCalls() = runBlocking {
+        val events = listOf(
+            newMultisig(),
+            multisigExecuted(success = true),
+            extrinsicSuccess()
+        )
+
+        val otherSignatories2 = otherSignatories
+        val threshold2 = 1
+
+        val extrinsic = createExtrinsic(
+            signer = signatory,
+            call = multisig_call(
+                threshold = threshold,
+                otherSignatories = otherSignatories,
+                innerCall = multisig_call(
+                    innerCall = testInnerCall,
+                    threshold = threshold2,
+                    otherSignatories = otherSignatories2
+                ),
+            ),
+            events = events
+        )
+
+        val visit = extrinsicWalk.walkToList(extrinsic)
+        assertEquals(2, visit.size)
+
+        val visit1 = visit[0]
+        assertEquals(true, visit1.success)
+        assertArrayEquals(signatory, visit1.origin)
+
+        val visit2 = visit[1]
+        assertEquals(true, visit2.success)
+        assertArrayEquals(multisig, visit2.origin)
+    }
+
+    private fun multisigExecuted(success: Boolean): GenericEvent.Instance {
+        val outcomeVariant = if (success) "Ok" else "Err"
+        val outcome = DictEnum.Entry(name = outcomeVariant, value = null)
+
+        return GenericEvent.Instance(multisigModule, multisigExecutedEvent, arguments = listOf(null, null, null, null, outcome))
+    }
+
+    private fun newMultisig(): GenericEvent.Instance {
+        return GenericEvent.Instance(multisigModule, multisigNewMultisigEvent, arguments = emptyList())
+    }
+
+    private fun multisigApproval(): GenericEvent.Instance {
+        return GenericEvent.Instance(multisigModule, multisigApprovalEvent, arguments = emptyList())
+    }
+
+    private fun multisig_call(
+        innerCall: GenericCall.Instance,
+        threshold: Int,
+        otherSignatories: List<ByteArray>
+    ): GenericCall.Instance {
+        return mockCall(
+            moduleName = "Multisig",
+            callName = "as_multi",
+            arguments = mapOf(
+                "threshold" to threshold.toBigInteger(),
+                "other_signatories" to otherSignatories,
+                "call" to innerCall,
+                // other args are not relevant
+            )
+        )
+    }
+}

--- a/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/ProxyWalkTest.kt
+++ b/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/ProxyWalkTest.kt
@@ -75,7 +75,7 @@ internal class ProxyWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(true, visit.success)
         assertArrayEquals(proxied, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -92,7 +92,7 @@ internal class ProxyWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(false, visit.success)
         assertArrayEquals(proxied, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -113,7 +113,7 @@ internal class ProxyWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(true, visit.success)
         assertArrayEquals(proxied, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -134,7 +134,7 @@ internal class ProxyWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(false, visit.success)
         assertArrayEquals(proxied, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -166,7 +166,7 @@ internal class ProxyWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(true, visit.success)
         assertArrayEquals(proxied, visit.origin)
         assertEquals(testInnerCall, visit.call)
@@ -198,7 +198,7 @@ internal class ProxyWalkTest {
             events = events
         )
 
-        val visit = extrinsicWalk.walkSingle(extrinsic)
+        val visit = extrinsicWalk.walkSingleIgnoringBranches(extrinsic)
         assertEquals(false, visit.success)
         assertArrayEquals(proxied, visit.origin)
         assertEquals(testInnerCall, visit.call)

--- a/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/multisig/CommonsTest.kt
+++ b/runtime/src/test/java/io/novafoundation/nova/runtime/extrinsic/visitor/impl/multisig/CommonsTest.kt
@@ -1,0 +1,60 @@
+package io.novafoundation.nova.runtime.extrinsic.visitor.impl.multisig
+
+import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.address.intoKey
+import io.novafoundation.nova.runtime.extrinsic.visitor.impl.nodes.multisig.generateMultisigAddress
+import io.novasama.substrate_sdk_android.extensions.asEthereumAddress
+import io.novasama.substrate_sdk_android.extensions.toAccountId
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+
+class CommonsTest {
+
+    @Test
+    fun shouldGenerateSs58MultisigAddress() {
+        shouldGenerateMultisigAddress(
+            signatories = listOf(
+                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+                "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+                "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"
+            ),
+            threshold = 2,
+            expected = "5DjYJStmdZ2rcqXbXGX7TW85JsrW6uG4y9MUcLq2BoPMpRA7",
+        )
+    }
+
+    @Test
+    fun shouldGenerateEvmMultisigAddress() {
+        shouldGenerateMultisigAddress(
+            signatories = listOf(
+                "0xC60eFE26b9b92380D1b2c479472323eC35F0f0aB",
+                "0x61d8c5647f4181f2c35996c62a6272967f5739a8",
+                "0xaCCaCE4056A930745218328BF086369Fbd61c212"
+            ),
+            threshold =2,
+            expected = "0xb4e55b61678623fd5ece9c24e79d6c0532bee057",
+        )
+    }
+
+    private fun shouldGenerateMultisigAddress(
+        signatories: List<String>,
+        threshold: Int,
+        expected: String
+    ) {
+        val accountIds = signatories.map { it.addressToAccountId() }
+        val expectedId = expected.addressToAccountId()
+
+        val actual = generateMultisigAddress(accountIds, threshold)
+        assertArrayEquals(expectedId.value, actual.value)
+    }
+
+    private fun String.addressToAccountId(): AccountIdKey {
+        return if (startsWith("0x")) {
+            asEthereumAddress().toAccountId().value
+        } else {
+            toAccountId()
+        }.intoKey()
+    }
+}


### PR DESCRIPTION
* Implement multisig address derivation + tests
* Implement MultisigNode for ExtrinsicWalk + tests
* Detect pending call-data in realtime by analysing extrinsics related to user's multisigs. Analysis is done by traversing all as_multi calls and comparing call-datas with newly found call-hashes