### PR TITLE
Multisig/nested signers calldata sync

### DIFF
--- a/core-db/src/main/java/io/novafoundation/nova/core_db/dao/MetaAccountDao.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/dao/MetaAccountDao.kt
@@ -126,12 +126,6 @@ interface MetaAccountDao {
     @Transaction
     suspend fun getMetaAccountsQuantityByStatus(status: MetaAccountLocal.Status): Int
 
-    @Query("SELECT id FROM meta_accounts WHERE status = :status")
-    suspend fun getMetaAccountIdsByStatus(status: MetaAccountLocal.Status): List<Long>
-
-    @Query("SELECT id FROM meta_accounts WHERE type = :type")
-    suspend fun getMetaAccountIdsByType(type: MetaAccountLocal.Type): List<Long>
-
     @Query("SELECT * FROM meta_accounts WHERE status = :status")
     @Transaction
     suspend fun getMetaAccountsByStatus(status: MetaAccountLocal.Status): List<RelationJoinedMetaAccountInfo>
@@ -151,9 +145,6 @@ interface MetaAccountDao {
 
     @Query(META_ACCOUNT_WITH_BALANCE_QUERY)
     fun metaAccountWithBalanceFlow(metaId: Long): Flow<List<MetaAccountWithBalanceLocal>>
-
-    @Query("SELECT * FROM proxy_accounts WHERE chainId = :chainId")
-    suspend fun getProxyAccounts(chainId: String): List<ProxyAccountLocal>
 
     @Query("UPDATE meta_accounts SET isSelected = (id = :metaId)")
     suspend fun selectMetaAccount(metaId: Long)
@@ -222,6 +213,9 @@ interface MetaAccountDao {
 
     @Query("SELECT * FROM meta_accounts WHERE isSelected = 1")
     suspend fun selectedMetaAccount(): RelationJoinedMetaAccountInfo?
+
+    @Query("SELECT EXISTS(SELECT id FROM meta_accounts WHERE type = :type)")
+    fun hasMetaAccountsCountOfTypeFlow(type: MetaAccountLocal.Type): Flow<Boolean>
 
     @Query(
         """

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/interfaces/AccountRepository.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/interfaces/AccountRepository.kt
@@ -128,7 +128,7 @@ interface AccountRepository {
 
     suspend fun getActiveMetaAccountsQuantity(): Int
 
-    suspend fun getMetaAccountIdsByType(type: LightMetaAccount.Type): List<Long>
+    fun hasMetaAccountsCountOfTypeFlow(type: LightMetaAccount.Type): Flow<Boolean>
 
     suspend fun generateRestoreJson(metaAccount: MetaAccount, password: String): String
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/AccountRepositoryImpl.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/AccountRepositoryImpl.kt
@@ -292,8 +292,8 @@ class AccountRepositoryImpl(
         return accountDataSource.getActiveMetaAccountsQuantity()
     }
 
-    override suspend fun getMetaAccountIdsByType(type: LightMetaAccount.Type): List<Long> {
-        return accountDataSource.getMetaAccountIdsByType(type)
+    override fun hasMetaAccountsCountOfTypeFlow(type: LightMetaAccount.Type): Flow<Boolean> {
+       return accountDataSource.hasMetaAccountsCountOfTypeFlow(type)
     }
 
     override suspend fun hasSecretsAccounts(): Boolean {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/AccountRepositoryImpl.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/AccountRepositoryImpl.kt
@@ -293,7 +293,7 @@ class AccountRepositoryImpl(
     }
 
     override fun hasMetaAccountsCountOfTypeFlow(type: LightMetaAccount.Type): Flow<Boolean> {
-       return accountDataSource.hasMetaAccountsCountOfTypeFlow(type)
+        return accountDataSource.hasMetaAccountsCountOfTypeFlow(type)
     }
 
     override suspend fun hasSecretsAccounts(): Boolean {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSource.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSource.kt
@@ -101,11 +101,11 @@ interface AccountDataSource : SecretStoreV1 {
 
     suspend fun getAllMetaAccounts(): List<MetaAccount>
 
+    fun hasMetaAccountsCountOfTypeFlow(type: LightMetaAccount.Type): Flow<Boolean>
+
     suspend fun getActiveMetaAccountsQuantity(): Int
 
     suspend fun hasSecretsAccounts(): Boolean
-
-    suspend fun getMetaAccountIdsByType(type: LightMetaAccount.Type): List<Long>
 
     suspend fun deleteProxiedMetaAccountsByChain(chainId: String)
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSourceImpl.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSourceImpl.kt
@@ -152,7 +152,7 @@ class AccountDataSourceImpl(
     }
 
     override fun hasMetaAccountsCountOfTypeFlow(type: LightMetaAccount.Type): Flow<Boolean> {
-       return metaAccountDao.hasMetaAccountsCountOfTypeFlow(mapMetaAccountTypeToLocal(type)).distinctUntilChanged()
+        return metaAccountDao.hasMetaAccountsCountOfTypeFlow(mapMetaAccountTypeToLocal(type)).distinctUntilChanged()
     }
 
     override suspend fun getActiveMetaAccountsQuantity(): Int {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSourceImpl.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSourceImpl.kt
@@ -151,12 +151,12 @@ class AccountDataSourceImpl(
         return accountMappers.mapMetaAccountsLocalToMetaAccounts(local)
     }
 
-    override suspend fun getActiveMetaAccountsQuantity(): Int {
-        return metaAccountDao.getMetaAccountsQuantityByStatus(MetaAccountLocal.Status.ACTIVE)
+    override fun hasMetaAccountsCountOfTypeFlow(type: LightMetaAccount.Type): Flow<Boolean> {
+       return metaAccountDao.hasMetaAccountsCountOfTypeFlow(mapMetaAccountTypeToLocal(type)).distinctUntilChanged()
     }
 
-    override suspend fun getMetaAccountIdsByType(type: LightMetaAccount.Type): List<Long> {
-        return metaAccountDao.getMetaAccountIdsByType(mapMetaAccountTypeToLocal(type))
+    override suspend fun getActiveMetaAccountsQuantity(): Int {
+        return metaAccountDao.getMetaAccountsQuantityByStatus(MetaAccountLocal.Status.ACTIVE)
     }
 
     override suspend fun deleteProxiedMetaAccountsByChain(chainId: String) {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/multisig/MultisigSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/multisig/MultisigSigner.kt
@@ -81,7 +81,6 @@ class MultisigSigner(
 
         // TODO multisig: implement acknowledge and validation
         // 1. Balance is enough
-        // 2. There is no pending mst with this exact call
 //        if (isRootSigner) {
 //            acknowledgeProxyOperation(signatoryMetaAccount())
 //            validateExtrinsic(context.chain)

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
@@ -2,46 +2,30 @@ package io.novafoundation.nova.feature_account_impl.domain.multisig
 
 import android.util.Log
 import io.novafoundation.nova.common.address.AccountIdKey
-import io.novafoundation.nova.common.address.intoKey
 import io.novafoundation.nova.common.data.memory.LazyAsyncMultiCache
-import io.novafoundation.nova.common.data.network.runtime.binding.BlockHash
-import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
-import io.novafoundation.nova.common.data.network.runtime.binding.bindGenericCall
 import io.novafoundation.nova.common.di.scope.FeatureScope
-import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.flowOf
-import io.novafoundation.nova.common.utils.instanceOf
-import io.novafoundation.nova.common.utils.isSigned
 import io.novafoundation.nova.common.utils.launchUnit
 import io.novafoundation.nova.common.utils.mapNotNullToSet
-import io.novafoundation.nova.common.utils.put
 import io.novafoundation.nova.common.utils.shareInBackground
 import io.novafoundation.nova.feature_account_api.data.multisig.model.PendingMultisigOperation
 import io.novafoundation.nova.feature_account_api.domain.model.MultisigMetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.accountIdKeyIn
 import io.novafoundation.nova.feature_account_api.domain.multisig.CallHash
-import io.novafoundation.nova.feature_account_api.domain.multisig.bindCallHash
 import io.novafoundation.nova.feature_account_impl.data.multisig.MultisigRepository
 import io.novafoundation.nova.feature_account_impl.data.multisig.blockhain.model.OnChainMultisig
-import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
+import io.novafoundation.nova.feature_account_impl.domain.multisig.calldata.RealtimeCallDataWatcher
 import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicWalk
-import io.novafoundation.nova.runtime.extrinsic.visitor.api.walkToList
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import io.novafoundation.nova.runtime.multiNetwork.getRuntime
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
-import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.ExtrinsicWithEvents
-import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.events
-import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.findEvents
-import io.novasama.substrate_sdk_android.hash.Hasher.blake2b256
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
-import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
-import io.novasama.substrate_sdk_android.runtime.definitions.types.toByteArray
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -51,25 +35,21 @@ import javax.inject.Inject
 
 @FeatureScope
 internal class MultisigChainPendingOperationsSyncerFactory @Inject constructor(
-    private val eventsRepository: EventsRepository,
     private val multisigRepository: MultisigRepository,
-    private val chainRegistry: ChainRegistry,
-    private val extrinsicWalk: ExtrinsicWalk,
 ) {
 
     fun create(
         chain: Chain,
         multisig: MultisigMetaAccount,
+        callDataWatcher: RealtimeCallDataWatcher,
         scope: CoroutineScope,
     ): MultisigPendingOperationsSyncer {
         return RealMultisigChainPendingOperationsSyncer(
             chain = chain,
             multisig = multisig,
             scope = scope,
-            eventsRepository = eventsRepository,
             multisigRepository = multisigRepository,
-            chainRegistry = chainRegistry,
-            extrinsicWalk = extrinsicWalk
+            callDataWatcher = callDataWatcher
         )
     }
 }
@@ -82,21 +62,12 @@ internal interface MultisigPendingOperationsSyncer {
 }
 
 internal class RealMultisigChainPendingOperationsSyncer(
-    val chain: Chain,
-    val multisig: MultisigMetaAccount,
-    val scope: CoroutineScope,
-    private val eventsRepository: EventsRepository,
+    private val chain: Chain,
+    private val multisig: MultisigMetaAccount,
+    private val scope: CoroutineScope,
+    private val callDataWatcher: RealtimeCallDataWatcher,
     private val multisigRepository: MultisigRepository,
-    private val extrinsicWalk: ExtrinsicWalk,
-    private val chainRegistry: ChainRegistry,
 ) : CoroutineScope by scope, MultisigPendingOperationsSyncer {
-
-    companion object {
-
-        private const val NEW_MULTISIG = "NewMultisig"
-
-        private const val MULTISIG_APPROVAL = "MultisigApproval"
-    }
 
     private val pendingCallHashesFlow = MutableStateFlow<Set<CallHash>>(emptySet())
 
@@ -133,20 +104,31 @@ internal class RealMultisigChainPendingOperationsSyncer(
         startDetectingNewPendingCallHashesFromEvents(accountId)
     }
 
+    private fun startDetectingNewPendingCallHashesFromEvents(accountId: AccountIdKey) {
+        callDataWatcher.newMultisigEvents
+            .filter { it.multisig == accountId && it.chainId == chain.id }
+            .onEach {
+                pendingCallHashesFlow.update { pendingCallHashesFlow -> pendingCallHashesFlow + it.callHash }
+            }.launchIn(this)
+    }
+
     private suspend fun observePendingOperations(callHashes: Set<CallHash>): Flow<Map<CallHash, PendingMultisigOperation?>> {
         val accountId = multisig.accountIdKeyIn(chain)
         if (accountId == null || callHashes.isEmpty()) return flowOf { emptyMap() }
 
-        val callDatasFlow = flowOf { knownCallDatas.getOrCompute(callHashes) }
+        val callDatasFromFetchFlow = flowOf { knownCallDatas.getOrCompute(callHashes) }
 
         return combine(
-            callDatasFlow,
+            callDataWatcher.realtimeCallData,
+            callDatasFromFetchFlow,
             multisigRepository.subscribePendingOperations(this.chain, accountId, callHashes)
-        ) { callDatas, onChainOperations ->
+        ) { realtimeCallDatas, callDatas, onChainOperations ->
             onChainOperations.mapValues { (callHash, onChainOperation) ->
+                val realtimeKey = chain.id to callHash
+
                 PendingMultisigOperation.from(
                     onChainMultisig = onChainOperation ?: return@mapValues null,
-                    callData = callDatas[callHash],
+                    callData = realtimeCallDatas[realtimeKey] ?: callDatas[callHash],
                     chain = chain,
                 )
             }
@@ -178,96 +160,5 @@ internal class RealMultisigChainPendingOperationsSyncer(
         }.onFailure {
             Log.e("RealMultisigChainPendingOperationsSyncer", "Failed to load initial call hashes", it)
         }
-    }
-
-    private fun startDetectingNewPendingCallHashesFromEvents(accountId: AccountIdKey) {
-        eventsRepository.subscribeEventRecords(chain.id).map { (eventRecords, blockHash) ->
-            val newCallHashes = eventRecords.events().findOurNewMultisigs(accountId)
-
-            // Important to do this first, so `pendingCallHashesFlow` will trigger list re-compute when detected call-data is already present in
-            // `knownCallDatas`
-            tryAddNewCallDatas(newCallHashes, blockHash)
-
-            pendingCallHashesFlow.update { it + newCallHashes }
-        }
-            .catch { Log.e("RealMultisigChainPendingOperationsSyncer", "Failed to detect new pending operations from events", it) }
-            .launchIn(this)
-    }
-
-    private suspend fun tryAddNewCallDatas(newCallHashes: List<CallHash>, blockHash: BlockHash): Result<Unit> = runCatching {
-        if (newCallHashes.isEmpty()) return@runCatching
-
-        Log.d("RealMultisigChainPendingOperationsSyncer", "Detected own multisig at block $blockHash, trying to find call-data")
-
-        val blockWithEvents = eventsRepository.getBlockEvents(chain.id, blockHash)
-
-        val newCallDatas = buildMap {
-            blockWithEvents.applyExtrinsic
-                .filter { it.extrinsic.isSigned() }
-                .forEach { extrinsicWithEvents -> extrinsicWithEvents.tryAddNewCallDatas(newCallHashes) }
-        }
-
-        Log.d("RealMultisigChainPendingOperationsSyncer", "Found call-datas: ${newCallDatas.size}")
-
-        knownCallDatas.putAll(newCallDatas)
-    }.onFailure {
-        Log.e("RealMultisigChainPendingOperationsSyncer", "Error while detecting call-data from chain", it)
-    }
-
-    context(MutableMap<CallHash, GenericCall.Instance>)
-    private suspend fun ExtrinsicWithEvents.tryAddNewCallDatas(newCallHashes: List<CallHash>) {
-        val visitedEntries = extrinsicWalk.walkToList(source = this@tryAddNewCallDatas, chain.id)
-        visitedEntries.forEach {
-            val callHashAndData = it.tryFindCallDataInAsMulti(newCallHashes)
-            if (callHashAndData != null) {
-                put(callHashAndData)
-            }
-        }
-    }
-
-    private suspend fun ExtrinsicVisit.tryFindCallDataInAsMulti(callHashes: List<CallHash>): Pair<CallHash, GenericCall.Instance>? {
-        if (!call.instanceOf(Modules.MULTISIG, "as_multi")) return null
-
-        val runtime = chainRegistry.getRuntime(chain.id)
-
-        val callData = bindGenericCall(call.arguments["call"])
-        val callHash = GenericCall.toByteArray(runtime, callData).blake2b256().intoKey()
-
-        return if (callHash in callHashes) {
-            callHash to callData
-        } else {
-            null
-        }
-    }
-
-    private fun List<GenericEvent.Instance>.findOurNewMultisigs(ourAccountId: AccountIdKey): List<CallHash> {
-        return findEvents(Modules.MULTISIG, NEW_MULTISIG, MULTISIG_APPROVAL).mapNotNull { newMultisigEvent ->
-            extractOurCallHash(newMultisigEvent, ourAccountId)
-        }
-    }
-
-    private fun extractOurCallHash(
-        newMultisigEvent: GenericEvent.Instance,
-        ourAccountId: AccountIdKey
-    ): CallHash? {
-        return runCatching {
-            val multisigRaw: Any?
-            val callHashRaw: Any?
-
-            if (newMultisigEvent.instanceOf(Modules.MULTISIG, NEW_MULTISIG)) {
-                multisigRaw = newMultisigEvent.arguments[1]
-                callHashRaw = newMultisigEvent.arguments[2]
-            } else {
-                multisigRaw = newMultisigEvent.arguments[2]
-                callHashRaw = newMultisigEvent.arguments[3]
-            }
-
-            val multisig = bindAccountIdKey(multisigRaw)
-            val callHash = bindCallHash(callHashRaw)
-
-            callHash.takeIf { multisig == ourAccountId }
-        }
-            .onFailure { Log.e("RealMultisigChainPendingOperationsSyncer", "Failed to parse new NewMultisig/MultisigApproval event", it) }
-            .getOrNull()
     }
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/MultisigPendingOperationsSyncer.kt
@@ -15,10 +15,7 @@ import io.novafoundation.nova.feature_account_api.domain.multisig.CallHash
 import io.novafoundation.nova.feature_account_impl.data.multisig.MultisigRepository
 import io.novafoundation.nova.feature_account_impl.data.multisig.blockhain.model.OnChainMultisig
 import io.novafoundation.nova.feature_account_impl.domain.multisig.calldata.RealtimeCallDataWatcher
-import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicWalk
-import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/EventsRealtimeCallDataWatcher.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/EventsRealtimeCallDataWatcher.kt
@@ -1,0 +1,163 @@
+package io.novafoundation.nova.feature_account_impl.domain.multisig.calldata
+
+import android.util.Log
+import io.novafoundation.nova.common.address.intoKey
+import io.novafoundation.nova.common.data.network.runtime.binding.BlockHash
+import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountIdKey
+import io.novafoundation.nova.common.data.network.runtime.binding.bindGenericCall
+import io.novafoundation.nova.common.utils.Modules
+import io.novafoundation.nova.common.utils.instanceOf
+import io.novafoundation.nova.common.utils.isSigned
+import io.novafoundation.nova.common.utils.put
+import io.novafoundation.nova.feature_account_api.domain.multisig.CallHash
+import io.novafoundation.nova.feature_account_api.domain.multisig.bindCallHash
+import io.novafoundation.nova.feature_account_impl.data.multisig.MultisigRepository
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicVisit
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicWalk
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.walkToList
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.enabledChains
+import io.novafoundation.nova.runtime.multiNetwork.getRuntime
+import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
+import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.ExtrinsicWithEvents
+import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.events
+import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.findEvents
+import io.novasama.substrate_sdk_android.hash.Hasher.blake2b256
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
+import io.novasama.substrate_sdk_android.runtime.definitions.types.toByteArray
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+class EventsRealtimeCallDataWatcher(
+    private val eventsRepository: EventsRepository,
+    private val extrinsicWalk: ExtrinsicWalk,
+    private val chainRegistry: ChainRegistry,
+    private val multisigRepository: MultisigRepository,
+    coroutineScope: CoroutineScope,
+) : RealtimeCallDataWatcher, CoroutineScope by coroutineScope {
+
+    companion object {
+
+        private const val NEW_MULTISIG = "NewMultisig"
+
+        private const val MULTISIG_APPROVAL = "MultisigApproval"
+    }
+
+    override val realtimeCallData = MutableStateFlow<Map<MultiChainCallHash, GenericCall.Instance>>(emptyMap())
+
+    override val newMultisigEvents= MutableSharedFlow<MultiChainMultisigEvent>(extraBufferCapacity = 10)
+
+    init {
+        launch {
+            val multisigChains = chainRegistry.enabledChains()
+                .filter { multisigRepository.supportsMultisigSync(it) }
+
+            multisigChains.forEach(::startDetectingNewPendingCallHashesFromEvents)
+        }
+    }
+
+    private fun startDetectingNewPendingCallHashesFromEvents(chain: Chain) {
+        eventsRepository.subscribeEventRecords(chain.id).map { (eventRecords, blockHash) ->
+            val newMultisigEvents = eventRecords.events().findNewMultisigs(chain)
+            val newCallHashes = newMultisigEvents.map { it.callHash }
+
+            newMultisigEvents.forEach { this.newMultisigEvents.emit(it) }
+
+            tryAddNewCallDatas(newCallHashes, blockHash, chain)
+        }
+            .catch { Log.e("ChainRealtimeCallDataWatcher", "Failed to detect new pending operations from events", it) }
+            .launchIn(this)
+    }
+
+    private suspend fun tryAddNewCallDatas(
+        newCallHashes: List<CallHash>,
+        blockHash: BlockHash,
+        chain: Chain
+    ): Result<Unit> = runCatching {
+        if (newCallHashes.isEmpty()) return@runCatching
+
+        Log.d("ChainRealtimeCallDataWatcher", "Detected multisig at block $blockHash, trying to find call-data")
+
+        val blockWithEvents = eventsRepository.getBlockEvents(chain.id, blockHash)
+
+        val newCallDatas = buildMap {
+            blockWithEvents.applyExtrinsic
+                .filter { it.extrinsic.isSigned() }
+                .forEach { extrinsicWithEvents -> extrinsicWithEvents.tryAddNewCallDatas(newCallHashes, chain) }
+        }
+        val newCallDatasWithChain = newCallDatas.mapKeys { (callHash, _) -> chain.id to callHash }
+
+        Log.d("ChainRealtimeCallDataWatcher", "Found call-datas: ${newCallDatas.size}")
+
+        realtimeCallData.value += newCallDatasWithChain
+    }.onFailure {
+        Log.e("ChainRealtimeCallDataWatcher", "Error while detecting call-data from chain", it)
+    }
+
+    context(MutableMap<CallHash, GenericCall.Instance>)
+    private suspend fun ExtrinsicWithEvents.tryAddNewCallDatas(newCallHashes: List<CallHash>, chain: Chain) {
+        val visitedEntries = extrinsicWalk.walkToList(source = this@tryAddNewCallDatas, chain.id)
+        visitedEntries.forEach {
+            val callHashAndData = it.tryFindCallDataInAsMulti(newCallHashes, chain)
+            if (callHashAndData != null) {
+                put(callHashAndData)
+            }
+        }
+    }
+
+    private suspend fun ExtrinsicVisit.tryFindCallDataInAsMulti(
+        callHashes: List<CallHash>,
+        chain: Chain
+    ): Pair<CallHash, GenericCall.Instance>? {
+        if (!call.instanceOf(Modules.MULTISIG, "as_multi")) return null
+
+        val runtime = chainRegistry.getRuntime(chain.id)
+
+        val callData = bindGenericCall(call.arguments["call"])
+        val callHash = GenericCall.toByteArray(runtime, callData).blake2b256().intoKey()
+
+        return if (callHash in callHashes) {
+            callHash to callData
+        } else {
+            null
+        }
+    }
+
+    private fun List<GenericEvent.Instance>.findNewMultisigs(chain: Chain): List<MultiChainMultisigEvent> {
+        return findEvents(Modules.MULTISIG, NEW_MULTISIG, MULTISIG_APPROVAL).mapNotNull { newMultisigEvent ->
+            extractCallHash(newMultisigEvent, chain)
+        }
+    }
+
+    private fun extractCallHash(
+        newMultisigEvent: GenericEvent.Instance,
+        chain: Chain
+    ): MultiChainMultisigEvent? {
+        return runCatching {
+            val multisigRaw: Any?
+            val callHashRaw: Any?
+
+            if (newMultisigEvent.instanceOf(Modules.MULTISIG, NEW_MULTISIG)) {
+                multisigRaw = newMultisigEvent.arguments[1]
+                callHashRaw = newMultisigEvent.arguments[2]
+            } else {
+                multisigRaw = newMultisigEvent.arguments[2]
+                callHashRaw = newMultisigEvent.arguments[3]
+            }
+
+            val multisig = bindAccountIdKey(multisigRaw)
+            val callHash = bindCallHash(callHashRaw)
+
+            MultiChainMultisigEvent(multisig, callHash, chain.id)
+        }
+            .onFailure { Log.e("RealMultisigChainPendingOperationsSyncer", "Failed to parse new NewMultisig/MultisigApproval event", it) }
+            .getOrNull()
+    }
+}

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/EventsRealtimeCallDataWatcher.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/EventsRealtimeCallDataWatcher.kt
@@ -52,7 +52,7 @@ class EventsRealtimeCallDataWatcher(
 
     override val realtimeCallData = MutableStateFlow<Map<MultiChainCallHash, GenericCall.Instance>>(emptyMap())
 
-    override val newMultisigEvents= MutableSharedFlow<MultiChainMultisigEvent>(extraBufferCapacity = 10)
+    override val newMultisigEvents = MutableSharedFlow<MultiChainMultisigEvent>(extraBufferCapacity = 10)
 
     init {
         launch {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/MultisigOnlyCallDataWatcher.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/MultisigOnlyCallDataWatcher.kt
@@ -1,0 +1,42 @@
+package io.novafoundation.nova.feature_account_impl.domain.multisig.calldata
+
+import android.util.Log
+import io.novafoundation.nova.common.utils.shareInBackground
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount.Type
+import io.novafoundation.nova.feature_account_impl.data.multisig.MultisigRepository
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicWalk
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.mapLatest
+
+class MultisigOnlyCallDataWatcher(
+    private val eventsRepository: EventsRepository,
+    private val extrinsicWalk: ExtrinsicWalk,
+    private val chainRegistry: ChainRegistry,
+    private val multisigRepository: MultisigRepository,
+    private val accountRepository: AccountRepository,
+    private val coroutineScope: CoroutineScope,
+) : RealtimeCallDataWatcher, CoroutineScope by coroutineScope {
+
+    private val delegate = accountRepository.hasMetaAccountsCountOfTypeFlow(Type.MULTISIG).mapLatest { hasMultisigs ->
+        if (hasMultisigs) {
+            Log.d("MultisigOnlyCallDataWatcher", "User has multisig wallets - starting to sync realtime call-data")
+
+            val scope = CoroutineScope(coroutineContext)
+            val delegate = EventsRealtimeCallDataWatcher(eventsRepository, extrinsicWalk, chainRegistry, multisigRepository, scope)
+            delegate
+        } else {
+            Log.d("MultisigOnlyCallDataWatcher", "User has no multisig wallets - not syncing call-data")
+
+            NoOpRealtimeCallDataWatcher
+        }
+    }.shareInBackground()
+
+    override val realtimeCallData = delegate.flatMapLatest { it.realtimeCallData }
+
+    override val newMultisigEvents: Flow<MultiChainMultisigEvent> = delegate.flatMapLatest { it.newMultisigEvents }
+}

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/NoOpRealtimeCallDataWatcher.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/NoOpRealtimeCallDataWatcher.kt
@@ -1,0 +1,13 @@
+package io.novafoundation.nova.feature_account_impl.domain.multisig.calldata
+
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+
+object NoOpRealtimeCallDataWatcher : RealtimeCallDataWatcher {
+    override val newMultisigEvents: Flow<MultiChainMultisigEvent> = emptyFlow()
+
+    override val realtimeCallData: StateFlow<Map<MultiChainCallHash, GenericCall.Instance>> = MutableStateFlow(emptyMap())
+}

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/RealtimeCallDataWatcher.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/RealtimeCallDataWatcher.kt
@@ -1,0 +1,24 @@
+package io.novafoundation.nova.feature_account_impl.domain.multisig.calldata
+
+import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.feature_account_api.domain.multisig.CallHash
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+interface RealtimeCallDataWatcher {
+
+    val newMultisigEvents: Flow<MultiChainMultisigEvent>
+
+    val realtimeCallData: Flow<Map<MultiChainCallHash, GenericCall.Instance>>
+}
+
+class MultiChainMultisigEvent(
+    val multisig: AccountIdKey,
+    val callHash: CallHash,
+    val chainId: ChainId
+)
+
+typealias MultiChainCallHash = Pair<ChainId, CallHash>

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/RealtimeCallDataWatcher.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/RealtimeCallDataWatcher.kt
@@ -2,11 +2,9 @@ package io.novafoundation.nova.feature_account_impl.domain.multisig.calldata
 
 import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.feature_account_api.domain.multisig.CallHash
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
 
 interface RealtimeCallDataWatcher {
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/RealtimeCallDataWatcherFactory.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/multisig/calldata/RealtimeCallDataWatcherFactory.kt
@@ -1,0 +1,31 @@
+package io.novafoundation.nova.feature_account_impl.domain.multisig.calldata
+
+import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_impl.data.multisig.MultisigRepository
+import io.novafoundation.nova.runtime.extrinsic.visitor.api.ExtrinsicWalk
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.EventsRepository
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+
+@FeatureScope
+class RealtimeCallDataWatcherFactory @Inject constructor(
+    private val eventsRepository: EventsRepository,
+    private val extrinsicWalk: ExtrinsicWalk,
+    private val chainRegistry: ChainRegistry,
+    private val multisigRepository: MultisigRepository,
+    private val accountRepository: AccountRepository,
+) {
+
+    fun createOnlyMultisig(coroutineScope: CoroutineScope): RealtimeCallDataWatcher {
+        return MultisigOnlyCallDataWatcher(
+            eventsRepository = eventsRepository,
+            extrinsicWalk = extrinsicWalk,
+            chainRegistry = chainRegistry,
+            multisigRepository = multisigRepository,
+            accountRepository = accountRepository,
+            coroutineScope = coroutineScope
+        )
+    }
+}


### PR DESCRIPTION
Syncing call-data for selected multisig account is not enough as complex setup might feature other type of accounts being selected (e.g. Proxy)
To address this, this PR makes call-data independent on a particular multisig - instead, this sync is launched as soon as there is at least 1 multisig in the app.  This call-data feed is then used by pending operations sync in two ways - firstly, to add new pending hashes to the watch list, and, secondly, to access synced call-datas. Synced call-datas are currently available until the end of the current session. Then, they can be fetched from the indexer once it catches up


Also removed some dead code