### PR TITLE
Ensure signatories are always sorted

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/address/AccountId.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/address/AccountId.kt
@@ -1,18 +1,13 @@
 package io.novafoundation.nova.common.address
 
 import io.novafoundation.nova.common.utils.HexString
-import io.novafoundation.nova.common.utils.compareTo
 import io.novasama.substrate_sdk_android.extensions.fromHex
 import io.novasama.substrate_sdk_android.extensions.toHexString
 import io.novasama.substrate_sdk_android.runtime.AccountId
 
-class AccountIdKey(val value: AccountId) : Comparable<AccountIdKey> {
+class AccountIdKey(val value: AccountId) {
 
     companion object;
-
-    override fun compareTo(other: AccountIdKey): Int {
-        return value.compareTo(other.value, unsigned = false)
-    }
 
     override fun equals(other: Any?): Boolean {
         return this === other || other is AccountIdKey && this.value contentEquals other.value

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/multisig/MultisigCalls.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/multisig/MultisigCalls.kt
@@ -1,17 +1,16 @@
 package io.novafoundation.nova.feature_account_api.data.multisig
 
-import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.data.network.runtime.binding.WeightV2
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.composeCall
 import io.novafoundation.nova.feature_account_api.data.multisig.model.MultisigTimePoint
+import io.novafoundation.nova.feature_account_api.domain.model.MultisigMetaAccount
 import io.novafoundation.nova.feature_account_api.domain.multisig.CallHash
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 
 fun RuntimeSnapshot.composeMultisigAsMulti(
-    threshold: Int,
-    otherSignatories: List<AccountIdKey>,
+    multisigMetaAccount: MultisigMetaAccount,
     maybeTimePoint: MultisigTimePoint?,
     call: GenericCall.Instance,
     maxWeight: WeightV2
@@ -20,8 +19,8 @@ fun RuntimeSnapshot.composeMultisigAsMulti(
         moduleName = Modules.MULTISIG,
         callName = "as_multi",
         arguments = mapOf(
-            "threshold" to threshold.toBigInteger(),
-            "other_signatories" to otherSignatories.sorted().map { it.value },
+            "threshold" to multisigMetaAccount.threshold.toBigInteger(),
+            "other_signatories" to multisigMetaAccount.otherSignatories.map { it.value },
             "maybe_timepoint" to maybeTimePoint?.toEncodableInstance(),
             "call" to call,
             "max_weight" to maxWeight.toEncodableInstance()
@@ -30,8 +29,7 @@ fun RuntimeSnapshot.composeMultisigAsMulti(
 }
 
 fun RuntimeSnapshot.composeMultisigCancelAsMulti(
-    threshold: Int,
-    otherSignatories: List<AccountIdKey>,
+    multisigMetaAccount: MultisigMetaAccount,
     maybeTimePoint: MultisigTimePoint,
     callHash: CallHash,
 ): GenericCall.Instance {
@@ -39,8 +37,8 @@ fun RuntimeSnapshot.composeMultisigCancelAsMulti(
         moduleName = Modules.MULTISIG,
         callName = "cancel_as_multi",
         arguments = mapOf(
-            "threshold" to threshold.toBigInteger(),
-            "other_signatories" to otherSignatories.sorted().map { it.value },
+            "threshold" to multisigMetaAccount.threshold.toBigInteger(),
+            "other_signatories" to multisigMetaAccount.otherSignatories.map { it.value },
             "timepoint" to maybeTimePoint.toEncodableInstance(),
             "call_hash" to callHash.value
         )

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
@@ -129,6 +129,9 @@ interface MultisigMetaAccount : MetaAccount {
 
     val signatoryAccountId: AccountIdKey
 
+    /**
+     * A **sorted** list of other signatories signatories of the account
+     */
     val otherSignatories: List<AccountIdKey>
 
     val threshold: Int

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/mappers/AccountMappers.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/mappers/AccountMappers.kt
@@ -174,7 +174,7 @@ class AccountMappers(
                         name = name,
                         status = mapMetaAccountStateFromLocal(status),
                         signatoryMetaId = requireNotNull(parentMetaId) { "parentMetaId is null: $id" },
-                        otherSignatories = multisigTypeExtras.otherSignatories,
+                        otherSignatoriesUnsorted = multisigTypeExtras.otherSignatories,
                         threshold = multisigTypeExtras.threshold,
                         signatoryAccountId = multisigTypeExtras.signatoryAccountId,
                         parentMetaId = parentMetaId,

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/multisig/MultisigSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/multisig/MultisigSigner.kt
@@ -182,8 +182,7 @@ class MultisigSigner(
         val call = getWrappedCall()
 
         val multisigCall = runtime.composeMultisigAsMulti(
-            threshold = multisigAccount.threshold,
-            otherSignatories = multisigAccount.otherSignatories,
+            multisigMetaAccount = multisigAccount,
             maybeTimePoint = null,
             call = call,
             maxWeight = maxWeight

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/sync/MultisigAccountsSyncDataSource.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/sync/MultisigAccountsSyncDataSource.kt
@@ -34,11 +34,6 @@ internal class MultisigAccountsSyncDataSourceFactory @Inject constructor(
     }
 }
 
-/*
-TODO multisig:
-1. Integrate multisigs to MetaAccountsUpdatesRegistry - just adding ids to the repository isn't enough as ui only shows proxies, see
-MetaAccountGroupingInteractor.updatedProxieds
- */
 private class MultisigAccountsSyncDataSource(
     private val multisigRepository: MultisigRepository,
     private val gson: Gson,

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/account/model/MultisigMetaAccount.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/account/model/MultisigMetaAccount.kt
@@ -41,7 +41,8 @@ class RealMultisigMetaAccount(
     status = status,
     chainAccounts = chainAccounts,
     parentMetaId = parentMetaId
-), MultisigMetaAccount {
+),
+    MultisigMetaAccount {
 
     override val otherSignatories by lazy(LazyThreadSafetyMode.PUBLICATION) {
         otherSignatoriesUnsorted.sortedWith { a, b -> a.value.compareTo(b.value, unsigned = true) }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/account/model/MultisigMetaAccount.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/account/model/MultisigMetaAccount.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_account_impl.domain.account.model
 
 import io.novafoundation.nova.common.address.AccountIdKey
+import io.novafoundation.nova.common.utils.compareTo
 import io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.MultisigAvailability
@@ -22,7 +23,7 @@ class RealMultisigMetaAccount(
     status: LightMetaAccount.Status,
     override val signatoryMetaId: Long,
     override val signatoryAccountId: AccountIdKey,
-    override val otherSignatories: List<AccountIdKey>,
+    private val otherSignatoriesUnsorted: List<AccountIdKey>,
     override val threshold: Int,
     private val multisigRepository: MultisigRepository,
     parentMetaId: Long?
@@ -40,8 +41,11 @@ class RealMultisigMetaAccount(
     status = status,
     chainAccounts = chainAccounts,
     parentMetaId = parentMetaId
-),
-    MultisigMetaAccount {
+), MultisigMetaAccount {
+
+    override val otherSignatories by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        otherSignatoriesUnsorted.sortedWith { a, b -> a.value.compareTo(b.value, unsigned = true) }
+    }
 
     override val availability: MultisigAvailability
         get() = if (chainAccounts.isEmpty()) {

--- a/feature-multisig/operations/src/main/java/io/novafoundation/nova/feature_multisig_operations/domain/details/MultisigOperationDetailsInteractor.kt
+++ b/feature-multisig/operations/src/main/java/io/novafoundation/nova/feature_multisig_operations/domain/details/MultisigOperationDetailsInteractor.kt
@@ -135,8 +135,7 @@ class RealMultisigOperationDetailsInteractor @Inject constructor(
         val selectedAccount = accountRepository.getSelectedMetaAccount() as MultisigMetaAccount
 
         val approveCall = runtime.composeMultisigAsMulti(
-            threshold = selectedAccount.threshold,
-            otherSignatories = selectedAccount.otherSignatories,
+            multisigMetaAccount = selectedAccount,
             maybeTimePoint = operation.timePoint,
             call = operation.call!!,
             maxWeight = maxWeight
@@ -149,8 +148,7 @@ class RealMultisigOperationDetailsInteractor @Inject constructor(
         val selectedAccount = accountRepository.getSelectedMetaAccount() as MultisigMetaAccount
 
         val approveCall = runtime.composeMultisigCancelAsMulti(
-            threshold = selectedAccount.threshold,
-            otherSignatories = selectedAccount.otherSignatories,
+            multisigMetaAccount = selectedAccount,
             maybeTimePoint = operation.timePoint,
             callHash = operation.callHash
         )


### PR DESCRIPTION
* Remove Comparable from AccountIdKey since it is ambiguous
* Ensure otherSignatories are always sorted by not exposing unsorted signatories whatsoever