### PR TITLE
Do not derive accountId form InheritedImplication during signing

### DIFF
--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/signer/SeparateFlowSignerState.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/signer/SeparateFlowSignerState.kt
@@ -7,7 +7,6 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novasama.substrate_sdk_android.extensions.toHexString
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.InheritedImplication
-import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.getAccountIdOrThrow
 import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.getGenesisHashOrThrow
 import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.signingPayload
 
@@ -17,7 +16,7 @@ class SeparateFlowSignerState(val payload: SignerPayload, val metaAccount: MetaA
 
 sealed class SignerPayload {
 
-    class Extrinsic(val extrinsic: InheritedImplication) : SignerPayload()
+    class Extrinsic(val extrinsic: InheritedImplication, val accountId: AccountId) : SignerPayload()
 
     class Raw(val raw: SignerPayloadRawWithChain) : SignerPayload()
 }
@@ -31,7 +30,7 @@ fun SignerPayload.chainId(): ChainId {
 
 fun SignerPayload.accountId(): AccountId {
     return when (this) {
-        is SignerPayload.Extrinsic -> extrinsic.getAccountIdOrThrow()
+        is SignerPayload.Extrinsic -> accountId
         is SignerPayload.Raw -> raw.accountId
     }
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/SeparateFlowSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/SeparateFlowSigner.kt
@@ -28,7 +28,7 @@ abstract class SeparateFlowSigner(
         inheritedImplication: InheritedImplication,
         accountId: AccountId
     ): SignatureWrapper {
-        val payload = SeparateFlowSignerState(SignerPayload.Extrinsic(inheritedImplication), metaAccount)
+        val payload = SeparateFlowSignerState(SignerPayload.Extrinsic(inheritedImplication, accountId), metaAccount)
 
         val result = awaitConfirmation(payload)
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/paritySigner/transaction/Encoder.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/paritySigner/transaction/Encoder.kt
@@ -8,7 +8,7 @@ import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtensi
 import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.transientEncodedCallData
 
 fun SignerPayload.Extrinsic.paritySignerLegacyTxPayload(): ByteArray {
-    return accountId +  extrinsic.transientEncodedCallData() + extrinsic.encodedExtensions() + extrinsic.getGenesisHashOrThrow()
+    return accountId + extrinsic.transientEncodedCallData() + extrinsic.encodedExtensions() + extrinsic.getGenesisHashOrThrow()
 }
 
 fun SignerPayload.Extrinsic.paritySignerTxPayloadWithProof(proof: ExtrinsicProof): ByteArray {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/paritySigner/transaction/Encoder.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/paritySigner/transaction/Encoder.kt
@@ -1,19 +1,18 @@
 package io.novafoundation.nova.feature_account_impl.data.signer.paritySigner.transaction
 
+import io.novafoundation.nova.feature_account_api.data.signer.SignerPayload
 import io.novafoundation.nova.runtime.extrinsic.metadata.ExtrinsicProof
 import io.novafoundation.nova.runtime.extrinsic.signer.SignerPayloadRawWithChain
 import io.novasama.substrate_sdk_android.extensions.fromHex
-import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.InheritedImplication
-import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.getAccountIdOrThrow
 import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.getGenesisHashOrThrow
 import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.transientEncodedCallData
 
-fun InheritedImplication.paritySignerLegacyTxPayload(): ByteArray {
-    return getAccountIdOrThrow() + transientEncodedCallData() + encodedExtensions() + getGenesisHashOrThrow()
+fun SignerPayload.Extrinsic.paritySignerLegacyTxPayload(): ByteArray {
+    return accountId +  extrinsic.transientEncodedCallData() + extrinsic.encodedExtensions() + extrinsic.getGenesisHashOrThrow()
 }
 
-fun InheritedImplication.paritySignerTxPayloadWithProof(proof: ExtrinsicProof): ByteArray {
-    return getAccountIdOrThrow() + proof.value + transientEncodedCallData() + encodedExtensions() + getGenesisHashOrThrow()
+fun SignerPayload.Extrinsic.paritySignerTxPayloadWithProof(proof: ExtrinsicProof): ByteArray {
+    return accountId + proof.value + extrinsic.transientEncodedCallData() + extrinsic.encodedExtensions() + extrinsic.getGenesisHashOrThrow()
 }
 
 fun SignerPayloadRawWithChain.polkadotVaultSignRawPayload(): ByteArray {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/paritySigner/sign/show/ShowSignParitySignerInteractor.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/paritySigner/sign/show/ShowSignParitySignerInteractor.kt
@@ -14,7 +14,6 @@ import io.novafoundation.nova.feature_account_impl.data.signer.paritySigner.uos.
 import io.novafoundation.nova.feature_account_impl.data.signer.paritySigner.uos.paritySignerUOSCryptoType
 import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerService
 import io.novafoundation.nova.runtime.extrinsic.signer.SignerPayloadRawWithChain
-import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.InheritedImplication
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -39,7 +38,7 @@ class RealShowSignParitySignerInteractor(
         mode: ParitySignerSignMode
     ): ParitySignerSignRequest = withContext(Dispatchers.Default) {
         val uosPayload = when (payload) {
-            is SignerPayload.Extrinsic -> mode.createUOSPayloadFor(payload.extrinsic)
+            is SignerPayload.Extrinsic -> mode.createUOSPayloadFor(payload)
             is SignerPayload.Raw -> createRawMessagePayload(payload.raw)
         }
 
@@ -61,14 +60,14 @@ class RealShowSignParitySignerInteractor(
         )
     }
 
-    private suspend fun ParitySignerSignMode.createUOSPayloadFor(payload: InheritedImplication): ByteArray {
+    private suspend fun ParitySignerSignMode.createUOSPayloadFor(payload: SignerPayload.Extrinsic): ByteArray {
         return when (this) {
             ParitySignerSignMode.LEGACY -> createLegacyUOSPayload(payload)
             ParitySignerSignMode.WITH_METADATA_PROOF -> createUOSPayloadWithProof(payload)
         }
     }
 
-    private fun createLegacyUOSPayload(payload: InheritedImplication): ByteArray {
+    private fun createLegacyUOSPayload(payload: SignerPayload.Extrinsic): ByteArray {
         val txPayload = payload.paritySignerLegacyTxPayload()
         return UOS.createUOSPayload(
             payload = txPayload,
@@ -78,8 +77,8 @@ class RealShowSignParitySignerInteractor(
         )
     }
 
-    private suspend fun createUOSPayloadWithProof(payload: InheritedImplication): ByteArray {
-        val proof = metadataShortenerService.generateExtrinsicProof(payload)
+    private suspend fun createUOSPayloadWithProof(payload: SignerPayload.Extrinsic): ByteArray {
+        val proof = metadataShortenerService.generateExtrinsicProof(payload.extrinsic)
         val txPayload = payload.paritySignerTxPayloadWithProof(proof)
         return UOS.createUOSPayload(
             payload = txPayload,


### PR DESCRIPTION
When signing InheritedImplication to fill VerifySignature extension, the VerifySignature itself is not present yet in InheritedImplication, so `accountIdOrThrow` fails
Instead, we should pass and use `accountId` argument provided to `signInheritedImplication`