### PR TITLE
Fix typo in the validation

### DIFF
--- a/feature-multisig/operations/src/main/java/io/novafoundation/nova/feature_multisig_operations/domain/details/validations/ApproveMultisigOperationValidationPayload.kt
+++ b/feature-multisig/operations/src/main/java/io/novafoundation/nova/feature_multisig_operations/domain/details/validations/ApproveMultisigOperationValidationPayload.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.feature_account_api.data.model.Fee
 import io.novafoundation.nova.feature_account_api.data.multisig.model.PendingMultisigOperation
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.feature_account_api.domain.model.MultisigMetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdKeyIn
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.balances.model.ChainAssetBalance
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -13,10 +14,11 @@ class ApproveMultisigOperationValidationPayload(
     val signatoryBalance: ChainAssetBalance,
     val signatory: MetaAccount,
     val operation: PendingMultisigOperation,
+    val multisig: MultisigMetaAccount
 )
 
 val ApproveMultisigOperationValidationPayload.chain: Chain
     get() = operation.chain
 
-val ApproveMultisigOperationValidationPayload.signatoryAccountId: AccountIdKey
-    get() = signatory.requireAccountIdKeyIn(chain)
+val ApproveMultisigOperationValidationPayload.multisigAccountId: AccountIdKey
+    get() = multisig.requireAccountIdKeyIn(chain)

--- a/feature-multisig/operations/src/main/java/io/novafoundation/nova/feature_multisig_operations/domain/details/validations/OperationIsStillPendingValidation.kt
+++ b/feature-multisig/operations/src/main/java/io/novafoundation/nova/feature_multisig_operations/domain/details/validations/OperationIsStillPendingValidation.kt
@@ -12,7 +12,7 @@ class OperationIsStillPendingValidation @Inject constructor(
 ) : ApproveMultisigOperationValidation {
 
     override suspend fun validate(value: ApproveMultisigOperationValidationPayload): ValidationStatus<ApproveMultisigOperationValidationFailure> {
-        val hasPendingCallHash = multisigValidationsRepository.hasPendingCallHash(value.chain.id, value.signatoryAccountId, value.operation.callHash)
+        val hasPendingCallHash = multisigValidationsRepository.hasPendingCallHash(value.chain.id, value.multisigAccountId, value.operation.callHash)
 
         return hasPendingCallHash isTrueOrError {
             ApproveMultisigOperationValidationFailure.TransactionIsNotAvailable

--- a/feature-multisig/operations/src/main/java/io/novafoundation/nova/feature_multisig_operations/presentation/details/general/MultisigOperationDetailsViewModel.kt
+++ b/feature-multisig/operations/src/main/java/io/novafoundation/nova/feature_multisig_operations/presentation/details/general/MultisigOperationDetailsViewModel.kt
@@ -282,7 +282,8 @@ class MultisigOperationDetailsViewModel(
             fee = feeLoaderMixin.awaitFee(),
             signatoryBalance = signatoryBalance,
             signatory = signatory,
-            operation = operation
+            operation = operation,
+            multisig = selectedAccountFlow.first()
         )
 
         validationExecutor.requireValid(


### PR DESCRIPTION
#8699hfrvh
We should use multisig account to check existence of the operation on-chain, not a signatory account