### PR TITLE
Rc/10.1.1

### DIFF
--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/requestBusHandler/ProxyExtrinsicValidationRequestBusHandler.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/requestBusHandler/ProxyExtrinsicValidationRequestBusHandler.kt
@@ -4,10 +4,11 @@ import io.novafoundation.nova.common.utils.bus.observeBusEvent
 import io.novafoundation.nova.common.utils.coroutines.RootScope
 import io.novafoundation.nova.common.validation.ValidationSystem
 import io.novafoundation.nova.common.validation.ValidationSystemBuilder
-import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxyExtrinsicValidationRequestBus
-import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxyExtrinsicValidationRequestBus.ValidationResponse
 import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxiedExtrinsicValidationFailure
 import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxiedExtrinsicValidationPayload
+import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxyExtrinsicValidationRequestBus
+import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxyExtrinsicValidationRequestBus.ValidationResponse
+import io.novafoundation.nova.feature_account_api.data.proxy.validation.proxyAccountId
 import io.novafoundation.nova.feature_wallet_api.domain.validation.ProxyHaveEnoughFeeValidationFactory
 import io.novafoundation.nova.feature_wallet_api.domain.validation.proxyHasEnoughFeeValidation
 import kotlinx.coroutines.flow.launchIn
@@ -36,14 +37,14 @@ class ProxyExtrinsicValidationRequestBusHandler(
     private fun ValidationSystemBuilder<ProxiedExtrinsicValidationPayload, ProxiedExtrinsicValidationFailure>.proxyHasEnoughFee() {
         proxyHasEnoughFeeValidation(
             factory = proxyHaveEnoughFeeValidationFactory,
-            metaAccount = { it.proxyMetaAccount },
+            proxiedMetaAccount = { it.proxiedMetaAccount },
             proxyAccountId = { it.proxyAccountId },
-            call = { it.call },
+            proxiedCall = { it.proxiedCall },
             chainWithAsset = { it.chainWithAsset },
             proxyNotEnoughFee = { payload, availableBalance, fee ->
                 val asset = payload.chainWithAsset.asset
                 ProxiedExtrinsicValidationFailure.ProxyNotEnoughFee(
-                    metaAccount = payload.proxyMetaAccount,
+                    proxy = payload.proxyMetaAccount,
                     asset = asset,
                     fee = fee.amount,
                     availableBalance = availableBalance

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
         // App version
-        versionName = '10.1.0'
-        versionCode = 216
+        versionName = '10.1.1'
+        versionCode = 217
 
         applicationId = "io.novafoundation.nova"
         releaseApplicationSuffix = "market"

--- a/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/KotlinExt.kt
@@ -608,7 +608,7 @@ fun ByteArray.compareTo(other: ByteArray, unsigned: Boolean): Int {
         return size - other.size
     }
 
-    for (i in 0 until size) {
+    for (i in indices) {
         val result = if (unsigned) {
             this[i].toUByte().compareTo(other[i].toUByte())
         } else {

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/account/ProxyAccountLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/account/ProxyAccountLocal.kt
@@ -35,6 +35,7 @@ data class ProxyAccountLocal(
     val proxiedMetaId: Long,
     val proxyMetaId: Long,
     val chainId: String,
+    @Deprecated("Unused")
     val proxiedAccountId: ByteArray,
     val proxyType: String
 ) : Identifiable {

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/multisig/validation/MultisigExtrinsicValidationPayload.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/multisig/validation/MultisigExtrinsicValidationPayload.kt
@@ -15,15 +15,12 @@ class MultisigExtrinsicValidationPayload(
     val chain: Chain,
     val signatoryFeePaymentMode: SignatoryFeePaymentMode,
     // Call that is passed to as_multi. Might be both the actual call (in case multisig is a the root signer) or be wrapped by some other signer
-    val delegatedCall: GenericCall.Instance,
+    val callInsideAsMulti: GenericCall.Instance,
 )
 
 sealed class SignatoryFeePaymentMode {
 
-    class PaysSubmissionFee(
-        // The inner-most call (e.g. transfer)
-        val actualCall: GenericCall.Instance
-    ) : SignatoryFeePaymentMode()
+    data object PaysSubmissionFee: SignatoryFeePaymentMode()
 
     data object NothingToPay : SignatoryFeePaymentMode()
 }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/multisig/validation/MultisigExtrinsicValidationPayload.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/multisig/validation/MultisigExtrinsicValidationPayload.kt
@@ -20,7 +20,7 @@ class MultisigExtrinsicValidationPayload(
 
 sealed class SignatoryFeePaymentMode {
 
-    data object PaysSubmissionFee: SignatoryFeePaymentMode()
+    data object PaysSubmissionFee : SignatoryFeePaymentMode()
 
     data object NothingToPay : SignatoryFeePaymentMode()
 }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/proxy/validation/ProxiedExtrinsicValidationSystem.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/proxy/validation/ProxiedExtrinsicValidationSystem.kt
@@ -1,6 +1,8 @@
 package io.novafoundation.nova.feature_account_api.data.proxy.validation
 
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.feature_account_api.domain.model.ProxiedMetaAccount
+import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
 import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -8,16 +10,19 @@ import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.Gene
 import java.math.BigInteger
 
 class ProxiedExtrinsicValidationPayload(
+    val proxiedMetaAccount: ProxiedMetaAccount,
     val proxyMetaAccount: MetaAccount,
-    val proxyAccountId: AccountId,
     val chainWithAsset: ChainWithAsset,
-    val call: GenericCall.Instance
+    val proxiedCall: GenericCall.Instance
 )
+
+val ProxiedExtrinsicValidationPayload.proxyAccountId: AccountId
+    get() = proxyMetaAccount.requireAccountIdIn(chainWithAsset.chain)
 
 sealed interface ProxiedExtrinsicValidationFailure {
 
     class ProxyNotEnoughFee(
-        val metaAccount: MetaAccount,
+        val proxy: MetaAccount,
         val asset: Chain.Asset,
         val fee: BigInteger,
         val availableBalance: BigInteger

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/signer/NovaSigner.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/data/signer/NovaSigner.kt
@@ -38,6 +38,19 @@ interface NovaSigner : Signer {
      *
      * This should only be called after all other extrinsic information has been set, including all non-signer related extensions and calls
      * So, this should be the final operation that modifies the extrinsic, followed just by [ExtrinsicBuilder.buildExtrinsic]
+     *
+     * Note for nested signers:
+     *
+     * Since signers delegation work in top-down approach(root signer is the executing account),
+     * but the wrapping should be done in the bottom-up way (the actual call is the inner-most one),
+     * nested signers should perform call wrapping themselves, and only after that perform nested [setSignerDataForSubmission] call.
+     *
+     * For example:
+     *
+     * With Secrets Wallet -> Proxy -> Multisig setup, the signing sequence will be MultisigSigner -> ProxiedSigner -> SecretsSigner.
+     * The final call should be proxy(as_multi(actual)) from Secrets origin.
+     * So, the wrapping should be done in the following sequence: actual -> wrap in as_multi -> wrap in proxy.
+     * So, the top-most signer (MultisigSigner) should first wrap the actual call into as_multi and only then delegate to ProxiedSigner.
      */
     context(ExtrinsicBuilder)
     suspend fun setSignerDataForSubmission(context: SigningContext)
@@ -49,6 +62,8 @@ interface NovaSigner : Signer {
      *
      * This should only be called after all other extrinsic information has been set, including all non-signer related extensions and calls
      * So, this should be the final operation that modifies the extrinsic, followed just by [ExtrinsicBuilder.buildExtrinsic]
+     *
+     * You can find notes about nested signers in [setSignerDataForSubmission]
      */
     context(ExtrinsicBuilder)
     suspend fun setSignerDataForFee(context: SigningContext)

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
@@ -17,6 +17,8 @@ import io.novasama.substrate_sdk_android.extensions.toAccountId
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 class MetaAccountOrdering(
     val id: Long,
@@ -145,6 +147,15 @@ sealed class MultisigAvailability {
     class Universal(val addressScheme: AddressScheme) : MultisigAvailability()
 
     class SingleChain(val chainId: ChainId) : MultisigAvailability()
+}
+
+@OptIn(ExperimentalContracts::class)
+fun MetaAccount.isMultisig(): Boolean {
+    contract {
+        returns(true) implies (this@isMultisig is MultisigMetaAccount)
+    }
+
+    return this is MultisigMetaAccount
 }
 
 fun MetaAccount.isUniversal(): Boolean {

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/MetaAccount.kt
@@ -17,8 +17,6 @@ import io.novasama.substrate_sdk_android.extensions.toAccountId
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 
 class MetaAccountOrdering(
     val id: Long,
@@ -147,15 +145,6 @@ sealed class MultisigAvailability {
     class Universal(val addressScheme: AddressScheme) : MultisigAvailability()
 
     class SingleChain(val chainId: ChainId) : MultisigAvailability()
-}
-
-@OptIn(ExperimentalContracts::class)
-fun MetaAccount.isMultisig(): Boolean {
-    contract {
-        returns(true) implies (this@isMultisig is MultisigMetaAccount)
-    }
-
-    return this is MultisigMetaAccount
 }
 
 fun MetaAccount.isUniversal(): Boolean {

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/ProxyAccount.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/model/ProxyAccount.kt
@@ -6,6 +6,5 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 class ProxyAccount(
     val proxyMetaId: Long,
     val chainId: ChainId,
-    val proxiedAccountId: ByteArray,
     val proxyType: ProxyType,
 )

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/proxy/ProxySigningPresenter.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/proxy/ProxySigningPresenter.kt
@@ -1,17 +1,18 @@
 package io.novafoundation.nova.feature_account_api.presenatation.account.proxy
 
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.feature_account_api.domain.model.ProxiedMetaAccount
 import io.novafoundation.nova.feature_proxy_api.domain.model.ProxyType
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import java.math.BigInteger
 
 interface ProxySigningPresenter {
 
-    suspend fun acknowledgeProxyOperation(proxiedMetaAccount: MetaAccount, proxyMetaAccount: MetaAccount): Boolean
+    suspend fun acknowledgeProxyOperation(proxiedMetaAccount: ProxiedMetaAccount, proxyMetaAccount: MetaAccount): Boolean
 
     suspend fun notEnoughPermission(proxiedMetaAccount: MetaAccount, proxyMetaAccount: MetaAccount, proxyTypes: List<ProxyType>)
 
     suspend fun signingIsNotSupported()
 
-    suspend fun notEnoughFee(metaAccount: MetaAccount, chainAsset: Chain.Asset, availableBalance: BigInteger, fee: BigInteger)
+    suspend fun notEnoughFee(proxy: MetaAccount, chainAsset: Chain.Asset, availableBalance: BigInteger, fee: BigInteger)
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/mappers/Mappers.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/mappers/Mappers.kt
@@ -142,7 +142,6 @@ fun mapProxyAccountFromLocal(proxyAccountLocal: ProxyAccountLocal): ProxyAccount
         ProxyAccount(
             proxyMetaId = proxyMetaId,
             chainId = chainId,
-            proxiedAccountId = proxiedAccountId,
             proxyType = ProxyType.fromString(proxyType)
         )
     }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/multisig/MultisigSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/multisig/MultisigSigner.kt
@@ -46,13 +46,12 @@ class MultisigSignerFactory @Inject constructor(
             multisigSigningPresenter = multisigSigningPresenter,
             multisigAccount = metaAccount,
 
-        )
+            )
     }
 }
 
 // TODO multisig:
-// 3. Create a base class NestedSigner for Multisig and Proxieds
-// Example: 1 click swaps
+// 1. Create a base class NestedSigner for Multisig and Proxieds
 class MultisigSigner(
     private val multisigAccount: MultisigMetaAccount,
     private val accountRepository: AccountRepository,
@@ -96,14 +95,14 @@ class MultisigSigner(
             acknowledgeMultisigOperation()
         }
 
-        val actualCall = getWrappedCall()
-        delegateSigner().setSignerDataForSubmission(context)
-        val delegatedCall = getWrappedCall()
+        val callInsideAsMulti = getWrappedCall()
 
         // We intentionally do validation before wrapping to pass the actual call to the validation
-        validateExtrinsic(context.chain, actualCall = actualCall, delegatedCall = delegatedCall)
-
+        validateExtrinsic(context.chain, callInsideAsMulti)
+        
         wrapCallsInAsMultiForSubmission()
+
+        delegateSigner().setSignerDataForSubmission(context)
     }
 
     context(ExtrinsicBuilder)
@@ -130,15 +129,14 @@ class MultisigSigner(
     context(ExtrinsicBuilder)
     private suspend fun validateExtrinsic(
         chain: Chain,
-        actualCall: GenericCall.Instance,
-        delegatedCall: GenericCall.Instance,
+        callInsideAsMulti: GenericCall.Instance,
     ) {
         val validationPayload = MultisigExtrinsicValidationPayload(
             multisig = multisigAccount,
             signatory = signatoryMetaAccount(),
             chain = chain,
-            signatoryFeePaymentMode = determineSignatoryFeePaymentMode(actualCall),
-            delegatedCall = delegatedCall
+            signatoryFeePaymentMode = determineSignatoryFeePaymentMode(),
+            callInsideAsMulti = callInsideAsMulti
         )
 
         val requestBusPayload = MultisigExtrinsicValidationRequestBus.Request(validationPayload)
@@ -153,13 +151,11 @@ class MultisigSigner(
     }
 
     context(ExtrinsicBuilder)
-    private suspend fun determineSignatoryFeePaymentMode(actualCall: GenericCall.Instance): SignatoryFeePaymentMode {
+    private suspend fun determineSignatoryFeePaymentMode(): SignatoryFeePaymentMode {
         // Our direct signatory only pay fees if it is a LeafSigner
         // Otherwise it is paid by signer's own delegate
         return if (delegateSigner() is LeafSigner) {
-            SignatoryFeePaymentMode.PaysSubmissionFee(
-                actualCall = actualCall
-            )
+            SignatoryFeePaymentMode.PaysSubmissionFee
         } else {
             SignatoryFeePaymentMode.NothingToPay
         }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/multisig/MultisigSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/multisig/MultisigSigner.kt
@@ -46,7 +46,7 @@ class MultisigSignerFactory @Inject constructor(
             multisigSigningPresenter = multisigSigningPresenter,
             multisigAccount = metaAccount,
 
-            )
+        )
     }
 }
 
@@ -99,7 +99,7 @@ class MultisigSigner(
 
         // We intentionally do validation before wrapping to pass the actual call to the validation
         validateExtrinsic(context.chain, callInsideAsMulti)
-        
+
         wrapCallsInAsMultiForSubmission()
 
         delegateSigner().setSignerDataForSubmission(context)

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/proxy/ProxiedSigner.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/signer/proxy/ProxiedSigner.kt
@@ -6,7 +6,6 @@ import io.novafoundation.nova.common.data.memory.SingleValueCache
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.composeCall
-import io.novafoundation.nova.common.utils.getChainIdOrThrow
 import io.novafoundation.nova.common.validation.ValidationStatus
 import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxiedExtrinsicValidationFailure.ProxyNotEnoughFee
 import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxiedExtrinsicValidationPayload
@@ -22,14 +21,15 @@ import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.ProxiedMetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
 import io.novafoundation.nova.feature_account_api.presenatation.account.proxy.ProxySigningPresenter
+import io.novafoundation.nova.feature_account_impl.data.signer.LeafSigner
 import io.novafoundation.nova.feature_proxy_api.data.repository.GetProxyRepository
 import io.novafoundation.nova.feature_proxy_api.domain.model.ProxyType
 import io.novafoundation.nova.runtime.ext.commissionAsset
-import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
+import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
 import io.novasama.substrate_sdk_android.runtime.definitions.types.instances.AddressInstanceConstructor
 import io.novasama.substrate_sdk_android.runtime.extrinsic.builder.ExtrinsicBuilder
 import io.novasama.substrate_sdk_android.runtime.extrinsic.signer.SignedRaw
@@ -38,7 +38,6 @@ import javax.inject.Inject
 
 @FeatureScope
 class ProxiedSignerFactory @Inject constructor(
-    private val chainRegistry: ChainRegistry,
     private val accountRepository: AccountRepository,
     private val proxySigningPresenter: ProxySigningPresenter,
     private val getProxyRepository: GetProxyRepository,
@@ -48,7 +47,6 @@ class ProxiedSignerFactory @Inject constructor(
 
     fun create(metaAccount: ProxiedMetaAccount, signerProvider: SignerProvider, isRoot: Boolean): ProxiedSigner {
         return ProxiedSigner(
-            chainRegistry = chainRegistry,
             accountRepository = accountRepository,
             signerProvider = signerProvider,
             proxySigningPresenter = proxySigningPresenter,
@@ -63,7 +61,6 @@ class ProxiedSignerFactory @Inject constructor(
 
 class ProxiedSigner(
     private val proxiedMetaAccount: ProxiedMetaAccount,
-    private val chainRegistry: ChainRegistry,
     private val accountRepository: AccountRepository,
     private val signerProvider: SignerProvider,
     private val proxySigningPresenter: ProxySigningPresenter,
@@ -99,21 +96,26 @@ class ProxiedSigner(
 
     context(ExtrinsicBuilder)
     override suspend fun setSignerDataForSubmission(context: SigningContext) {
-        wrapCallsInProxyForSubmission()
+        if (isRootSigner) {
+            acknowledgeProxyOperation(proxyMetaAccount())
+        }
+
+        val proxiedCall = getWrappedCall()
+
+        validateExtrinsic(context.chain, proxyMetaAccount = proxyMetaAccount(), proxiedCall = proxiedCall)
+
+        wrapCallsInProxyForSubmission(context.chain, proxiedCall = proxiedCall)
 
         Log.d("Signer", "ProxiedSigner: wrapped proxy calls for submission")
 
         delegateSigner().setSignerDataForSubmission(context)
-
-        if (isRootSigner) {
-            acknowledgeProxyOperation(proxyMetaAccount())
-            validateExtrinsic(context.chain)
-        }
     }
 
     context(ExtrinsicBuilder)
     override suspend fun setSignerDataForFee(context: SigningContext) {
-        wrapCallsInProxyForFee()
+        val proxiedCall = getWrappedCall()
+
+        wrapCallsInProxyForFee(context.chain, proxiedCall = proxiedCall)
 
         Log.d("Signer", "ProxiedSigner: wrapped proxy calls for fee")
 
@@ -129,15 +131,18 @@ class ProxiedSigner(
     }
 
     context(ExtrinsicBuilder)
-    private suspend fun validateExtrinsic(chain: Chain) {
-        val proxyAccountId = submissionSignerAccountId(chain)
-        val proxyAccount = accountRepository.findMetaAccount(proxyAccountId, chain.id) ?: throw IllegalStateException("Proxy account is not found")
+    private suspend fun validateExtrinsic(
+        chain: Chain,
+        proxyMetaAccount: MetaAccount,
+        proxiedCall: GenericCall.Instance,
+    ) {
+        if (!proxyPaysFees()) return
 
         val validationPayload = ProxiedExtrinsicValidationPayload(
-            proxyMetaAccount = proxyAccount,
-            proxyAccountId = proxyAccountId,
+            proxiedMetaAccount = proxiedMetaAccount,
+            proxyMetaAccount = proxyMetaAccount,
             chainWithAsset = ChainWithAsset(chain, chain.commissionAsset),
-            call = getWrappedCall()
+            proxiedCall = proxiedCall
         )
 
         val requestBusPayload = ProxyExtrinsicValidationRequestBus.Request(validationPayload)
@@ -146,19 +151,14 @@ class ProxiedSigner(
         val validationStatus = validationResponse.validationResult.getOrNull()
         if (validationStatus is ValidationStatus.NotValid && validationStatus.reason is ProxyNotEnoughFee) {
             val reason = validationStatus.reason as ProxyNotEnoughFee
-            proxySigningPresenter.notEnoughFee(reason.metaAccount, reason.asset, reason.availableBalance, reason.fee)
+            proxySigningPresenter.notEnoughFee(reason.proxy, reason.asset, reason.availableBalance, reason.fee)
 
             throw SigningCancelledException()
         }
     }
 
     context(ExtrinsicBuilder)
-    private suspend fun wrapCallsInProxyForSubmission() {
-        val chainId = getChainIdOrThrow()
-        val chain = chainRegistry.getChain(chainId)
-
-        val call = getWrappedCall()
-
+    private suspend fun wrapCallsInProxyForSubmission(chain: Chain, proxiedCall: GenericCall.Instance) {
         val proxyAccountId = proxyMetaAccount().requireAccountIdIn(chain)
         val proxiedAccountId = proxiedMetaAccount.requireAccountIdIn(chain)
 
@@ -168,27 +168,26 @@ class ProxiedSigner(
             proxyAccountId = proxyAccountId
         )
 
-        val proxyType = proxyCallFilterFactory.getFirstMatchedTypeOrNull(call, availableProxyTypes)
+        val proxyType = proxyCallFilterFactory.getFirstMatchedTypeOrNull(proxiedCall, availableProxyTypes)
             ?: notEnoughPermission(proxyMetaAccount(), availableProxyTypes)
 
         return wrapCallsIntoProxy(
             proxiedAccountId = proxiedAccountId,
             proxyType = proxyType,
+            proxiedCall = proxiedCall
         )
     }
 
     // Wrap without verifying proxy permissions and hardcode proxy type
     // to speed up fee calculation
     context(ExtrinsicBuilder)
-    private suspend fun wrapCallsInProxyForFee() {
-        val chainId = getChainIdOrThrow()
-        val chain = chainRegistry.getChain(chainId)
-
+    private fun wrapCallsInProxyForFee(chain: Chain, proxiedCall: GenericCall.Instance) {
         val proxiedAccountId = proxiedMetaAccount.requireAccountIdIn(chain)
 
         return wrapCallsIntoProxy(
             proxiedAccountId = proxiedAccountId,
             proxyType = ProxyType.Any,
+            proxiedCall = proxiedCall
         )
     }
 
@@ -196,16 +195,15 @@ class ProxiedSigner(
     private fun wrapCallsIntoProxy(
         proxiedAccountId: AccountId,
         proxyType: ProxyType,
+        proxiedCall: GenericCall.Instance,
     ) {
-        val call = getWrappedCall()
-
         val proxyCall = runtime.composeCall(
             moduleName = Modules.PROXY,
             callName = "proxy",
             arguments = mapOf(
                 "real" to AddressInstanceConstructor.constructInstance(runtime.typeRegistry, proxiedAccountId),
                 "force_proxy_type" to DictEnum.Entry(proxyType.name, null),
-                "call" to call
+                "call" to proxiedCall
             )
         )
 
@@ -233,5 +231,10 @@ class ProxiedSigner(
     private suspend fun signingNotSupported(): Nothing {
         proxySigningPresenter.signingIsNotSupported()
         throw SigningCancelledException()
+    }
+
+    private suspend fun proxyPaysFees(): Boolean {
+        // Our direct proxy only pay fees it is a leaf. Otherwise fees paid by proxy's own delegate
+        return delegateSigner() is LeafSigner
     }
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/modules/signers/ProxiedSignerModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/modules/signers/ProxiedSignerModule.kt
@@ -5,14 +5,10 @@ import dagger.Module
 import dagger.Provides
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.feature_account_api.data.proxy.validation.ProxyExtrinsicValidationRequestBus
-import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_account_api.presenatation.account.proxy.ProxySigningPresenter
-import io.novafoundation.nova.feature_account_impl.data.signer.proxy.ProxiedSignerFactory
 import io.novafoundation.nova.feature_account_impl.data.signer.proxy.ProxyCallFilterFactory
 import io.novafoundation.nova.feature_account_impl.di.modules.signers.ProxiedSignerModule.BindsModule
 import io.novafoundation.nova.feature_account_impl.presentation.proxy.sign.RealProxySigningPresenter
-import io.novafoundation.nova.feature_proxy_api.data.repository.GetProxyRepository
-import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 
 @Module(includes = [BindsModule::class])
 class ProxiedSignerModule {
@@ -31,22 +27,4 @@ class ProxiedSignerModule {
     @Provides
     @FeatureScope
     fun provideProxyCallFilterFactory() = ProxyCallFilterFactory()
-
-    @Provides
-    @FeatureScope
-    fun provideProxiedSignerFactory(
-        chainRegistry: ChainRegistry,
-        accountRepository: AccountRepository,
-        proxySigningPresenter: ProxySigningPresenter,
-        proxyRepository: GetProxyRepository,
-        proxyExtrinsicValidationRequestBus: ProxyExtrinsicValidationRequestBus,
-        proxyCallFilterFactory: ProxyCallFilterFactory
-    ) = ProxiedSignerFactory(
-        chainRegistry = chainRegistry,
-        accountRepository = accountRepository,
-        proxySigningPresenter = proxySigningPresenter,
-        getProxyRepository = proxyRepository,
-        proxyExtrinsicValidationEventBus = proxyExtrinsicValidationRequestBus,
-        proxyCallFilterFactory = proxyCallFilterFactory
-    )
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/proxy/sign/RealProxySigningPresenter.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/proxy/sign/RealProxySigningPresenter.kt
@@ -10,6 +10,7 @@ import io.novafoundation.nova.common.utils.formatTokenAmount
 import io.novafoundation.nova.common.utils.formatting.spannable.SpannableFormatter
 import io.novafoundation.nova.common.utils.toSpannable
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.feature_account_api.domain.model.ProxiedMetaAccount
 import io.novafoundation.nova.feature_account_api.presenatation.account.proxy.ProxySigningPresenter
 import io.novafoundation.nova.feature_account_impl.R
 import io.novafoundation.nova.feature_account_impl.presentation.common.sign.notSupported.SigningNotSupportedPresentable
@@ -31,7 +32,7 @@ class RealProxySigningPresenter @Inject constructor(
     private val nestedSigningPresenter: NestedSigningPresenter,
 ) : ProxySigningPresenter {
 
-    override suspend fun acknowledgeProxyOperation(proxiedMetaAccount: MetaAccount, proxyMetaAccount: MetaAccount): Boolean {
+    override suspend fun acknowledgeProxyOperation(proxiedMetaAccount: ProxiedMetaAccount, proxyMetaAccount: MetaAccount): Boolean {
         return nestedSigningPresenter.acknowledgeNestedSignOperation(
             warningShowFor = proxiedMetaAccount,
             title = { resourceManager.getString(R.string.proxy_signing_warning_title) },
@@ -64,7 +65,7 @@ class RealProxySigningPresenter @Inject constructor(
     }
 
     override suspend fun notEnoughFee(
-        metaAccount: MetaAccount,
+        proxy: MetaAccount,
         chainAsset: Chain.Asset,
         availableBalance: BigInteger,
         fee: BigInteger
@@ -73,7 +74,7 @@ class RealProxySigningPresenter @Inject constructor(
             title = resourceManager.getString(R.string.error_not_enough_to_pay_fee_title),
             message = resourceManager.getString(
                 R.string.proxy_error_not_enough_to_pay_fee_message,
-                metaAccount.name,
+                proxy.name,
                 fee.amountFromPlanks(chainAsset.precision).formatTokenAmount(chainAsset.symbol),
                 availableBalance.amountFromPlanks(chainAsset.precision).formatTokenAmount(chainAsset.symbol)
             )

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/ProxyHaveEnoughFeeValidation.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/domain/validation/ProxyHaveEnoughFeeValidation.kt
@@ -9,7 +9,7 @@ import io.novafoundation.nova.common.validation.validOrError
 import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.intoOrigin
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_account_api.data.model.Fee
-import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.feature_account_api.domain.model.ProxiedMetaAccount
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.AssetSourceRegistry
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novafoundation.nova.runtime.multiNetwork.ChainWithAsset
@@ -25,17 +25,17 @@ class ProxyHaveEnoughFeeValidationFactory @Inject constructor(
 ) {
     fun <P, E> create(
         proxyAccountId: (P) -> AccountId,
-        metaAccount: (P) -> MetaAccount,
-        call: (P) -> GenericCall.Instance,
+        proxiedMetaAccount: (P) -> ProxiedMetaAccount,
+        proxiedCall: (P) -> GenericCall.Instance,
         chainWithAsset: (P) -> ChainWithAsset,
         proxyNotEnoughFee: (payload: P, availableBalance: Balance, fee: Fee) -> E,
     ): ProxyHaveEnoughFeeValidation<P, E> {
         return ProxyHaveEnoughFeeValidation(
             assetSourceRegistry,
             extrinsicService,
-            metaAccount,
+            proxiedMetaAccount,
             proxyAccountId,
-            call,
+            proxiedCall,
             chainWithAsset,
             proxyNotEnoughFee
         )
@@ -45,9 +45,9 @@ class ProxyHaveEnoughFeeValidationFactory @Inject constructor(
 class ProxyHaveEnoughFeeValidation<P, E>(
     private val assetSourceRegistry: AssetSourceRegistry,
     private val extrinsicService: ExtrinsicService,
-    private val metaAccount: (P) -> MetaAccount,
+    private val proxiedMetaAccount: (P) -> ProxiedMetaAccount,
     private val proxyAccountId: (P) -> AccountId,
-    private val call: (P) -> GenericCall.Instance,
+    private val proxiedCall: (P) -> GenericCall.Instance,
     private val chainWithAsset: (P) -> ChainWithAsset,
     private val proxyNotEnoughFee: (payload: P, availableBalance: Balance, fee: Fee) -> E,
 ) : Validation<P, E> {
@@ -55,7 +55,7 @@ class ProxyHaveEnoughFeeValidation<P, E>(
     override suspend fun validate(value: P): ValidationStatus<E> {
         val chain = chainWithAsset(value).chain
         val chainAsset = chainWithAsset(value).asset
-        val fee = calculateFee(metaAccount(value), chain, call(value))
+        val fee = calculateFee(proxiedMetaAccount(value), chain, proxiedCall(value))
 
         val assetSource = assetSourceRegistry.sourceFor(chainAsset)
         val assetBalanceSource = assetSource.balance
@@ -70,26 +70,30 @@ class ProxyHaveEnoughFeeValidation<P, E>(
         }
     }
 
-    private suspend fun calculateFee(metaAccount: MetaAccount, chain: Chain, callInstance: GenericCall.Instance): Fee {
-        return extrinsicService.estimateFee(chain, metaAccount.intoOrigin()) {
-            call(callInstance)
+    private suspend fun calculateFee(
+        proxiedMetaAccount: ProxiedMetaAccount,
+        chain: Chain,
+        proxiedCall: GenericCall.Instance
+    ): Fee {
+        return extrinsicService.estimateFee(chain, proxiedMetaAccount.intoOrigin()) {
+            call(proxiedCall)
         }
     }
 }
 
 fun <P, E> ValidationSystemBuilder<P, E>.proxyHasEnoughFeeValidation(
     factory: ProxyHaveEnoughFeeValidationFactory,
-    metaAccount: (P) -> MetaAccount,
+    proxiedMetaAccount: (P) -> ProxiedMetaAccount,
     proxyAccountId: (P) -> AccountId,
-    call: (P) -> GenericCall.Instance,
+    proxiedCall: (P) -> GenericCall.Instance,
     chainWithAsset: (P) -> ChainWithAsset,
     proxyNotEnoughFee: (payload: P, availableBalance: Balance, fee: Fee) -> E,
 ) = validate(
     factory.create(
-        proxyAccountId,
-        metaAccount,
-        call,
-        chainWithAsset,
-        proxyNotEnoughFee
+        proxyAccountId = proxyAccountId,
+        proxiedMetaAccount = proxiedMetaAccount,
+        proxiedCall = proxiedCall,
+        chainWithAsset = chainWithAsset,
+        proxyNotEnoughFee = proxyNotEnoughFee
     )
 )

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/domain/validaiton/multisig/MultisigNoPendingCallHashValidaiton.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/domain/validaiton/multisig/MultisigNoPendingCallHashValidaiton.kt
@@ -19,7 +19,7 @@ class MultisigNoPendingCallHashValidation(
 
     override suspend fun validate(value: MultisigExtrinsicValidationPayload): ValidationStatus<MultisigExtrinsicValidationFailure> {
         val runtime = chainRegistry.getRuntime(value.chain.id)
-        val callHash = value.delegatedCall.callHash(runtime).intoKey()
+        val callHash = value.callInsideAsMulti.callHash(runtime).intoKey()
 
         val hasPendingCallHash = multisigValidationsRepository.hasPendingCallHash(value.chain.id, value.multisigAccountId(), callHash)
 


### PR DESCRIPTION
* Fix wrapping order for MultisigSigner (see new docs in NovaSigner for details)
* Always use proxy/proxied explicit namings
* Unify namings in multisig validations
* Remove unused field in Proxy class
* Use stricter types when it comes to Proxied and Multisig meta accounts
* Fix condition for performing proxy validation - it should be done not when signer is root, but when the delegate signer is the leaf