### PR TITLE
Fix storage key encoding introduced after updating to K2 compiler

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/di/modules/CommonModule.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/di/modules/CommonModule.kt
@@ -7,7 +7,6 @@ import android.graphics.Color
 import coil.ImageLoader
 import coil.decode.SvgDecoder
 import com.google.android.play.core.integrity.IntegrityManagerFactory
-import com.google.android.play.core.integrity.StandardIntegrityManager
 import dagger.Module
 import dagger.Provides
 import io.novafoundation.nova.common.BuildConfig

--- a/common/src/main/java/io/novafoundation/nova/common/utils/IntegrityService.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/IntegrityService.kt
@@ -9,7 +9,6 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
-
 class IntegrityService(
     private val cloudProjectNumber: Long,
     private var standardIntegrityManager: StandardIntegrityManager

--- a/common/src/main/java/io/novafoundation/nova/common/utils/SubstrateSdkExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/SubstrateSdkExt.kt
@@ -404,12 +404,6 @@ fun StorageEntry.createStorageKey(vararg keyArguments: Any?): String {
     }
 }
 
-context(RuntimeContext)
-@JvmName("createStorageKeyArray")
-fun StorageEntry.createStorageKey(keyArguments: Array<out Any?>): String {
-    return createStorageKey(*keyArguments)
-}
-
 fun SeedFactory.deriveSeed32(mnemonicWords: String, password: String?) = cropSeedTo32Bytes(deriveSeed(mnemonicWords, password))
 
 private fun cropSeedTo32Bytes(seedResult: SeedFactory.Result): SeedFactory.Result {

--- a/common/src/main/java/io/novafoundation/nova/common/validation/ValidationExecutor.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/validation/ValidationExecutor.kt
@@ -50,6 +50,8 @@ class ValidationExecutor : Validatable {
                 onFailure = {
                     progressConsumer?.invoke(false)
 
+                    it.printStackTrace()
+
                     errorDisplayer(it)
                 },
                 onInvalid = {

--- a/common/src/main/java/io/novafoundation/nova/common/validation/ValidationExecutor.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/validation/ValidationExecutor.kt
@@ -50,8 +50,6 @@ class ValidationExecutor : Validatable {
                 onFailure = {
                     progressConsumer?.invoke(false)
 
-                    it.printStackTrace()
-
                     errorDisplayer(it)
                 },
                 onInvalid = {

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/DAppBrowserFragment.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/DAppBrowserFragment.kt
@@ -30,7 +30,6 @@ import io.novafoundation.nova.feature_dapp_impl.presentation.browser.main.sheets
 import io.novafoundation.nova.feature_dapp_impl.presentation.browser.options.OptionsBottomSheetDialog
 import io.novafoundation.nova.feature_dapp_impl.presentation.common.favourites.setupRemoveFavouritesConfirmation
 import io.novafoundation.nova.feature_dapp_impl.utils.tabs.models.BrowserTabSession
-import io.novafoundation.nova.feature_dapp_impl.web3.webview.PageCallback
 import io.novafoundation.nova.feature_dapp_impl.web3.webview.Web3ChromeClient
 import io.novafoundation.nova.feature_dapp_impl.web3.webview.CompoundWeb3Injector
 import io.novafoundation.nova.feature_dapp_impl.web3.webview.Web3WebViewClient
@@ -38,7 +37,6 @@ import io.novafoundation.nova.common.utils.browser.fileChoosing.WebViewFileChoos
 import io.novafoundation.nova.feature_dapp_impl.web3.webview.WebViewHolder
 import io.novafoundation.nova.common.utils.browser.permissions.WebViewPermissionAsker
 import io.novafoundation.nova.common.utils.webView.WebViewRequestInterceptor
-import io.novafoundation.nova.common.view.dialog.dialog
 import io.novafoundation.nova.common.view.dialog.infoDialog
 import io.novafoundation.nova.feature_dapp_impl.utils.tabs.models.SessionCallback
 import io.novafoundation.nova.feature_external_sign_api.presentation.externalSign.AuthorizeDappBottomSheet

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/DAppBrowserViewModel.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/DAppBrowserViewModel.kt
@@ -24,7 +24,6 @@ import io.novafoundation.nova.feature_dapp_impl.presentation.common.favourites.R
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DAppSearchCommunicator
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.DAppSearchRequester
 import io.novafoundation.nova.feature_dapp_impl.presentation.search.SearchPayload
-import io.novafoundation.nova.feature_dapp_impl.utils.integrityCheck.IntegrityCheckProviderFactory
 import io.novafoundation.nova.feature_dapp_impl.utils.tabs.BrowserTabService
 import io.novafoundation.nova.feature_dapp_impl.utils.tabs.createAndSelectTab
 import io.novafoundation.nova.feature_dapp_impl.utils.tabs.models.CurrentTabState

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/utils/integrityCheck/IntegrityCheckApi.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/utils/integrityCheck/IntegrityCheckApi.kt
@@ -14,11 +14,9 @@ interface IntegrityCheckApi {
 
 class ChallengeResponse(val challenge: String)
 
-
 class AttestRequest(
     val appIntegrityId: String,
     val publicKey: String,
     val integrityToken: String,
     val challenge: String
 )
-

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/utils/integrityCheck/IntegrityCheckProvider.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/utils/integrityCheck/IntegrityCheckProvider.kt
@@ -97,7 +97,6 @@ class IntegrityCheckProvider(
         }
     }
 
-
     private fun log(message: String) = launchUnit(Dispatchers.Main) {
         Log.e(LOG_TAG, message)
         webView.evaluateJavascript("console.log('$message')", null)

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/BaseStorageQueryContext.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/storage/source/query/BaseStorageQueryContext.kt
@@ -5,6 +5,7 @@ import io.novafoundation.nova.common.data.network.runtime.binding.bindNumberOrZe
 import io.novafoundation.nova.common.data.network.runtime.binding.fromHexOrIncompatible
 import io.novafoundation.nova.common.data.network.runtime.binding.incompatible
 import io.novafoundation.nova.common.utils.ComponentHolder
+import io.novafoundation.nova.common.utils.RuntimeContext
 import io.novafoundation.nova.common.utils.createStorageKey
 import io.novafoundation.nova.common.utils.mapValuesNotNull
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
@@ -133,13 +134,13 @@ abstract class BaseStorageQueryContext(
         vararg keyArguments: Any?,
         binding: DynamicInstanceBinder<V>
     ): V {
-        val storageKey = createStorageKey(keyArguments)
+        val storageKey = createStorageKeyFromArrayArgs(keyArguments)
         val scaleResult = queryKey(storageKey, at)
         return decodeStorageValue(scaleResult, binding)
     }
 
     override suspend fun StorageEntry.queryRaw(vararg keyArguments: Any?): String? {
-        val storageKey = createStorageKey(keyArguments)
+        val storageKey = createStorageKeyFromArrayArgs(keyArguments)
 
         return queryKey(storageKey, at)
     }
@@ -148,7 +149,7 @@ abstract class BaseStorageQueryContext(
         vararg keyArguments: Any?,
         binding: DynamicInstanceBinder<V>
     ): Flow<V> {
-        val storageKey = createStorageKey(keyArguments)
+        val storageKey = createStorageKeyFromArrayArgs(keyArguments)
 
         return observeKey(storageKey).map { storageUpdate ->
             decodeStorageValue(storageUpdate.value, binding)
@@ -159,7 +160,7 @@ abstract class BaseStorageQueryContext(
         vararg keyArguments: Any?,
         binding: DynamicInstanceBinder<V>
     ): Flow<WithRawValue<V>> {
-        val storageKey = createStorageKey(keyArguments)
+        val storageKey = createStorageKeyFromArrayArgs(keyArguments)
 
         return observeKey(storageKey).map { storageUpdate ->
             val decoded = decodeStorageValue(storageUpdate.value, binding)
@@ -264,6 +265,11 @@ abstract class BaseStorageQueryContext(
                 null
             }
         }
+    }
+
+    context(RuntimeContext)
+    private fun StorageEntry.createStorageKeyFromArrayArgs(keyArguments: Array<out Any?>): String {
+        return createStorageKey(*keyArguments)
     }
 
     protected class StorageUpdate(


### PR DESCRIPTION
We had two functions

```
fun StorageEntry.createStorageKey(vararg keyArguments: Any?): String 
```

and 

```
fun StorageEntry.createStorageKey(keyArguments: Array<out Any?>): String 
```

With the old compiler the following

```
override suspend fun <V> StorageEntry.query(        vararg keyArguments: Any? ): V {
        val storageKey = createStorageKey(keyArguments)
    }
```
resolved to the overload with `Array` which was expected behavior. However with K2, this resolves to overaload with vararg

To address this, we remove this shady overloads entirely by making array function private and use a different name for it