### PR TITLE
Improve weight heuristics function

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/utils/graph/Graph.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/graph/Graph.kt
@@ -12,8 +12,7 @@ interface Edge<N> {
 
 interface WeightedEdge<N> : Edge<N> {
 
-    // Smaller the better
-    val weight: Int
+    fun weightForAppendingTo(path: Path<WeightedEdge<N>>): Int
 }
 
 class Graph<N, E : Edge<N>>(
@@ -113,7 +112,7 @@ suspend fun <N, E : WeightedEdge<N>> Graph<N, E>.findDijkstraPathsBetween(
 
                 val newElement = QueueElement(
                     currentPath = minimumQueueElement.currentPath + edge,
-                    score = minimumQueueElement.score + edge.weight
+                    score = minimumQueueElement.score + edge.weightForAppendingTo(minimumQueueElement.currentPath)
                 )
 
                 heap.add(newElement)

--- a/common/src/main/java/io/novafoundation/nova/common/utils/graph/SimpleGraph.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/graph/SimpleGraph.kt
@@ -4,7 +4,9 @@ import io.novafoundation.nova.common.utils.MultiMapList
 
 data class SimpleEdge<N>(override val from: N, override val to: N) : WeightedEdge<N> {
 
-    override val weight: Int = 1
+    override fun weightForAppendingTo(path: Path<WeightedEdge<N>>): Int {
+        return 1
+    }
 }
 
 typealias SimpleGraph<N> = Graph<N, SimpleEdge<N>>

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/paths/model/QuotedPath.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/paths/model/QuotedPath.kt
@@ -24,25 +24,29 @@ class QuotedPath<E>(
     }
 }
 
-class WeightBreakdown(
+class WeightBreakdown private constructor(
     val individualWeights: List<Int>,
     val total: Int
-)
+) {
 
-fun <N, E : WeightedEdge<N>> QuotedPath<E>.weightBreakdown(): WeightBreakdown {
-    val weightedPath = mutableListOf<E>()
-    val individualWeights = mutableListOf<Int>()
-    var weight = 0
+    companion object {
 
-    path.forEach { quotedEdge ->
-        val edgeWeight = quotedEdge.edge.weightForAppendingTo(weightedPath)
+        fun <N, E : WeightedEdge<N>> fromQuotedPath(path: QuotedPath<E>): WeightBreakdown {
+            val weightedPath = mutableListOf<E>()
+            val individualWeights = mutableListOf<Int>()
+            var weight = 0
 
-        weight += edgeWeight
-        weightedPath += quotedEdge.edge
-        individualWeights += edgeWeight
+            path.path.forEach { quotedEdge ->
+                val edgeWeight = quotedEdge.edge.weightForAppendingTo(weightedPath)
+
+                weight += edgeWeight
+                weightedPath += quotedEdge.edge
+                individualWeights += edgeWeight
+            }
+
+            return WeightBreakdown(individualWeights, weight)
+        }
     }
-
-    return WeightBreakdown(individualWeights, weight)
 }
 
 val QuotedPath<*>.quote: BigInteger

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/paths/model/QuotedPath.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/paths/model/QuotedPath.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_swap_core_api.data.paths.model
 
 import io.novafoundation.nova.common.utils.graph.Path
+import io.novafoundation.nova.common.utils.graph.WeightedEdge
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import java.math.BigInteger
 
@@ -22,6 +23,28 @@ class QuotedPath<E>(
         }
     }
 }
+
+class WeightBreakdown(
+    val individualWeights: List<Int>,
+    val total: Int
+)
+
+fun <N, E : WeightedEdge<N>> QuotedPath<E>.weightBreakdown() : WeightBreakdown {
+    val weightedPath = mutableListOf<E>()
+    val individualWeights = mutableListOf<Int>()
+    var weight = 0
+
+    path.forEach { quotedEdge ->
+        val edgeWeight = quotedEdge.edge.weightForAppendingTo(weightedPath)
+
+        weight += edgeWeight
+        weightedPath += quotedEdge.edge
+        individualWeights += edgeWeight
+    }
+
+    return WeightBreakdown(individualWeights, weight)
+}
+
 
 val QuotedPath<*>.quote: BigInteger
     get() = when (direction) {

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/paths/model/QuotedPath.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/paths/model/QuotedPath.kt
@@ -29,7 +29,7 @@ class WeightBreakdown(
     val total: Int
 )
 
-fun <N, E : WeightedEdge<N>> QuotedPath<E>.weightBreakdown() : WeightBreakdown {
+fun <N, E : WeightedEdge<N>> QuotedPath<E>.weightBreakdown(): WeightBreakdown {
     val weightedPath = mutableListOf<E>()
     val individualWeights = mutableListOf<Int>()
     var weight = 0
@@ -44,7 +44,6 @@ fun <N, E : WeightedEdge<N>> QuotedPath<E>.weightBreakdown() : WeightBreakdown {
 
     return WeightBreakdown(individualWeights, weight)
 }
-
 
 val QuotedPath<*>.quote: BigInteger
     get() = when (direction) {

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/primitive/model/QuotableEdge.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/primitive/model/QuotableEdge.kt
@@ -5,11 +5,10 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import java.math.BigInteger
 
 interface QuotableEdge : WeightedEdge<FullChainAssetId> {
-
     companion object {
 
-        // Allow [0..10] precision for smaller weights
-        const val DEFAULT_SEGMENT_WEIGHT = 10
+        // Allow [0..100] precision for smaller weights
+        const val DEFAULT_SEGMENT_WEIGHT = 100
     }
 
     suspend fun quote(

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/HydraDxQuotableEdge.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/HydraDxQuotableEdge.kt
@@ -1,0 +1,5 @@
+package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources
+
+import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
+
+interface HydraDxQuotableEdge : QuotableEdge

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/Wegiths.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/Wegiths.kt
@@ -1,21 +1,34 @@
 package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources
 
+import io.novafoundation.nova.common.utils.graph.Path
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
 
 object Weights {
 
     object Hydra {
 
+        fun weightAppendingToPath(path: Path<*>, baseWeight: Int): Int {
+            // Significantly reduce weight of consequent hydration segments since they are collapsed into single tx
+            return if (path.isNotEmpty() && path.last() is HydraDxQuotableEdge) {
+                (baseWeight / 10)
+            } else {
+                baseWeight
+            }
+        }
+
         const val OMNIPOOL = QuotableEdge.DEFAULT_SEGMENT_WEIGHT
 
-        const val STABLESWAP = QuotableEdge.DEFAULT_SEGMENT_WEIGHT - 1
+        const val STABLESWAP = QuotableEdge.DEFAULT_SEGMENT_WEIGHT - 10
 
-        const val XYK = QuotableEdge.DEFAULT_SEGMENT_WEIGHT + 1
+        const val XYK = QuotableEdge.DEFAULT_SEGMENT_WEIGHT + 10
     }
 
     object AssetConversion {
 
-        const val SWAP = QuotableEdge.DEFAULT_SEGMENT_WEIGHT + 2
+        // Asset conversion pools liquidity, they are unfavourable
+        // We do x3 to allow heuristics to find routes with 3 cross-chain to be ranked even higher prioritize
+        // Search via Hydration
+        const val SWAP = 3 * CrossChainTransfer.TRANSFER + 10
     }
 
     object CrossChainTransfer {

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/Wegiths.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/Wegiths.kt
@@ -10,6 +10,11 @@ object Weights {
         fun weightAppendingToPath(path: Path<*>, baseWeight: Int): Int {
             // Significantly reduce weight of consequent hydration segments since they are collapsed into single tx
             return if (path.isNotEmpty() && path.last() is HydraDxQuotableEdge) {
+                // We divide here by 10 to achieve two goals:
+                // 1. Divisor should be significant enough to allow multiple appended segments to be added without influencing total hydration weight much
+                // 2. On the other hand, divisor cannot be extremely large as we will loose precision and it wont be possible
+                // to distinguish different hydration segments weights between each other.
+                // That is also why OMNIPOOL, STABLESWAP and XYK differ by a multiple of ten
                 (baseWeight / 10)
             } else {
                 baseWeight

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/omnipool/RealOmniPoolQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/omnipool/RealOmniPoolQuotingSource.kt
@@ -1,6 +1,9 @@
 package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool
 
 import io.novafoundation.nova.common.utils.dynamicFees
+import io.novafoundation.nova.common.utils.graph.Path
+import io.novafoundation.nova.common.utils.graph.WeightedEdge
+import io.novafoundation.nova.common.utils.metadata
 import io.novafoundation.nova.common.utils.numberConstant
 import io.novafoundation.nova.common.utils.omnipool
 import io.novafoundation.nova.common.utils.orZero
@@ -8,6 +11,7 @@ import io.novafoundation.nova.common.utils.singleReplaySharedFlow
 import io.novafoundation.nova.common.utils.toMultiSubscription
 import io.novafoundation.nova.core.updater.SharedRequestsBuilder
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.Weights
+import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.Weights.Hydra.weightAppendingToPath
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.model.DynamicFee
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.model.OmniPool
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.model.OmniPoolFees
@@ -30,7 +34,6 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import io.novafoundation.nova.runtime.multiNetwork.getRuntime
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novafoundation.nova.runtime.storage.source.query.api.observeNonNull
-import io.novafoundation.nova.common.utils.metadata
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -205,8 +208,9 @@ private class RealOmniPoolQuotingSource(
 
         override val to: FullChainAssetId = toAsset.second.fullId
 
-        override val weight: Int
-            get() = Weights.Hydra.OMNIPOOL
+        override fun weightForAppendingTo(path: Path<WeightedEdge<FullChainAssetId>>): Int {
+            return weightAppendingToPath(path, Weights.Hydra.OMNIPOOL)
+        }
 
         override suspend fun quote(amount: BigInteger, direction: SwapDirection): BigInteger {
             val omniPool = omniPoolFlow.first()

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/stableswap/RealStableSwapQuotingSource.kt
@@ -6,11 +6,15 @@ import io.novafoundation.nova.common.data.network.runtime.binding.orEmpty
 import io.novafoundation.nova.common.domain.balance.TransferableMode
 import io.novafoundation.nova.common.domain.balance.calculateTransferable
 import io.novafoundation.nova.common.utils.filterNotNull
+import io.novafoundation.nova.common.utils.graph.Path
+import io.novafoundation.nova.common.utils.graph.WeightedEdge
+import io.novafoundation.nova.common.utils.metadata
 import io.novafoundation.nova.common.utils.orZero
 import io.novafoundation.nova.common.utils.singleReplaySharedFlow
 import io.novafoundation.nova.common.utils.toMultiSubscription
 import io.novafoundation.nova.core.updater.SharedRequestsBuilder
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.Weights
+import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.Weights.Hydra.weightAppendingToPath
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.model.RemoteAndLocalId
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.model.RemoteAndLocalIdOptional
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.model.flatten
@@ -29,7 +33,6 @@ import io.novafoundation.nova.runtime.ext.fullId
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
-import io.novafoundation.nova.common.utils.metadata
 import io.novasama.substrate_sdk_android.encrypt.json.asLittleEndianBytes
 import io.novasama.substrate_sdk_android.hash.Hasher.blake2b256
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -285,8 +288,9 @@ private class RealStableSwapQuotingSource(
 
         override val to: FullChainAssetId = toAsset.second
 
-        override val weight: Int
-            get() = Weights.Hydra.STABLESWAP
+        override fun weightForAppendingTo(path: Path<WeightedEdge<FullChainAssetId>>): Int {
+            return weightAppendingToPath(path, Weights.Hydra.STABLESWAP)
+        }
 
         override suspend fun quote(amount: BigInteger, direction: SwapDirection): BigInteger {
             val allPools = stablePools.first()

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/xyk/RealXYKSwapQuotingSource.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/xyk/RealXYKSwapQuotingSource.kt
@@ -2,10 +2,13 @@ package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.t
 
 import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.utils.combine
+import io.novafoundation.nova.common.utils.graph.Path
+import io.novafoundation.nova.common.utils.graph.WeightedEdge
 import io.novafoundation.nova.common.utils.singleReplaySharedFlow
 import io.novafoundation.nova.common.utils.xyk
 import io.novafoundation.nova.core.updater.SharedRequestsBuilder
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.Weights
+import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.Weights.Hydra.weightAppendingToPath
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.model.RemoteAndLocalId
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.model.localId
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.subscribeToTransferableBalance
@@ -176,8 +179,9 @@ private class RealXYKSwapQuotingSource(
 
         override val to: FullChainAssetId = toAsset.second
 
-        override val weight: Int
-            get() = Weights.Hydra.XYK
+        override fun weightForAppendingTo(path: Path<WeightedEdge<FullChainAssetId>>): Int {
+            return weightAppendingToPath(path, Weights.Hydra.XYK)
+        }
 
         override suspend fun quote(amount: BigInteger, direction: SwapDirection): BigInteger {
             val allPools = xykPools.first()

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/assetConversion/AssetConversionExchange.kt
@@ -1,15 +1,19 @@
 package io.novafoundation.nova.feature_swap_impl.data.assetExchange.assetConversion
 
-import io.novafoundation.nova.feature_xcm_api.multiLocation.RelativeMultiLocation
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumberOrNull
 import io.novafoundation.nova.common.utils.Modules
 import io.novafoundation.nova.common.utils.assetConversionAssetIdType
+import io.novafoundation.nova.common.utils.graph.Path
+import io.novafoundation.nova.common.utils.graph.WeightedEdge
+import io.novafoundation.nova.common.utils.metadata
 import io.novafoundation.nova.feature_account_api.data.conversion.assethub.assetConversionOrNull
 import io.novafoundation.nova.feature_account_api.data.conversion.assethub.pools
 import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.TransactionOrigin
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
+import io.novafoundation.nova.feature_account_api.data.extrinsic.execution.ExtrinsicExecutionResult
 import io.novafoundation.nova.feature_account_api.data.extrinsic.execution.requireOk
+import io.novafoundation.nova.feature_account_api.data.extrinsic.execution.requireOutcomeOk
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_swap_api.domain.model.AtomicOperationDisplayData
 import io.novafoundation.nova.feature_swap_api.domain.model.AtomicSwapOperation
@@ -21,6 +25,7 @@ import io.novafoundation.nova.feature_swap_api.domain.model.SwapExecutionCorrect
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapGraphEdge
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapLimit
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapMaxAdditionalAmountDeduction
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapSubmissionResult
 import io.novafoundation.nova.feature_swap_api.domain.model.UsdConverter
 import io.novafoundation.nova.feature_swap_api.domain.model.estimatedAmountIn
 import io.novafoundation.nova.feature_swap_api.domain.model.estimatedAmountOut
@@ -39,6 +44,7 @@ import io.novafoundation.nova.feature_wallet_api.domain.model.withAmount
 import io.novafoundation.nova.feature_xcm_api.converter.MultiLocationConverter
 import io.novafoundation.nova.feature_xcm_api.converter.MultiLocationConverterFactory
 import io.novafoundation.nova.feature_xcm_api.converter.toMultiLocationOrThrow
+import io.novafoundation.nova.feature_xcm_api.multiLocation.RelativeMultiLocation
 import io.novafoundation.nova.feature_xcm_api.versions.XcmVersion
 import io.novafoundation.nova.feature_xcm_api.versions.detector.XcmVersionDetector
 import io.novafoundation.nova.feature_xcm_api.versions.orDefault
@@ -53,10 +59,6 @@ import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.findEventO
 import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novafoundation.nova.runtime.repository.expectedBlockTime
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
-import io.novafoundation.nova.common.utils.metadata
-import io.novafoundation.nova.feature_account_api.data.extrinsic.execution.ExtrinsicExecutionResult
-import io.novafoundation.nova.feature_account_api.data.extrinsic.execution.requireOutcomeOk
-import io.novafoundation.nova.feature_swap_api.domain.model.SwapSubmissionResult
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.runtime.RuntimeSnapshot
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericEvent
@@ -223,8 +225,9 @@ private class AssetConversionExchange(
             ) ?: throw SwapQuoteException.NotEnoughLiquidity
         }
 
-        override val weight: Int
-            get() = Weights.AssetConversion.SWAP
+        override fun weightForAppendingTo(path: Path<WeightedEdge<FullChainAssetId>>): Int {
+            return Weights.AssetConversion.SWAP
+        }
     }
 
     inner class AssetConversionOperationPrototype(override val fromChain: ChainId) : AtomicSwapOperationPrototype {

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/crossChain/CrossChainTransferAssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/crossChain/CrossChainTransferAssetExchange.kt
@@ -3,6 +3,8 @@ package io.novafoundation.nova.feature_swap_impl.data.assetExchange.crossChain
 import io.novafoundation.nova.common.utils.firstNotNull
 import io.novafoundation.nova.common.utils.flatMap
 import io.novafoundation.nova.common.utils.graph.Edge
+import io.novafoundation.nova.common.utils.graph.Path
+import io.novafoundation.nova.common.utils.graph.WeightedEdge
 import io.novafoundation.nova.common.utils.mapError
 import io.novafoundation.nova.common.utils.mapToSet
 import io.novafoundation.nova.common.utils.orZero
@@ -117,9 +119,6 @@ class CrossChainTransferAssetExchange(
 
         private var canUseXcmExecute: Boolean? = null
 
-        override val weight: Int
-            get() = Weights.CrossChainTransfer.TRANSFER
-
         override suspend fun beginOperation(args: AtomicSwapOperationArgs): AtomicSwapOperation {
             return CrossChainTransferOperation(args, this)
         }
@@ -164,6 +163,10 @@ class CrossChainTransferAssetExchange(
 
         override suspend fun quote(amount: BigInteger, direction: SwapDirection): BigInteger {
             return amount
+        }
+
+        override fun weightForAppendingTo(path: Path<WeightedEdge<FullChainAssetId>>): Int {
+            return Weights.CrossChainTransfer.TRANSFER
         }
 
         private suspend fun canUseXcmExecute(): Boolean {

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxAssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxAssetExchange.kt
@@ -49,10 +49,10 @@ import io.novafoundation.nova.feature_swap_api.domain.model.fee.SubmissionOnlyAt
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.acceptedCurrencies
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.accountCurrencyMap
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.multiTransactionPayment
+import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.HydraDxQuotableEdge
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetId
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdConverter
 import io.novafoundation.nova.feature_swap_core_api.data.network.toOnChainIdOrThrow
-import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
@@ -239,7 +239,7 @@ private class HydraDxAssetExchange(
 
     private inner class HydraDxSwapEdge(
         private val sourceQuotableEdge: HydraDxSourceEdge,
-    ) : SwapGraphEdge, QuotableEdge by sourceQuotableEdge {
+    ) : SwapGraphEdge, HydraDxQuotableEdge by sourceQuotableEdge {
 
         override suspend fun beginOperation(args: AtomicSwapOperationArgs): AtomicSwapOperation {
             return HydraDxOperation(sourceQuotableEdge, args)

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxSwapSource.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxSwapSource.kt
@@ -3,7 +3,7 @@ package io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx
 import io.novafoundation.nova.common.utils.Identifiable
 import io.novafoundation.nova.core.updater.SharedRequestsBuilder
 import io.novafoundation.nova.feature_swap_api.domain.model.AtomicSwapOperationArgs
-import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
+import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.HydraDxQuotableEdge
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -20,7 +20,7 @@ interface StandaloneHydraSwap {
     fun extractReceivedAmount(events: List<GenericEvent.Instance>): Balance
 }
 
-interface HydraDxSourceEdge : QuotableEdge {
+interface HydraDxSourceEdge : HydraDxQuotableEdge {
 
     fun routerPoolArgument(): DictEnum.Entry<*>
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
@@ -65,11 +65,11 @@ import io.novafoundation.nova.feature_swap_core_api.data.paths.PathQuoter
 import io.novafoundation.nova.feature_swap_core_api.data.paths.model.PathRoughFeeEstimation
 import io.novafoundation.nova.feature_swap_core_api.data.paths.model.QuotedEdge
 import io.novafoundation.nova.feature_swap_core_api.data.paths.model.QuotedPath
+import io.novafoundation.nova.feature_swap_core_api.data.paths.model.WeightBreakdown
 import io.novafoundation.nova.feature_swap_core_api.data.paths.model.firstSegmentQuote
 import io.novafoundation.nova.feature_swap_core_api.data.paths.model.firstSegmentQuotedAmount
 import io.novafoundation.nova.feature_swap_core_api.data.paths.model.lastSegmentQuote
 import io.novafoundation.nova.feature_swap_core_api.data.paths.model.lastSegmentQuotedAmount
-import io.novafoundation.nova.feature_swap_core_api.data.paths.model.weightBreakdown
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import io.novafoundation.nova.feature_swap_impl.BuildConfig
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.AssetExchange
@@ -737,7 +737,7 @@ internal class RealSwapService(
 
     private suspend fun formatTrade(trade: QuotedTrade): String {
         return buildString {
-            val weightBreakdown = trade.weightBreakdown()
+            val weightBreakdown = WeightBreakdown.fromQuotedPath(trade)
 
             trade.path.zip(weightBreakdown.individualWeights).onEachIndexed { index, (quotedSwapEdge, weight) ->
                 val amountIn: Balance

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
@@ -768,7 +768,7 @@ internal class RealSwapService(
                     }
                 }
 
-                append(" --- ${quotedSwapEdge.edge.debugLabel()} (w: ${weight})---> ")
+                append(" --- ${quotedSwapEdge.edge.debugLabel()} (w: $weight)---> ")
 
                 val assetOut = chainRegistry.asset(quotedSwapEdge.edge.to)
                 val outAmount = amountOut.formatPlanks(assetOut)


### PR DESCRIPTION
* Increase granularity of weights by increasing base weight from 10 to 100
* Increase weight of AssetConversionSwap to 3x cross-chain tranfser weight (see reasoning in the comment)
* Decrease weight of hydration edges when they are merged together into single tx
* Add logging of the weight for better debugging

Main reason for the changes is to fix AssetConversion swaps taking all the candidate spaces not even allowing Hydration paths to be quoted