### PR TITLE
Feature/multichain indexer complete

### DIFF
--- a/core-db/src/androidTest/java/io/novafoundation/nova/core_db/dao/Helpers.kt
+++ b/core-db/src/androidTest/java/io/novafoundation/nova/core_db/dao/Helpers.kt
@@ -4,7 +4,6 @@ import io.novafoundation.nova.common.utils.CollectionDiffer
 import io.novafoundation.nova.core.model.CryptoType
 import io.novafoundation.nova.core_db.model.CurrencyLocal
 import io.novafoundation.nova.core_db.model.chain.AssetSourceLocal
-import io.novafoundation.nova.core_db.model.chain.account.ChainAccountLocal
 import io.novafoundation.nova.core_db.model.chain.ChainAssetLocal
 import io.novafoundation.nova.core_db.model.chain.ChainExplorerLocal
 import io.novafoundation.nova.core_db.model.chain.ChainExternalApiLocal
@@ -12,6 +11,7 @@ import io.novafoundation.nova.core_db.model.chain.ChainLocal
 import io.novafoundation.nova.core_db.model.chain.ChainNodeLocal
 import io.novafoundation.nova.core_db.model.chain.JoinedChainInfo
 import io.novafoundation.nova.core_db.model.chain.NodeSelectionPreferencesLocal
+import io.novafoundation.nova.core_db.model.chain.account.ChainAccountLocal
 import io.novafoundation.nova.core_db.model.chain.account.MetaAccountLocal
 
 fun createTestChain(
@@ -67,7 +67,8 @@ fun chainOf(
     hasSubstrateRuntime = true,
     nodeSelectionStrategy = ChainLocal.AutoBalanceStrategyLocal.ROUND_ROBIN,
     source = ChainLocal.Source.CUSTOM,
-    customFee = ""
+    customFee = "",
+    multisigSupport = true
 )
 
 fun ChainLocal.nodeOf(

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
@@ -52,7 +52,6 @@ import io.novafoundation.nova.core_db.migrations.AddBalanceHolds_60_61
 import io.novafoundation.nova.core_db.migrations.AddBalanceModesToAssets_51_52
 import io.novafoundation.nova.core_db.migrations.AddBrowserHostSettings_34_35
 import io.novafoundation.nova.core_db.migrations.AddBrowserTabs_64_65
-import io.novafoundation.nova.core_db.migrations.AddFavoriteDAppsOrdering_65_66
 import io.novafoundation.nova.core_db.migrations.AddBuyProviders_7_8
 import io.novafoundation.nova.core_db.migrations.AddChainColor_4_5
 import io.novafoundation.nova.core_db.migrations.AddChainForeignKeyForProxy_63_64
@@ -64,6 +63,7 @@ import io.novafoundation.nova.core_db.migrations.AddEnabledColumnToChainAssets_3
 import io.novafoundation.nova.core_db.migrations.AddEventIdToOperation_47_48
 import io.novafoundation.nova.core_db.migrations.AddExternalBalances_45_46
 import io.novafoundation.nova.core_db.migrations.AddExtrinsicContentField_37_38
+import io.novafoundation.nova.core_db.migrations.AddFavoriteDAppsOrdering_65_66
 import io.novafoundation.nova.core_db.migrations.AddFavouriteDApps_9_10
 import io.novafoundation.nova.core_db.migrations.AddFungibleNfts_55_56
 import io.novafoundation.nova.core_db.migrations.AddGloballyUniqueIdToMetaAccounts_58_59
@@ -76,6 +76,7 @@ import io.novafoundation.nova.core_db.migrations.AddLocalMigratorVersionToChainR
 import io.novafoundation.nova.core_db.migrations.AddLocks_22_23
 import io.novafoundation.nova.core_db.migrations.AddMetaAccountType_14_15
 import io.novafoundation.nova.core_db.migrations.AddMultisigCalls_69_70
+import io.novafoundation.nova.core_db.migrations.AddMultisigSupportFlag_70_71
 import io.novafoundation.nova.core_db.migrations.AddNfts_5_6
 import io.novafoundation.nova.core_db.migrations.AddNodeSelectionStrategyField_38_39
 import io.novafoundation.nova.core_db.migrations.AddPoolIdToOperations_46_47
@@ -161,7 +162,7 @@ import io.novafoundation.nova.core_db.model.operation.SwapTypeLocal
 import io.novafoundation.nova.core_db.model.operation.TransferTypeLocal
 
 @Database(
-    version = 70,
+    version = 71,
     entities = [
         AccountLocal::class,
         NodeLocal::class,
@@ -263,7 +264,7 @@ abstract class AppDatabase : RoomDatabase() {
                     .addMigrations(ChainNetworkManagement_59_60, AddBalanceHolds_60_61, ChainNetworkManagement_61_62)
                     .addMigrations(TinderGovBasket_62_63, AddChainForeignKeyForProxy_63_64, AddBrowserTabs_64_65)
                     .addMigrations(AddFavoriteDAppsOrdering_65_66, AddLegacyAddressPrefix_66_67, AddSellProviders_67_68)
-                    .addMigrations(AddTypeExtrasToMetaAccount_68_69, AddMultisigCalls_69_70)
+                    .addMigrations(AddTypeExtrasToMetaAccount_68_69, AddMultisigCalls_69_70, AddMultisigSupportFlag_70_71)
                     .build()
             }
             return instance!!

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/70_71_AddMultisigSupportFlag.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/70_71_AddMultisigSupportFlag.kt
@@ -7,7 +7,7 @@ val AddMultisigSupportFlag_70_71 = object : Migration(70, 71) {
     override fun migrate(db: SupportSQLiteDatabase) {
         // Add multisigSupport column to chains table
         db.execSQL("ALTER TABLE `chains` ADD COLUMN `multisigSupport` INTEGER NOT NULL DEFAULT 0")
-        
+
         // Update multisigSupport flag based on the presence of MULTISIG external API
         db.execSQL(
             """

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/70_71_AddMultisigSupportFlag.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/70_71_AddMultisigSupportFlag.kt
@@ -1,0 +1,30 @@
+package io.novafoundation.nova.core_db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val AddMultisigSupportFlag_70_71 = object : Migration(70, 71) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // Add multisigSupport column to chains table
+        db.execSQL("ALTER TABLE `chains` ADD COLUMN `multisigSupport` INTEGER NOT NULL DEFAULT 0")
+        
+        // Update multisigSupport flag based on the presence of MULTISIG external API
+        db.execSQL(
+            """
+            UPDATE chains SET multisigSupport = 1
+            WHERE id IN (
+                SELECT DISTINCT chainId FROM chain_external_apis 
+                WHERE apiType = 'MULTISIG'
+            )
+            """.trimIndent()
+        )
+
+        // Delete all multisig external apis
+        db.execSQL(
+            """
+                DELETE FROM chain_external_apis 
+                WHERE apiType = 'MULTISIG'
+            """.trimIndent()
+        )
+    }
+}

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/ChainExternalApiLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/ChainExternalApiLocal.kt
@@ -38,7 +38,7 @@ data class ChainExternalApiLocal(
         TRANSFERS, STAKING, CROWDLOANS,
         GOVERNANCE_REFERENDA, GOVERNANCE_DELEGATIONS,
         REFERENDUM_SUMMARY,
-        MULTISIG,
+
         UNKNOWN
     }
 

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/ChainLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/ChainLocal.kt
@@ -29,6 +29,8 @@ data class ChainLocal(
     val hasCrowdloans: Boolean,
     @ColumnInfo(defaultValue = "0")
     val supportProxy: Boolean,
+    @ColumnInfo(defaultValue = "0")
+    val multisigSupport: Boolean,
     val swap: String,
     val customFee: String,
     val governance: String,

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/multisig/RealMultisigRepository.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/multisig/RealMultisigRepository.kt
@@ -26,10 +26,8 @@ import io.novafoundation.nova.feature_account_impl.data.multisig.blockhain.multi
 import io.novafoundation.nova.feature_account_impl.data.multisig.model.DiscoveredMultisig
 import io.novafoundation.nova.feature_account_impl.data.multisig.model.OffChainPendingMultisigOperationInfo
 import io.novafoundation.nova.runtime.di.REMOTE_STORAGE_SOURCE
-import io.novafoundation.nova.runtime.ext.hasExternalApi
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.ExternalApi
 import io.novafoundation.nova.runtime.multiNetwork.withRuntime
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novasama.substrate_sdk_android.runtime.definitions.types.generics.GenericCall
@@ -50,7 +48,7 @@ class RealMultisigRepository @Inject constructor(
 ) : MultisigRepository {
 
     override fun supportsMultisigSync(chain: Chain): Boolean {
-        return chain.hasMultisigApi()
+        return chain.multisigSupport
     }
 
     override suspend fun findMultisigAccounts(accountIds: Set<AccountIdKey>): List<DiscoveredMultisig> {
@@ -153,9 +151,5 @@ class RealMultisigRepository @Inject constructor(
     private fun AccountMultisigRemote.MultisigRemote.thresholdIfValid(): Int? {
         // Just to be sure we do not insert some invalid data
         return threshold.takeIf { it >= 1 }
-    }
-
-    private fun Chain.hasMultisigApi(): Boolean {
-        return hasExternalApi<ExternalApi.Multisig>()
     }
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/multisig/api/request/OffChainPendingMultisigInfoRequest.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/multisig/api/request/OffChainPendingMultisigInfoRequest.kt
@@ -4,10 +4,13 @@ import io.novafoundation.nova.common.address.AccountIdKey
 import io.novafoundation.nova.common.address.toHexWithPrefix
 import io.novafoundation.nova.common.data.network.subquery.SubQueryFilters
 import io.novafoundation.nova.feature_account_api.domain.multisig.CallHash
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novasama.substrate_sdk_android.extensions.requireHexPrefix
 
 class OffChainPendingMultisigInfoRequest(
     accountIdKey: AccountIdKey,
-    callHashes: Collection<CallHash>
+    callHashes: Collection<CallHash>,
+    chainId: ChainId
 ) : SubQueryFilters {
 
     @Transient
@@ -19,6 +22,7 @@ class OffChainPendingMultisigInfoRequest(
              ${"accountId" equalTo accountIdKey.toHexWithPrefix() }
              ${"status" equalToEnum "pending"}
              ${"callHash" presentIn callHashesHex}
+             ${"chainId" equalTo chainId.requireHexPrefix()}
           }) {
             nodes {
               callHash

--- a/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/domain/utils/CustomChainFactory.kt
+++ b/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/domain/utils/CustomChainFactory.kt
@@ -129,6 +129,7 @@ class CustomChainFactory(
             hasSubstrateRuntime = hasSubstrateRuntime,
             pushSupport = prefilledChain?.pushSupport.orFalse(),
             hasCrowdloans = prefilledChain?.hasCrowdloans.orFalse(),
+            multisigSupport = prefilledChain?.multisigSupport.orFalse(),
             supportProxy = prefilledChain?.supportProxy.orFalse(),
             governance = prefilledChain?.governance.orEmpty(),
             swap = prefilledChain?.swap.orEmpty(),

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/DomainToLocalChainMapper.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/DomainToLocalChainMapper.kt
@@ -125,6 +125,7 @@ fun mapChainToLocal(chain: Chain, gson: Gson): ChainLocal {
         hasSubstrateRuntime = chain.hasSubstrateRuntime,
         pushSupport = chain.pushSupport,
         hasCrowdloans = chain.hasCrowdloans,
+        multisigSupport = chain.multisigSupport,
         supportProxy = chain.supportProxy,
         swap = mapSwapListToLocal(chain.swap),
         customFee = mapCustomFeeToLocal(chain.customFee),
@@ -194,7 +195,6 @@ fun mapChainExternalApiToLocal(gson: Gson, chainId: String, api: ExternalApi): C
         is ExternalApi.GovernanceReferenda -> mapExternalApiGovernanceReferenda(gson, chainId, api)
         is ExternalApi.Staking -> mapExternalApiStaking(chainId, api)
         is ExternalApi.ReferendumSummary -> mapExternalApiReferendumSummary(chainId, api)
-        is ExternalApi.Multisig -> mapExternalApiMultisig(chainId, api)
     }
 }
 
@@ -270,16 +270,6 @@ private fun mapExternalApiReferendumSummary(chainId: String, api: ExternalApi.Re
         chainId = chainId,
         sourceType = SourceType.UNKNOWN,
         apiType = ChainExternalApiLocal.ApiType.REFERENDUM_SUMMARY,
-        parameters = null,
-        url = api.url
-    )
-}
-
-private fun mapExternalApiMultisig(chainId: String, api: ExternalApi.Multisig): ChainExternalApiLocal {
-    return ChainExternalApiLocal(
-        chainId = chainId,
-        sourceType = SourceType.SUBSQUARE,
-        apiType = ChainExternalApiLocal.ApiType.MULTISIG,
         parameters = null,
         url = api.url
     )

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/LocalToDomainChainMapper.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/LocalToDomainChainMapper.kt
@@ -161,10 +161,6 @@ private fun mapExternalApiLocalToExternalApi(externalApiLocal: ChainExternalApiL
             ExternalApi.ReferendumSummary(externalApiLocal.url)
         }
 
-        ApiType.MULTISIG -> {
-            ExternalApi.Multisig(externalApiLocal.url)
-        }
-
         ApiType.UNKNOWN -> null
     }
 }.getOrNull()
@@ -271,6 +267,7 @@ fun mapChainLocalToChain(
             hasCrowdloans = hasCrowdloans,
             pushSupport = pushSupport,
             supportProxy = supportProxy,
+            multisigSupport = multisigSupport,
             hasSubstrateRuntime = hasSubstrateRuntime,
             governance = mapGovernanceListFromLocal(governance),
             swap = mapSwapListFromLocal(swap),

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
@@ -10,9 +10,9 @@ import io.novafoundation.nova.core_db.model.chain.ChainExternalApiLocal
 import io.novafoundation.nova.core_db.model.chain.ChainExternalApiLocal.ApiType
 import io.novafoundation.nova.core_db.model.chain.ChainExternalApiLocal.SourceType
 import io.novafoundation.nova.core_db.model.chain.ChainLocal
+import io.novafoundation.nova.core_db.model.chain.ChainLocal.AutoBalanceStrategyLocal
 import io.novafoundation.nova.core_db.model.chain.ChainLocal.Companion.EMPTY_CHAIN_ICON
 import io.novafoundation.nova.core_db.model.chain.ChainLocal.ConnectionStateLocal
-import io.novafoundation.nova.core_db.model.chain.ChainLocal.AutoBalanceStrategyLocal
 import io.novafoundation.nova.core_db.model.chain.ChainNodeLocal
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
@@ -23,6 +23,8 @@ private const val ETHEREUM_OPTION = "ethereumBased"
 private const val CROWDLOAN_OPTION = "crowdloans"
 private const val TESTNET_OPTION = "testnet"
 private const val PROXY_OPTION = "proxy"
+
+private const val MULTISIG_SUPPORT = "multisig"
 private const val SWAP_HUB = "swap-hub"
 private const val HYDRA_DX_SWAPS = "hydradx-swaps"
 private const val NO_SUBSTRATE_RUNTIME = "noSubstrateRuntime"
@@ -87,6 +89,7 @@ fun mapRemoteChainToLocal(
             isTestNet = TESTNET_OPTION in optionsOrEmpty,
             hasCrowdloans = CROWDLOAN_OPTION in optionsOrEmpty,
             supportProxy = PROXY_OPTION in optionsOrEmpty,
+            multisigSupport = MULTISIG_SUPPORT in optionsOrEmpty,
             hasSubstrateRuntime = NO_SUBSTRATE_RUNTIME !in optionsOrEmpty,
             pushSupport = PUSH_SUPPORT in optionsOrEmpty,
             governance = mapGovernanceRemoteOptionsToLocal(optionsOrEmpty),
@@ -215,7 +218,6 @@ private fun mapApiTypeRemoteToLocal(apiType: String): ApiType = when (apiType) {
     "governance" -> ApiType.GOVERNANCE_REFERENDA
     "governance-delegations" -> ApiType.GOVERNANCE_DELEGATIONS
     "referendum-summary" -> ApiType.REFERENDUM_SUMMARY
-    "multisig" -> ApiType.MULTISIG
     else -> ApiType.UNKNOWN
 }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
@@ -41,6 +41,7 @@ data class Chain(
     val governance: List<Governance>,
     val swap: List<Swap>,
     val customFee: List<CustomFee>,
+    val multisigSupport: Boolean,
     val connectionState: ConnectionState,
     val parentId: String?,
     val additional: Additional?
@@ -213,8 +214,6 @@ data class Chain(
         data class GovernanceDelegations(override val url: String) : ExternalApi()
 
         data class ReferendumSummary(override val url: String) : ExternalApi()
-
-        data class Multisig(override val url: String) : ExternalApi()
     }
 
     enum class Governance {


### PR DESCRIPTION
* Use multichain accounts api for multisig operations sync
* Remove support for multisig external api - migrate to multisig option to determine multisig support feature flag

Note that migration sets multisig flag to true for every multig api present in the db. This is to avoid "multisigs are disabled everywhere" state untill the next chain sync. Migration also cleans multisig apis at the end to avoid mapping issues (kotlin enum does not have multisig value anymore) 