### PR TITLE
Fix/snowbridge tokens ah

### DIFF
--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/multiLocation/MultiLocation.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/multiLocation/MultiLocation.kt
@@ -59,9 +59,9 @@ abstract class MultiLocation(
 
     sealed class NetworkId {
 
-        data class Substrate(val genesisHash: ChainId): NetworkId()
+        data class Substrate(val genesisHash: ChainId) : NetworkId()
 
-        data class Ethereum(val chainId: Int): NetworkId()
+        data class Ethereum(val chainId: Int) : NetworkId()
     }
 }
 

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/multiLocation/MultiLocationEncoding.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/multiLocation/MultiLocationEncoding.kt
@@ -168,7 +168,7 @@ private fun encodableGeneralKey(xcmVersion: XcmVersion, generalKey: HexString): 
 }
 
 private fun Junction.GlobalConsensus.toEncodableInstance(): Any {
-    val innerValue = when(networkId) {
+    val innerValue = when (networkId) {
         is NetworkId.Ethereum -> networkId.toEncodableInstance()
         is NetworkId.Substrate -> networkId.toEncodableInstance()
     }


### PR DESCRIPTION
Better support for GlobalConsensus junction and its NetworkId.Ethereum. This is used by snowbridge tokens to reference locations on ethereum
<img width="543" height="1091" alt="image" src="https://github.com/user-attachments/assets/1bb80276-3469-4039-84b3-994aa600046a" />
