### PR TITLE
Detect version for VersionedMultiAssetId separately

### DIFF
--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/common/TransferAssetUsingTypeTransactor.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/crosschain/common/TransferAssetUsingTypeTransactor.kt
@@ -49,9 +49,10 @@ class TransferAssetUsingTypeTransactor @Inject constructor(
         val multiAssetId = MultiAssetId(configuration.assetLocationOnOrigin())
 
         val multiLocationVersion = forceXcmVersion ?: xcmVersionDetector.lowestPresentMultiLocationVersion(transfer.originChain.id).orDefault()
-        val multiAssetVersion = forceXcmVersion ?: xcmVersionDetector.lowestPresentMultiAssetVersion(transfer.originChain.id).orDefault()
+        val multiAssetsVersion = forceXcmVersion ?: xcmVersionDetector.lowestPresentMultiAssetsVersion(transfer.originChain.id).orDefault()
+        val multiAssetIdVersion = forceXcmVersion ?: xcmVersionDetector.lowestPresentMultiAssetIdVersion(transfer.originChain.id).orDefault()
 
-        val transferTypeParam = configuration.transferTypeParam(multiAssetVersion)
+        val transferTypeParam = configuration.transferTypeParam(multiAssetsVersion)
 
         return chainRegistry.withRuntime(configuration.originChainId) {
             composeCall(
@@ -59,9 +60,9 @@ class TransferAssetUsingTypeTransactor @Inject constructor(
                 callName = "transfer_assets_using_type_and_then",
                 arguments = mapOf(
                     "dest" to configuration.destinationChainLocationOnOrigin().versionedXcm(multiLocationVersion).toEncodableInstance(),
-                    "assets" to MultiAssets(multiAsset).versionedXcm(multiAssetVersion).toEncodableInstance(),
+                    "assets" to MultiAssets(multiAsset).versionedXcm(multiAssetsVersion).toEncodableInstance(),
                     "assets_transfer_type" to transferTypeParam,
-                    "remote_fees_id" to multiAssetId.versionedXcm(multiAssetVersion).toEncodableInstance(),
+                    "remote_fees_id" to multiAssetId.versionedXcm(multiAssetIdVersion).toEncodableInstance(),
                     "fees_transfer_type" to transferTypeParam,
                     "custom_xcm_on_dest" to constructCustomXcmOnDest(configuration, transfer, multiLocationVersion).toEncodableInstance(),
                     "weight_limit" to WeightLimit.Unlimited.toEncodableInstance()

--- a/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/versions/detector/XcmVersionDetector.kt
+++ b/feature-xcm/api/src/main/java/io/novafoundation/nova/feature_xcm_api/versions/detector/XcmVersionDetector.kt
@@ -10,6 +10,8 @@ interface XcmVersionDetector {
 
     suspend fun lowestPresentMultiAssetsVersion(chainId: ChainId): XcmVersion?
 
+    suspend fun lowestPresentMultiAssetIdVersion(chainId: ChainId): XcmVersion?
+
     suspend fun lowestPresentMultiAssetVersion(chainId: ChainId): XcmVersion?
 
     suspend fun detectMultiLocationVersion(chainId: ChainId, multiLocationType: RuntimeType<*, *>?): XcmVersion?

--- a/feature-xcm/impl/src/main/java/io/novafoundation/nova/feature_xcm_impl/versions/detector/RealXcmVersionDetector.kt
+++ b/feature-xcm/impl/src/main/java/io/novafoundation/nova/feature_xcm_impl/versions/detector/RealXcmVersionDetector.kt
@@ -39,6 +39,14 @@ class RealXcmVersionDetector @Inject constructor(
         )
     }
 
+    override suspend fun lowestPresentMultiAssetIdVersion(chainId: ChainId): XcmVersion? {
+        return lowestPresentXcmTypeVersionFromCallArgument(
+            chainId = chainId,
+            getCall = { it.moduleOrNull(it.xcmPalletName())?.callOrNull("transfer_assets_using_type_and_then") },
+            argumentName = "remote_fees_id"
+        )
+    }
+
     override suspend fun lowestPresentMultiAssetVersion(chainId: ChainId): XcmVersion? {
         return lowestPresentMultiAssetsVersion(chainId)
     }


### PR DESCRIPTION
For some weird reason basilisk uses different min versions for VersionedMultiAssets and VersionedMultiAssetId:
<img width="614" height="300" alt="image" src="https://github.com/user-attachments/assets/22c97f6e-92de-4685-937b-dccf2c7a634c" />
So our assumption that both `assets` and `remote_fees_id` argument share the same version id breaks. Thus, we need to detect asset id version separately
<img width="543" height="1091" alt="image" src="https://github.com/user-attachments/assets/f8ae4664-ed3e-402a-8413-724964644d1e" />
