### PR TITLE
Replace deprecated set-output

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           VERSION=${{ github.head_ref }}
           VERSION=${VERSION/hotfix/rc} # Replace "hotfix" with "rc"
-          echo "::set-output name=version::${VERSION#*rc/}"
+          echo "version=${VERSION#*rc/}" >> $GITHUB_OUTPUT
 
       - uses: tibdex/github-app-token@v1
         id: generate-token


### PR DESCRIPTION
GitHub deprecated the `::set-output` command in favor of writing to `$GITHUB_OUTPUT` environment file. 