### PR TITLE
chore: correct spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ MOONPAY_PRODUCTION_SECRET=mock
 MOONPAY_TEST_SECRET=mock
 WALLET_CONNECT_PROJECT_ID=mock
 ```
-Note, that Firebase and Google related features (Notifications, Cloud Backups) wont work properly with this setup.
+Note, that Firebase and Google related features (Notifications, Cloud Backups) won't work properly with this setup.
 
 If you face `Secret X is not found` error, it means that README is not up-to-date. Add `X=mock` line to local.properties as well
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/yieldBoost/validations/CancelActiveTasksValidation.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/yieldBoost/validations/CancelActiveTasksValidation.kt
@@ -12,7 +12,7 @@ class CancelActiveTasksValidation : YieldBoostValidation {
 
     override suspend fun validate(value: YieldBoostValidationPayload): ValidationStatus<YieldBoostValidationFailure> {
         return when {
-            // there is no active yield boost tasks so we wont cancel anything
+            // there is no active yield boost tasks so we won't cancel anything
             value.activeTasks.isEmpty() -> valid()
 
             // cancel transactions are always OK

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/delegation/controller/set/SetControllerViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/delegation/controller/set/SetControllerViewModel.kt
@@ -105,7 +105,7 @@ class SetControllerViewModel(
             NORMAL -> usingWrongAccountToChangeController
 
             // when controllers are deprecated, there is no point to show the switch to stash warning if user has not separate controller
-            // switching to stash wont allow to change controller anyway
+            // switching to stash won't allow to change controller anyway
             DEPRECATED -> usingWrongAccountToChangeController && stakingState.hasSeparateController()
         }
     }
@@ -127,7 +127,7 @@ class SetControllerViewModel(
                 DescriptiveButtonState.Enabled(resourceManager.getString(R.string.staking_set_controller_deprecated_action))
             }
 
-            // User cant do anything beneficial when controllers are deprecated and user doesn't have controller set up
+            // User can't do anything beneficial when controllers are deprecated and user doesn't have controller set up
             controllerDeprecationStage == DEPRECATED && stakingState.hasSeparateController().not() -> {
                 DescriptiveButtonState.Gone
             }

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/Wegiths.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/sources/Wegiths.kt
@@ -12,7 +12,7 @@ object Weights {
             return if (path.isNotEmpty() && path.last() is HydraDxQuotableEdge) {
                 // We divide here by 10 to achieve two goals:
                 // 1. Divisor should be significant enough to allow multiple appended segments to be added without influencing total hydration weight much
-                // 2. On the other hand, divisor cannot be extremely large as we will loose precision and it wont be possible
+                // 2. On the other hand, divisor cannot be extremely large as we will lose precision and it won't be possible
                 // to distinguish different hydration segments weights between each other.
                 // That is also why OMNIPOOL, STABLESWAP and XYK differ by a multiple of ten
                 (baseWeight / 10)

--- a/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/v2/FeeContext.kt
+++ b/feature-wallet-api/src/main/java/io/novafoundation/nova/feature_wallet_api/presentation/mixin/fee/v2/FeeContext.kt
@@ -31,7 +31,7 @@ class FeeContext(
 
         /**
          * The specified [operationChainUtilityAsset] should be used as utility asset
-         * This mode is usefull when we cannot provide guarantees that a [FeeContext.operationAsset] is present in ChainRegistry
+         * This mode is useful when we cannot provide guarantees that a [FeeContext.operationAsset] is present in ChainRegistry
          *
          * This might be the case for some logic that construct [Chain.Asset] on the fly to use components such as [FeeLoaderMixinV2]
          * For example, Dapp Browser tx signing flow might do so for unknown EVM chains

--- a/feature-wallet-connect-impl/src/main/java/io/novafoundation/nova/feature_wallet_connect_impl/domain/session/requests/Base.kt
+++ b/feature-wallet-connect-impl/src/main/java/io/novafoundation/nova/feature_wallet_connect_impl/domain/session/requests/Base.kt
@@ -34,7 +34,7 @@ abstract class BaseWalletConnectRequest(
             Web3Wallet.respondSessionRequest(walletConnectResponse).getOrThrow()
 
             // TODO this code is untested since no dapp currently use redirect param
-            // We cant really enable this code without testing since we need to verify a corner-case when wc is used with redirect param inside dapp browser
+            // We can't really enable this code without testing since we need to verify a corner-case when wc is used with redirect param inside dapp browser
             // This might potentially break user flow since it might direct user to external browser instead of staying in our dapp browser
 
 //            val redirect = sessionRequest.peerMetaData?.redirect

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/realtime/substrate/AssetConversionSwapExtractor.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/realtime/substrate/AssetConversionSwapExtractor.kt
@@ -65,7 +65,7 @@ class AssetConversionSwapExtractor(
         val allSwaps = events.findEvents(Modules.ASSET_CONVERSION, "SwapExecuted")
 
         val swapExecutedEvent = when {
-            !success -> null // we wont be able to extract swap from event
+            !success -> null // we won't be able to extract swap from event
 
             isCustomFeeTokenUsed -> {
                 // Swaps with custom fee token produce up to free SwapExecuted events, in the following order:


### PR DESCRIPTION
Fixed some spelling mistakes in comments and documentation:
wont → won't (multiple files)
cant → can't
loose → lose
usefull → useful

