### PR TITLE
Added localised string resource for Learn more on the Gifts screen

### DIFF
--- a/feature-gift-impl/src/main/res/layout/item_gifts_header.xml
+++ b/feature-gift-impl/src/main/res/layout/item_gifts_header.xml
@@ -27,6 +27,6 @@
         android:layout_marginTop="4dp"
         android:minHeight="32dp"
         android:paddingVertical="8dp"
-        app:linkText="Learn more" /> <!--Hide until we have a special wiki page for gifts-->
+        app:linkText="@string/common_learn_more" />
 
 </LinearLayout>


### PR DESCRIPTION
Added localised string resource for Learn more button on the Gifts screen

<img width="649" height="1280" alt="image" src="https://github.com/user-attachments/assets/b249732c-79eb-41a1-b6cb-4d53b1f156de" />

<img width="649" height="1280" alt="image" src="https://github.com/user-attachments/assets/a88a7204-14d4-4741-9623-f422343cbbb3" />
