### PR TITLE
Fix default value of Toolbar right action visibility to be backward compatible

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/view/Toolbar.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/view/Toolbar.kt
@@ -56,7 +56,7 @@ class Toolbar @JvmOverloads constructor(
             val action = typedArray.getString(R.styleable.Toolbar_textRight)
             action?.let { setTextRight(it) }
 
-            val textRightVisible = typedArray.getBoolean(R.styleable.Toolbar_textRightVisible, false)
+            val textRightVisible = typedArray.getBoolean(R.styleable.Toolbar_textRightVisible, true)
             setRightTextVisible(textRightVisible)
 
             val homeButtonIcon = typedArray.getDrawable(R.styleable.Toolbar_homeButtonIcon)


### PR DESCRIPTION
<img width="543" height="1091" alt="image" src="https://github.com/user-attachments/assets/ac2fad43-8baa-4c63-9777-76a73ed024c5" />
<img width="543" height="1091" alt="image" src="https://github.com/user-attachments/assets/b18c1771-8f7c-4e42-a342-11512196a4a7" />
