### PR TITLE
Force Nova pool for Asset Hub and lock Novasama validators in selection

### DIFF
--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/nominationPools/pool/KnownNovaPools.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/nominationPools/pool/KnownNovaPools.kt
@@ -1,9 +1,15 @@
 package io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool
 
 import io.novafoundation.nova.feature_staking_api.domain.nominationPool.model.PoolId
+import io.novafoundation.nova.runtime.ext.ChainGeneses
 import io.novafoundation.nova.runtime.ext.Geneses
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+
+val FORCED_NOVA_POOL_CHAIN_IDS = setOf(
+    ChainGeneses.POLKADOT_ASSET_HUB,
+    ChainGeneses.KUSAMA_ASSET_HUB
+)
 
 interface KnownNovaPools {
 
@@ -11,6 +17,9 @@ interface KnownNovaPools {
 }
 
 fun KnownNovaPools.isNovaPool(chainId: ChainId, poolId: PoolId) = chainId to poolId in novaPoolIds
+
+fun KnownNovaPools.novaPoolIdForChain(chainId: ChainId): PoolId? =
+    novaPoolIds.firstOrNull { it.first == chainId }?.second
 
 class FixedKnownNovaPools : KnownNovaPools {
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/nominationPools/pool/KnownNovaPools.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/nominationPools/pool/KnownNovaPools.kt
@@ -1,19 +1,15 @@
 package io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool
 
 import io.novafoundation.nova.feature_staking_api.domain.nominationPool.model.PoolId
-import io.novafoundation.nova.runtime.ext.ChainGeneses
 import io.novafoundation.nova.runtime.ext.Geneses
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 
-val FORCED_NOVA_POOL_CHAIN_IDS = setOf(
-    ChainGeneses.POLKADOT_ASSET_HUB,
-    ChainGeneses.KUSAMA_ASSET_HUB
-)
-
 interface KnownNovaPools {
 
     val novaPoolIds: Set<Pair<ChainId, PoolId>>
+
+    val forcedPoolChainIds: Set<ChainId>
 }
 
 fun KnownNovaPools.isNovaPool(chainId: ChainId, poolId: PoolId) = chainId to poolId in novaPoolIds
@@ -29,6 +25,11 @@ class FixedKnownNovaPools : KnownNovaPools {
         key(Chain.Geneses.ALEPH_ZERO, 74),
         key(Chain.Geneses.VARA, 65),
         key(Chain.Geneses.AVAIL, 3)
+    )
+
+    override val forcedPoolChainIds: Set<ChainId> = setOf(
+        Chain.Geneses.POLKADOT_ASSET_HUB,
+        Chain.Geneses.KUSAMA_ASSET_HUB
     )
 
     private fun key(chainId: ChainId, poolId: Int) = chainId to PoolId(poolId)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/recommendations/ValidatorRecommender.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/recommendations/ValidatorRecommender.kt
@@ -38,7 +38,7 @@ class ValidatorRecommender(
 
         val cappedOthers = others.take(limit - cappedNovaValidators.size)
 
-        return (cappedNovaValidators + cappedOthers).sortedWith(sorting)
+        return cappedOthers.sortedWith(sorting) + cappedNovaValidators.sortedWith(sorting)
     }
 
     private fun List<Validator>.applyFiltersAdaptingToEmptyResult(filters: List<RecommendationFilter>): List<Validator> {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/mappers/Validator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/mappers/Validator.kt
@@ -85,6 +85,7 @@ suspend fun mapValidatorToValidatorModel(
             addressModel = addressModel,
             scoring = scoring,
             isChecked = isChecked,
+            isLocked = isNovaValidator,
             stakeTarget = validator,
             subtitle = null // TODO relaychain subtitles
         )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/EditableStakingTypeItemFormatter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/EditableStakingTypeItemFormatter.kt
@@ -12,8 +12,10 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.se
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.formatAmountToAmountModel
+import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.FORCED_NOVA_POOL_CHAIN_IDS
 import io.novafoundation.nova.runtime.ext.isDirectStaking
 import io.novafoundation.nova.runtime.ext.isPoolStaking
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 
 class EditableStakingTypeItemFormatter(
     private val resourceManager: ResourceManager,
@@ -24,7 +26,8 @@ class EditableStakingTypeItemFormatter(
     suspend fun format(
         asset: Asset,
         validatedStakingType: ValidatedStakingTypeDetails,
-        selection: RecommendableMultiStakingSelection
+        selection: RecommendableMultiStakingSelection,
+        chainId: ChainId
     ): EditableStakingTypeRVItem? {
         val stakingTarget = multiStakingTargetSelectionFormatter.formatForStakingType(selection)
         val selectedStakingType = selection.selection.stakingOption.stakingType
@@ -37,14 +40,17 @@ class EditableStakingTypeItemFormatter(
         }
 
         val isSelected = selectedStakingType == stakingType
+        val isPoolForced = stakingType.isPoolStaking() && chainId in FORCED_NOVA_POOL_CHAIN_IDS
+        val isEditable = !isPoolForced
 
         return EditableStakingTypeRVItem(
             isSelected = isSelected,
             isSelectable = validatedStakingType.isAvailable || isSelected,
+            isEditable = isEditable,
             title = resourceManager.getString(titleRes),
             imageRes = imageRes,
             conditions = mapConditions(asset, validatedStakingType.stakingTypeDetails),
-            stakingTarget = stakingTarget.takeIf { selectedStakingType == stakingType }
+            stakingTarget = if (isPoolForced) null else stakingTarget.takeIf { selectedStakingType == stakingType }
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/EditableStakingTypeItemFormatter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/EditableStakingTypeItemFormatter.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.staking.start.s
 
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.KnownNovaPools
 import io.novafoundation.nova.feature_staking_impl.data.stakingType
 import io.novafoundation.nova.feature_staking_impl.domain.model.PayoutType
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.selection.RecommendableMultiStakingSelection
@@ -12,7 +13,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.se
 import io.novafoundation.nova.feature_wallet_api.domain.model.Asset
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.formatAmountToAmountModel
-import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.FORCED_NOVA_POOL_CHAIN_IDS
 import io.novafoundation.nova.runtime.ext.isDirectStaking
 import io.novafoundation.nova.runtime.ext.isPoolStaking
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
@@ -20,7 +20,8 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 class EditableStakingTypeItemFormatter(
     private val resourceManager: ResourceManager,
     private val multiStakingTargetSelectionFormatter: MultiStakingTargetSelectionFormatter,
-    private val amountFormatter: AmountFormatter
+    private val amountFormatter: AmountFormatter,
+    private val knownNovaPools: KnownNovaPools,
 ) {
 
     suspend fun format(
@@ -40,7 +41,7 @@ class EditableStakingTypeItemFormatter(
         }
 
         val isSelected = selectedStakingType == stakingType
-        val isPoolForced = stakingType.isPoolStaking() && chainId in FORCED_NOVA_POOL_CHAIN_IDS
+        val isPoolForced = stakingType.isPoolStaking() && chainId in knownNovaPools.forcedPoolChainIds
         val isEditable = !isPoolForced
 
         return EditableStakingTypeRVItem(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeFlowExecutor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeFlowExecutor.kt
@@ -1,12 +1,15 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.staking.start.setupStakingType
 
 import io.novafoundation.nova.common.utils.orZero
+import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.KnownNovaPools
+import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.novaPoolIdForChain
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.selection.store.StartMultiStakingSelectionStoreProvider
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.selection.store.getValidatorsOrEmpty
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.common.SetupStakingProcess
 import io.novafoundation.nova.feature_staking_impl.presentation.common.SetupStakingSharedState
 import io.novafoundation.nova.feature_staking_impl.presentation.pools.common.SelectingPoolPayload
+import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.FORCED_NOVA_POOL_CHAIN_IDS
 import io.novafoundation.nova.runtime.ext.isDirectStaking
 import io.novafoundation.nova.runtime.ext.isPoolStaking
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -17,6 +20,7 @@ class SetupStakingTypeFlowExecutorFactory(
     private val router: StakingRouter,
     private val setupStakingSharedState: SetupStakingSharedState,
     private val editableSelectionStoreProvider: StartMultiStakingSelectionStoreProvider,
+    private val knownNovaPools: KnownNovaPools,
 ) {
 
     fun create(chainId: ChainId, assetId: Int, stakingType: Chain.Asset.StakingType): SetupStakingTypeFlowExecutor {
@@ -31,7 +35,8 @@ class SetupStakingTypeFlowExecutorFactory(
                 router,
                 chainId,
                 assetId,
-                stakingType
+                stakingType,
+                knownNovaPools
             )
 
             else -> throw IllegalArgumentException("Unsupported staking type: $stakingType")
@@ -68,10 +73,21 @@ class SetupPoolStakingFlowExecutor(
     private val router: StakingRouter,
     private val chainId: ChainId,
     private val assetId: Int,
-    private val stakingType: Chain.Asset.StakingType
+    private val stakingType: Chain.Asset.StakingType,
+    private val knownNovaPools: KnownNovaPools,
 ) : SetupStakingTypeFlowExecutor {
 
     override suspend fun execute(coroutineScope: CoroutineScope) {
+        val novaPoolId = knownNovaPools.novaPoolIdForChain(chainId)
+
+        // For forced Nova pool chains, the automatic recommendation already selects the Nova pool.
+        // Do nothing here to preserve the Automatic selection source, which keeps
+        // the "Recommended" label on the amount screen instead of switching to a Manual selection
+        // that would display the specific pool name.
+        if (chainId in FORCED_NOVA_POOL_CHAIN_IDS && novaPoolId != null) {
+            return
+        }
+
         val selectingPoolPayload = SelectingPoolPayload(
             chainId,
             assetId,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeFlowExecutor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeFlowExecutor.kt
@@ -9,7 +9,6 @@ import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.common.SetupStakingProcess
 import io.novafoundation.nova.feature_staking_impl.presentation.common.SetupStakingSharedState
 import io.novafoundation.nova.feature_staking_impl.presentation.pools.common.SelectingPoolPayload
-import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.FORCED_NOVA_POOL_CHAIN_IDS
 import io.novafoundation.nova.runtime.ext.isDirectStaking
 import io.novafoundation.nova.runtime.ext.isPoolStaking
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -84,7 +83,7 @@ class SetupPoolStakingFlowExecutor(
         // Do nothing here to preserve the Automatic selection source, which keeps
         // the "Recommended" label on the amount screen instead of switching to a Manual selection
         // that would display the specific pool name.
-        if (chainId in FORCED_NOVA_POOL_CHAIN_IDS && novaPoolId != null) {
+        if (chainId in knownNovaPools.forcedPoolChainIds && novaPoolId != null) {
             return
         }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeViewModel.kt
@@ -172,6 +172,7 @@ class SetupStakingTypeViewModel(
             val stakingType = stakingTypesDataFlow.first()[position]
                 .stakingTypeDetails
                 .stakingType
+
             val setupStakingTypeFlowExecutor = setupStakingTypeFlowExecutorFactory.create(
                 payload.availableStakingOptions.chainId,
                 payload.availableStakingOptions.assetId,
@@ -194,8 +195,9 @@ class SetupStakingTypeViewModel(
         stakingTypesDetails: List<ValidatedStakingTypeDetails>,
         selection: RecommendableMultiStakingSelection
     ): List<EditableStakingTypeRVItem> {
+        val chainId = payload.availableStakingOptions.chainId
         return stakingTypesDetails.mapNotNull {
-            editableStakingTypeItemFormatter.format(asset, it, selection)
+            editableStakingTypeItemFormatter.format(asset, it, selection, chainId)
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/adapter/EditableStakingTypeRVItem.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/adapter/EditableStakingTypeRVItem.kt
@@ -6,6 +6,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.view.stakingTarg
 class EditableStakingTypeRVItem(
     val isSelected: Boolean,
     val isSelectable: Boolean,
+    val isEditable: Boolean,
     val title: String,
     @DrawableRes val imageRes: Int,
     val conditions: List<String>,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/adapter/SetupStakingTypeAdapter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/adapter/SetupStakingTypeAdapter.kt
@@ -37,6 +37,7 @@ class SetupStakingTypeAdapter(
                 EditableStakingTypeRVItem::conditions -> holder.setConditions(item)
                 EditableStakingTypeRVItem::isSelected -> holder.select(item)
                 EditableStakingTypeRVItem::isSelectable -> holder.setSelectable(item)
+                EditableStakingTypeRVItem::isEditable -> holder.setEditable(item)
                 EditableStakingTypeRVItem::stakingTarget -> holder.setStakingTarget(item)
                 EditableStakingTypeRVItem::imageRes -> holder.setImage(item)
             }
@@ -69,6 +70,7 @@ class EditableStakingTypeViewHolder(
         setConditions(item)
         select(item)
         setSelectable(item)
+        setEditable(item)
         setStakingTarget(item)
         setImage(item)
 
@@ -97,6 +99,10 @@ class EditableStakingTypeViewHolder(
         binder.editableStakingType.setSelectable(item.isSelectable)
     }
 
+    fun setEditable(item: EditableStakingTypeRVItem) {
+        binder.editableStakingType.setStakingTargetEditable(item.isEditable)
+    }
+
     fun setStakingTarget(item: EditableStakingTypeRVItem) {
         binder.editableStakingType.setStakingTarget(item.stakingTarget)
     }
@@ -111,6 +117,7 @@ private object SetupStakingTypePayloadGenerator : PayloadGenerator<EditableStaki
     EditableStakingTypeRVItem::conditions,
     EditableStakingTypeRVItem::isSelected,
     EditableStakingTypeRVItem::isSelectable,
+    EditableStakingTypeRVItem::isEditable,
     EditableStakingTypeRVItem::stakingTarget,
     EditableStakingTypeRVItem::imageRes
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/di/SetupStakingTypeModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/di/SetupStakingTypeModule.kt
@@ -13,6 +13,7 @@ import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.validation.ValidationExecutor
 import io.novafoundation.nova.feature_staking_impl.di.staking.startMultiStaking.MultiStakingSelectionStoreProviderKey
 import io.novafoundation.nova.feature_staking_impl.di.staking.startMultiStaking.StakingTypeEditingStoreProviderKey
+import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.KnownNovaPools
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.selection.store.StartMultiStakingSelectionStoreProvider
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.CompoundStakingTypeDetailsProvidersFactory
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.SetupStakingTypeSelectionMixinFactory
@@ -34,12 +35,14 @@ class SetupStakingTypeModule {
     fun provideSetupStakingTypeFlowExecutorFactory(
         stakingRouter: StakingRouter,
         setupStakingSharedState: SetupStakingSharedState,
-        @StakingTypeEditingStoreProviderKey editableSelectionStoreProvider: StartMultiStakingSelectionStoreProvider
+        @StakingTypeEditingStoreProviderKey editableSelectionStoreProvider: StartMultiStakingSelectionStoreProvider,
+        knownNovaPools: KnownNovaPools,
     ): SetupStakingTypeFlowExecutorFactory {
         return SetupStakingTypeFlowExecutorFactory(
             stakingRouter,
             setupStakingSharedState,
-            editableSelectionStoreProvider
+            editableSelectionStoreProvider,
+            knownNovaPools
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/di/SetupStakingTypeModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/di/SetupStakingTypeModule.kt
@@ -11,9 +11,9 @@ import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.validation.ValidationExecutor
+import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.KnownNovaPools
 import io.novafoundation.nova.feature_staking_impl.di.staking.startMultiStaking.MultiStakingSelectionStoreProviderKey
 import io.novafoundation.nova.feature_staking_impl.di.staking.startMultiStaking.StakingTypeEditingStoreProviderKey
-import io.novafoundation.nova.feature_staking_impl.data.nominationPools.pool.KnownNovaPools
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.selection.store.StartMultiStakingSelectionStoreProvider
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.types.CompoundStakingTypeDetailsProvidersFactory
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.setupStakingType.SetupStakingTypeSelectionMixinFactory
@@ -50,12 +50,14 @@ class SetupStakingTypeModule {
     fun provideEditableStakingTypeItemFormatter(
         resourceManager: ResourceManager,
         multiStakingTargetSelectionFormatter: MultiStakingTargetSelectionFormatter,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        knownNovaPools: KnownNovaPools,
     ): EditableStakingTypeItemFormatter {
         return EditableStakingTypeItemFormatter(
             resourceManager,
             multiStakingTargetSelectionFormatter,
-            amountFormatter = amountFormatter
+            amountFormatter = amountFormatter,
+            knownNovaPools = knownNovaPools
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/StakeTargetAdapter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/StakeTargetAdapter.kt
@@ -103,12 +103,19 @@ class StakingTargetViewHolder<V>(private val binder: ItemValidatorBinding) : Rec
         StakeTargetModel: StakeTargetModel<V>,
         handler: StakeTargetAdapter.ItemHandler<V>
     ) = with(binder) {
+        root.isEnabled = true
+        root.isClickable = true
+
         when {
             mode == StakeTargetAdapter.Mode.EDIT -> {
-                itemStakingTargetActionIcon.makeVisible()
                 itemStakingTargetCheck.makeGone()
 
-                itemStakingTargetActionIcon.setOnClickListener { handler.removeClicked(StakeTargetModel) }
+                if (StakeTargetModel.isLocked) {
+                    itemStakingTargetActionIcon.makeGone()
+                } else {
+                    itemStakingTargetActionIcon.makeVisible()
+                    itemStakingTargetActionIcon.setOnClickListener { handler.removeClicked(StakeTargetModel) }
+                }
             }
 
             StakeTargetModel.isChecked == null -> {
@@ -121,6 +128,10 @@ class StakingTargetViewHolder<V>(private val binder: ItemValidatorBinding) : Rec
                 itemStakingTargetCheck.makeVisible()
 
                 itemStakingTargetCheck.isChecked = StakeTargetModel.isChecked
+                itemStakingTargetCheck.isEnabled = !StakeTargetModel.isLocked
+                itemStakingTargetCheck.alpha = if (StakeTargetModel.isLocked) 0.3f else 1.0f
+                root.isEnabled = !StakeTargetModel.isLocked
+                root.isClickable = !StakeTargetModel.isLocked
             }
         }
     }
@@ -172,7 +183,7 @@ class StakingTargetDiffCallback<V> : DiffUtil.ItemCallback<StakeTargetModel<V>>(
     }
 
     override fun areContentsTheSame(oldItem: StakeTargetModel<V>, newItem: StakeTargetModel<V>): Boolean {
-        return oldItem.scoring == newItem.scoring && oldItem.isChecked == newItem.isChecked && oldItem.subtitle == newItem.subtitle
+        return oldItem.scoring == newItem.scoring && oldItem.isChecked == newItem.isChecked && oldItem.subtitle == newItem.subtitle && oldItem.isLocked == newItem.isLocked
     }
 
     override fun getChangePayload(oldItem: StakeTargetModel<V>, newItem: StakeTargetModel<V>): Any? {
@@ -183,5 +194,6 @@ class StakingTargetDiffCallback<V> : DiffUtil.ItemCallback<StakeTargetModel<V>>(
 private object StakingTargetPayloadGenerator : PayloadGenerator<StakeTargetModel<*>>(
     StakeTargetModel<*>::isChecked,
     StakeTargetModel<*>::scoring,
-    StakeTargetModel<*>::subtitle
+    StakeTargetModel<*>::subtitle,
+    StakeTargetModel<*>::isLocked
 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/ValidatorModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/ValidatorModel.kt
@@ -13,6 +13,7 @@ data class StakeTargetModel<V>(
     val subtitle: Subtitle?,
     val addressModel: AddressModel,
     val isChecked: Boolean?,
+    val isLocked: Boolean = false,
     val stakeTarget: V,
 ) {
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/review/ReviewCustomValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/review/ReviewCustomValidatorsViewModel.kt
@@ -89,6 +89,8 @@ class ReviewCustomValidatorsViewModel(
     val isInEditMode = MutableStateFlow(false)
 
     fun deleteClicked(validatorModel: ValidatorStakeTargetModel) {
+        if (validatorModel.isLocked) return
+
         launch {
             val validators = selectedValidators.first()
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/search/SearchCustomValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/search/SearchCustomValidatorsViewModel.kt
@@ -90,6 +90,8 @@ class SearchCustomValidatorsViewModel(
     }
 
     override fun itemClicked(item: ValidatorStakeTargetModel) {
+        if (item.isLocked) return
+
         if (item.stakeTarget.prefs!!.blocked) {
             showError(resourceManager.getString(R.string.staking_custom_blocked_warning))
             return

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/select/SelectCustomValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/select/SelectCustomValidatorsViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlin.math.max
 import kotlinx.coroutines.launch
 
 class SelectCustomValidatorsViewModel(
@@ -114,16 +115,19 @@ class SelectCustomValidatorsViewModel(
 
     val buttonState = selectedValidators.map {
         val maxSelectedValidators = maxSelectedValidatorsFlow.first()
+        val lockedCount = it.count { item -> item.value.isNovaValidator }
+        val availableSlots = maxSelectedValidators - lockedCount
+        val communitySelected = it.size - lockedCount
 
-        if (it.isEmpty()) {
+        if (communitySelected == 0 && lockedCount == 0) {
             ContinueButtonState(
                 enabled = false,
-                text = resourceManager.getString(R.string.staking_custom_proceed_button_disabled_title, maxSelectedValidators)
+                text = resourceManager.getString(R.string.staking_custom_proceed_button_disabled_title, availableSlots)
             )
         } else {
             ContinueButtonState(
                 enabled = true,
-                text = resourceManager.getString(R.string.staking_custom_proceed_button_enabled_title, it.size, maxSelectedValidators)
+                text = resourceManager.getString(R.string.staking_custom_proceed_button_enabled_title, max(communitySelected, 0), availableSlots)
             )
         }
     }
@@ -144,7 +148,9 @@ class SelectCustomValidatorsViewModel(
     val clearFiltersEnabled = recommendationSettingsFlow.map { it.customEnabledFilters.isNotEmpty() || it.postProcessors.isNotEmpty() }
         .share()
 
-    val deselectAllEnabled = selectedValidators.map { it.isNotEmpty() }
+    val deselectAllEnabled = selectedValidators.map { selected ->
+        selected.any { !it.value.isNovaValidator }
+    }
         .share()
 
     init {
@@ -171,6 +177,8 @@ class SelectCustomValidatorsViewModel(
     }
 
     fun validatorClicked(validatorModel: ValidatorStakeTargetModel) {
+        if (validatorModel.isLocked) return
+
         mutateSelected {
             it.toggle(validatorModel.stakeTarget.asSetItem())
         }
@@ -203,7 +211,9 @@ class SelectCustomValidatorsViewModel(
     }
 
     fun deselectAll() {
-        mutateSelected { emptySet() }
+        mutateSelected { selected ->
+            selected.filter { it.value.isNovaValidator }.toSet()
+        }
     }
 
     fun fillRestWithRecommended() {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/view/stakingTarget/StakingTargetView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/view/stakingTarget/StakingTargetView.kt
@@ -46,6 +46,14 @@ class StakingTargetView @JvmOverloads constructor(
         makeGoneViews(binder.stakingTargetTitle, binder.stakingTargetSubtitle, binder.stakingTargetQuantity, binder.stakingTargetIcon)
     }
 
+    fun setChevronVisible(visible: Boolean) {
+        if (visible) {
+            binder.stakingTargetChevron.makeVisible()
+        } else {
+            binder.stakingTargetChevron.makeGone()
+        }
+    }
+
     fun setModel(stakingTargetModel: StakingTargetModel) {
         binder.stakingTargetTitle.text = stakingTargetModel.title
         binder.stakingTargetTitle.makeVisible()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/view/stakingType/StakingTypeView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/view/stakingType/StakingTypeView.kt
@@ -78,6 +78,10 @@ class StakingTypeView @JvmOverloads constructor(
         binder.stakingTypeTarget.setModel(stakingTarget)
     }
 
+    fun setStakingTargetEditable(editable: Boolean) {
+        binder.stakingTypeTarget.setChevronVisible(editable)
+    }
+
     fun setStakingTargetClickListener(listener: OnClickListener) {
         binder.stakingTypeTarget.setOnClickListener(listener)
     }


### PR DESCRIPTION
- Bypass pool selection screen for Polkadot/Kusama Asset Hub chains; recommendation system selects Nova pool and user cannot change it
- Pool name hidden on staking type screen; "Recommended" label persists
- Preferred (Nova) validators locked at bottom of custom validator list with greyed-out checkboxes; cannot be deselected via tap, search, edit-mode delete, or "Deselect All"
- Selection count reflects community-only available slots