### PR TITLE
Add wallet search and favourites to wallet lists

### DIFF
--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -2039,4 +2039,7 @@
     <string name="yield_boost_stake_increase_time">Tiempo de aumento de stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost apostará automáticamente %s todos mis tokens transferibles por encima de %s</string>
     <string name="yiled_boost_yield_boosted">Con Yield Boost</string>
+    <string name="favourites_section_header">★ Favoritos</string>
+    <string name="wallets_section_header">Billeteras</string>
+    <string name="search_wallets_placeholder">Buscar billeteras…</string>
 </resources>

--- a/common/src/main/res/values-fr-rFR/strings.xml
+++ b/common/src/main/res/values-fr-rFR/strings.xml
@@ -2039,4 +2039,7 @@
     <string name="yield_boost_stake_increase_time">La mise augmente avec le temps</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost misera automatiquement %s tous mes actifs transférables au-dessus de %s</string>
     <string name="yiled_boost_yield_boosted">Rendement boosté</string>
+    <string name="favourites_section_header">★ Favoris</string>
+    <string name="wallets_section_header">Portefeuilles</string>
+    <string name="search_wallets_placeholder">Rechercher des portefeuilles…</string>
 </resources>

--- a/common/src/main/res/values-hu/strings.xml
+++ b/common/src/main/res/values-hu/strings.xml
@@ -2039,4 +2039,7 @@
     <string name="yield_boost_stake_increase_time">Stake növekedési idő</string>
     <string name="yield_boost_terms" formatted="false">A  Yield Boost %s automatikusan stake-elni fogja a %s feletti utalható tokeneket</string>
     <string name="yiled_boost_yield_boosted">Yield Boost-olt</string>
+    <string name="favourites_section_header">★ Kedvencek</string>
+    <string name="wallets_section_header">Tárcák</string>
+    <string name="search_wallets_placeholder">Tárcák keresése…</string>
 </resources>

--- a/common/src/main/res/values-in/strings.xml
+++ b/common/src/main/res/values-in/strings.xml
@@ -2025,4 +2025,7 @@
     <string name="yield_boost_stake_increase_time">Waktu peningkatan staking</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost akan secara otomatis melakukan staking %s semua token yang dapat ditransfer di atas %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="favourites_section_header">★ Favorit</string>
+    <string name="wallets_section_header">Dompet</string>
+    <string name="search_wallets_placeholder">Cari dompet…</string>
 </resources>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -2039,4 +2039,7 @@
     <string name="yield_boost_stake_increase_time">Tempo di aumento dello stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost stakerà automaticamente %s tutti i miei token trasferibili oltre %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="favourites_section_header">★ Preferiti</string>
+    <string name="wallets_section_header">Portafogli</string>
+    <string name="search_wallets_placeholder">Cerca portafogli…</string>
 </resources>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -2025,4 +2025,7 @@
     <string name="yield_boost_stake_increase_time">Stake増加時間</string>
     <string name="yield_boost_terms" formatted="false">Yield Boostは自動的に%s私の全ての譲渡可能なトークンを%s以上ステークします</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="favourites_section_header">★ お気に入り</string>
+    <string name="wallets_section_header">ウォレット</string>
+    <string name="search_wallets_placeholder">ウォレットを検索…</string>
 </resources>

--- a/common/src/main/res/values-ko/strings.xml
+++ b/common/src/main/res/values-ko/strings.xml
@@ -2025,4 +2025,7 @@
     <string name="yield_boost_stake_increase_time">Stake 증가 시간</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost가 %s 모든 양도 가능한 토큰을 %s 이상 자동으로 Stake 합니다</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="favourites_section_header">★ 즐겨찾기</string>
+    <string name="wallets_section_header">지갑</string>
+    <string name="search_wallets_placeholder">지갑 검색…</string>
 </resources>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -2067,4 +2067,7 @@
     <string name="yield_boost_stake_increase_time">Czas zwiększenia Stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost automatycznie Stake %s wszystkie moje przenośne tokeny powyżej %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="favourites_section_header">★ Ulubione</string>
+    <string name="wallets_section_header">Portfele</string>
+    <string name="search_wallets_placeholder">Szukaj portfeli…</string>
 </resources>

--- a/common/src/main/res/values-pt/strings.xml
+++ b/common/src/main/res/values-pt/strings.xml
@@ -2039,4 +2039,7 @@
     <string name="yield_boost_stake_increase_time">Tempo de aumento de stake</string>
     <string name="yield_boost_terms" formatted="false">O Impulso de Rendimento irá automaticamente fazer o stake de %s de todos os meus tokens transferíveis acima de %s</string>
     <string name="yiled_boost_yield_boosted">Com Impulso de Rendimento</string>
+    <string name="favourites_section_header">★ Favoritos</string>
+    <string name="wallets_section_header">Carteiras</string>
+    <string name="search_wallets_placeholder">Pesquisar carteiras…</string>
 </resources>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -2067,4 +2067,7 @@
     <string name="yield_boost_stake_increase_time">Частота увеличения стейка</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost будет автоматически стейкать %s все мои переводные токены выше %s</string>
     <string name="yiled_boost_yield_boosted">С Yield Boost</string>
+    <string name="favourites_section_header">★ Избранное</string>
+    <string name="wallets_section_header">Кошельки</string>
+    <string name="search_wallets_placeholder">Поиск кошельков…</string>
 </resources>

--- a/common/src/main/res/values-tr/strings.xml
+++ b/common/src/main/res/values-tr/strings.xml
@@ -2039,4 +2039,7 @@
     <string name="yield_boost_stake_increase_time">Bahis artış süresi</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost, %s tüm transfer edilebilir tokenlerimi otomatik olarak %s üzerinde stake edecek</string>
     <string name="yiled_boost_yield_boosted">Yield Boost\'lu</string>
+    <string name="favourites_section_header">★ Favoriler</string>
+    <string name="wallets_section_header">Cüzdanlar</string>
+    <string name="search_wallets_placeholder">Cüzdan ara…</string>
 </resources>

--- a/common/src/main/res/values-vi/strings.xml
+++ b/common/src/main/res/values-vi/strings.xml
@@ -2025,4 +2025,7 @@
     <string name="yield_boost_stake_increase_time">Thời gian tăng Stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost sẽ tự động stake %s tất cả token có thể chuyển được của tôi trên %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="favourites_section_header">★ Yêu thích</string>
+    <string name="wallets_section_header">Ví</string>
+    <string name="search_wallets_placeholder">Tìm kiếm ví…</string>
 </resources>

--- a/common/src/main/res/values-zh-rCN/strings.xml
+++ b/common/src/main/res/values-zh-rCN/strings.xml
@@ -2025,4 +2025,7 @@
     <string name="yield_boost_stake_increase_time">加注时间</string>
     <string name="yield_boost_terms" formatted="false">收益增强将自动加注我所有可转让代币中超过%s的%s</string>
     <string name="yiled_boost_yield_boosted">已增强收益</string>
+    <string name="favourites_section_header">★ 收藏</string>
+    <string name="wallets_section_header">钱包</string>
+    <string name="search_wallets_placeholder">搜索钱包…</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -223,6 +223,10 @@
 
     <string name="account_proxieds">Delegated to you (Proxied)</string>
 
+    <string name="favourites_section_header">★ Favourites</string>
+    <string name="wallets_section_header">Wallets</string>
+    <string name="search_wallets_placeholder">Search wallets…</string>
+
     <string name="multisig_signing_reject_confirmation_subtitle">Transaction will be rejected. Multisig deposit will be returned to %s.</string>
 
     <string name="common_full_details">Full details</string>

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/AppDatabase.kt
@@ -69,6 +69,7 @@ import io.novafoundation.nova.core_db.migrations.AddFavoriteDAppsOrdering_65_66
 import io.novafoundation.nova.core_db.migrations.AddFavouriteDApps_9_10
 import io.novafoundation.nova.core_db.migrations.AddFungibleNfts_55_56
 import io.novafoundation.nova.core_db.migrations.AddGifts_71_72
+import io.novafoundation.nova.core_db.migrations.AddWalletFavourites_73_74
 import io.novafoundation.nova.core_db.migrations.AddGloballyUniqueIdToMetaAccounts_58_59
 import io.novafoundation.nova.core_db.migrations.AddGovernanceDapps_25_26
 import io.novafoundation.nova.core_db.migrations.AddGovernanceExternalApiToChain_27_28
@@ -166,7 +167,7 @@ import io.novafoundation.nova.core_db.model.operation.SwapTypeLocal
 import io.novafoundation.nova.core_db.model.operation.TransferTypeLocal
 
 @Database(
-    version = 73,
+    version = 74,
     entities = [
         AccountLocal::class,
         NodeLocal::class,
@@ -270,7 +271,7 @@ abstract class AppDatabase : RoomDatabase() {
                     .addMigrations(TinderGovBasket_62_63, AddChainForeignKeyForProxy_63_64, AddBrowserTabs_64_65)
                     .addMigrations(AddFavoriteDAppsOrdering_65_66, AddLegacyAddressPrefix_66_67, AddSellProviders_67_68)
                     .addMigrations(AddTypeExtrasToMetaAccount_68_69, AddMultisigCalls_69_70, AddMultisigSupportFlag_70_71)
-                    .addMigrations(AddGifts_71_72, AddFieldsToContributions)
+                    .addMigrations(AddGifts_71_72, AddFieldsToContributions, AddWalletFavourites_73_74)
                     .build()
             }
             return instance!!

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/dao/MetaAccountDao.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/dao/MetaAccountDao.kt
@@ -187,6 +187,12 @@ interface MetaAccountDao {
     @Query("UPDATE meta_accounts SET name = :newName WHERE id = :metaId")
     suspend fun updateName(metaId: Long, newName: String)
 
+    @Query("UPDATE meta_accounts SET isFavourite = :isFavourite WHERE id = :metaId")
+    suspend fun setFavourite(metaId: Long, isFavourite: Boolean)
+
+    @Query("SELECT id FROM meta_accounts WHERE isFavourite = 1")
+    fun observeFavouriteIds(): Flow<List<Long>>
+
     @Query(
         """
         WITH RECURSIVE accounts_to_delete AS (

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/73_74_AddWalletFavourites.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/migrations/73_74_AddWalletFavourites.kt
@@ -1,0 +1,11 @@
+package io.novafoundation.nova.core_db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val AddWalletFavourites_73_74 = object : Migration(73, 74) {
+
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE meta_accounts ADD COLUMN isFavourite INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/account/MetaAccountLocal.kt
+++ b/core-db/src/main/java/io/novafoundation/nova/core_db/model/chain/account/MetaAccountLocal.kt
@@ -36,7 +36,9 @@ class MetaAccountLocal(
     @ColumnInfo(defaultValue = "ACTIVE")
     val status: Status,
     val globallyUniqueId: String,
-    val typeExtras: SerializedJson?
+    val typeExtras: SerializedJson?,
+    @ColumnInfo(name = "isFavourite", defaultValue = "0")
+    val isFavourite: Boolean = false
 ) {
 
     enum class Status {
@@ -56,6 +58,7 @@ class MetaAccountLocal(
 
             const val NAME = "name"
             const val IS_SELECTED = "isSelected"
+            const val IS_FAVOURITE = "isFavourite"
             const val POSITION = "position"
             const val ID = "id"
         }
@@ -83,7 +86,8 @@ class MetaAccountLocal(
             type = type,
             status = status,
             globallyUniqueId = globallyUniqueId,
-            typeExtras = typeExtras
+            typeExtras = typeExtras,
+            isFavourite = isFavourite
         ).also {
             it.id = id
         }
@@ -108,6 +112,7 @@ class MetaAccountLocal(
         if (status != other.status) return false
         if (globallyUniqueId != other.globallyUniqueId) return false
         if (typeExtras != other.typeExtras) return false
+        if (isFavourite != other.isFavourite) return false
 
         return true
     }
@@ -127,6 +132,7 @@ class MetaAccountLocal(
         result = 31 * result + status.hashCode()
         result = 31 * result + globallyUniqueId.hashCode()
         result = 31 * result + (typeExtras?.hashCode() ?: 0)
+        result = 31 * result + isFavourite.hashCode()
         result = 31 * result + id.hashCode()
         return result
     }

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/interfaces/AccountInteractor.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/interfaces/AccountInteractor.kt
@@ -36,6 +36,10 @@ interface AccountInteractor {
 
     suspend fun deleteAccount(metaId: Long): Boolean
 
+    suspend fun setFavourite(metaId: Long, isFavourite: Boolean)
+
+    fun observeFavouriteMetaIds(): Flow<List<Long>>
+
     suspend fun updateMetaAccountPositions(idsInNewOrder: List<Long>)
 
     fun chainFlow(chainId: ChainId): Flow<Chain>

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/interfaces/AccountRepository.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/interfaces/AccountRepository.kt
@@ -58,6 +58,10 @@ interface AccountRepository {
 
     suspend fun updateMetaAccountName(metaId: Long, newName: String)
 
+    suspend fun setFavourite(metaId: Long, isFavourite: Boolean)
+
+    fun observeFavouriteMetaIds(): Flow<List<Long>>
+
     suspend fun isAccountSelected(): Boolean
 
     suspend fun deleteAccount(metaId: Long)

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/listing/CommonAccountsAdapter.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/listing/CommonAccountsAdapter.kt
@@ -65,12 +65,13 @@ abstract class CommonAccountsAdapter<Group : AccountGroupRvItem>(
             holder,
             position,
             payloads,
-            onUnknownPayload = { holder.bindMode(mode, child, accountItemHandler) },
+            onUnknownPayload = { holder.bind(mode, child, accountItemHandler) },
             onDiffCheck = {
                 when (it) {
                     AccountUi::title -> holder.bindName(child)
                     AccountUi::subtitle -> holder.bindSubtitle(child)
-                    AccountUi::isSelected -> holder.bindMode(mode, child, accountItemHandler)
+                    AccountUi::isSelected -> holder.bind(mode, child, accountItemHandler)
+                    AccountUi::isFavourite -> holder.bind(mode, child, accountItemHandler)
                 }
             }
         )
@@ -87,11 +88,18 @@ class AccountDiffCallback<Group : AccountGroupRvItem>(groupClass: Class<Group>) 
     }
 
     override fun areChildItemsTheSame(oldItem: AccountUi, newItem: AccountUi): Boolean {
-        return oldItem.id == newItem.id
+        // Identity = wallet id + groupTag. The same wallet can appear twice
+        // (once in Favourites, once in its original group) and DiffUtil must
+        // treat them as distinct rows so the favourites toggle does not flicker
+        // or dedupe entries.
+        return oldItem.id == newItem.id && oldItem.groupTag == newItem.groupTag
     }
 
     override fun areChildContentsTheSame(oldItem: AccountUi, newItem: AccountUi): Boolean {
-        return oldItem.title == newItem.title && oldItem.subtitle == newItem.subtitle && oldItem.isSelected == newItem.isSelected
+        return oldItem.title == newItem.title &&
+            oldItem.subtitle == newItem.subtitle &&
+            oldItem.isSelected == newItem.isSelected &&
+            oldItem.isFavourite == newItem.isFavourite
     }
 
     override fun getChildChangePayload(oldItem: AccountUi, newItem: AccountUi): Any? {

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/listing/MetaAccountPayloadGenerator.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/listing/MetaAccountPayloadGenerator.kt
@@ -6,5 +6,6 @@ import io.novafoundation.nova.feature_account_api.presenatation.account.listing.
 object MetaAccountPayloadGenerator : PayloadGenerator<AccountUi>(
     AccountUi::title,
     AccountUi::subtitle,
-    AccountUi::isSelected
+    AccountUi::isSelected,
+    AccountUi::isFavourite
 )

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/listing/holders/AccountHolder.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/listing/holders/AccountHolder.kt
@@ -30,6 +30,10 @@ class AccountHolder(
         fun deleteClicked(accountModel: AccountUi) {
             // default no op
         }
+
+        fun favouriteClicked(accountModel: AccountUi) {
+            // default no op
+        }
     }
 
     enum class Mode {
@@ -55,6 +59,8 @@ class AccountHolder(
         bindSubtitle(accountModel)
         bindMode(mode, accountModel, handler)
 
+        bindFavourite(mode, accountModel, handler)
+
         itemAccountIcon.setImageDrawable(accountModel.picture)
         itemChainIcon.letOrHide(accountModel.chainIcon) {
             itemChainIcon.colorFilter = AlphaColorFilter(accountModel.chainIconOpacity)
@@ -65,6 +71,24 @@ class AccountHolder(
             itemAccountTitle.setDrawableEnd(R.drawable.shape_account_updated_indicator, paddingInDp = 8)
         } else {
             itemAccountTitle.removeDrawableEnd()
+        }
+    }
+
+    private fun bindFavourite(
+        mode: Mode,
+        accountModel: AccountUi,
+        handler: AccountItemHandler?
+    ) = with(binder) {
+        val showFav = accountModel.showFavouriteToggle && mode != Mode.EDIT
+        itemAccountFavourite.isVisible = showFav
+        if (showFav) {
+            itemAccountFavourite.setImageResource(
+                if (accountModel.isFavourite) android.R.drawable.btn_star_big_on
+                else android.R.drawable.btn_star_big_off
+            )
+            itemAccountFavourite.setOnClickListener { handler?.favouriteClicked(accountModel) }
+        } else {
+            itemAccountFavourite.setOnClickListener(null)
         }
     }
 

--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/listing/items/AccountUi.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/presenatation/account/listing/items/AccountUi.kt
@@ -14,5 +14,9 @@ class AccountUi(
     val chainIcon: Icon?,
     val updateIndicator: Boolean,
     val subtitleIconRes: Int?,
-    val chainIconOpacity: Float = 1f
+    val chainIconOpacity: Float = 1f,
+    val isFavourite: Boolean = false,
+    val showFavouriteToggle: Boolean = false,
+    val typeBadge: String? = null,
+    val groupTag: String = ""
 )

--- a/feature-account-api/src/main/res/layout/item_account.xml
+++ b/feature-account-api/src/main/res/layout/item_account.xml
@@ -20,14 +20,27 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
+        android:id="@+id/itemAccountFavourite"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:layout_marginStart="8dp"
+        android:padding="4dp"
+        android:src="@android:drawable/btn_star_big_off"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/itemAccountDelete"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <ImageView
         android:id="@+id/itemAccountIcon"
         android:layout_width="32dp"
         android:layout_height="32dp"
-        android:layout_marginStart="12dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/itemAccountDelete"
+        app:layout_constraintStart_toEndOf="@+id/itemAccountFavourite"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_goneMarginStart="16dp"
         tools:src="@color/icon_primary" />

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/AccountRepositoryImpl.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/AccountRepositoryImpl.kt
@@ -166,6 +166,14 @@ class AccountRepositoryImpl(
         metaAccountChangesEventBus.notify(event, source = null)
     }
 
+    override suspend fun setFavourite(metaId: Long, isFavourite: Boolean) = withContext(Dispatchers.Default) {
+        accountDataSource.setFavourite(metaId, isFavourite)
+    }
+
+    override fun observeFavouriteMetaIds(): Flow<List<Long>> {
+        return accountDataSource.observeFavouriteMetaIds()
+    }
+
     override suspend fun isAccountSelected(): Boolean {
         return accountDataSource.anyAccountSelected()
     }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSource.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSource.kt
@@ -71,6 +71,11 @@ interface AccountDataSource : SecretStoreV1 {
     fun metaAccountFlow(metaId: Long): Flow<MetaAccount>
 
     suspend fun updateMetaAccountName(metaId: Long, newName: String)
+
+    suspend fun setFavourite(metaId: Long, isFavourite: Boolean)
+
+    fun observeFavouriteMetaIds(): Flow<List<Long>>
+
     suspend fun deleteMetaAccount(metaId: Long): List<MetaIdWithType>
 
     suspend fun insertMetaAccountWithChainAccounts(metaAccount: MetaAccountInsertionData, chainAccounts: List<ChainAccountInsertionData>): Long

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSourceImpl.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/repository/datasource/AccountDataSourceImpl.kt
@@ -258,6 +258,14 @@ class AccountDataSourceImpl(
         metaAccountDao.updateName(metaId, newName)
     }
 
+    override suspend fun setFavourite(metaId: Long, isFavourite: Boolean) {
+        metaAccountDao.setFavourite(metaId, isFavourite)
+    }
+
+    override fun observeFavouriteMetaIds(): Flow<List<Long>> {
+        return metaAccountDao.observeFavouriteIds()
+    }
+
     override suspend fun deleteMetaAccount(metaId: Long): List<MetaIdWithType> {
         val joinedMetaAccountInfo = metaAccountDao.getJoinedMetaAccountInfo(metaId)
         val chainAccountIds = joinedMetaAccountInfo.chainAccounts.map(ChainAccountLocal::accountId)

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureModule.kt
@@ -619,12 +619,18 @@ class AccountFeatureModule {
     fun provideAccountListingMixinFactory(
         walletUseCase: WalletUiUseCase,
         metaAccountGroupingInteractor: MetaAccountGroupingInteractor,
+        accountInteractor: AccountInteractor,
+        chainRegistry: io.novafoundation.nova.runtime.multiNetwork.ChainRegistry,
+        resourceManager: io.novafoundation.nova.common.resources.ResourceManager,
         proxyFormatter: ProxyFormatter,
         multisigFormatter: MultisigFormatter,
         accountTypePresentationMapper: MetaAccountTypePresentationMapper,
     ) = MetaAccountWithBalanceListingMixinFactory(
         walletUseCase,
         metaAccountGroupingInteractor,
+        accountInteractor,
+        chainRegistry,
+        resourceManager,
         accountTypePresentationMapper,
         multisigFormatter,
         proxyFormatter

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/AccountInteractorImpl.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/domain/AccountInteractorImpl.kt
@@ -77,6 +77,12 @@ class AccountInteractorImpl(
     /**
      * return true if all accounts was deleted
      */
+    override suspend fun setFavourite(metaId: Long, isFavourite: Boolean) {
+        accountRepository.setFavourite(metaId, isFavourite)
+    }
+
+    override fun observeFavouriteMetaIds() = accountRepository.observeFavouriteMetaIds()
+
     override suspend fun deleteAccount(metaId: Long) = withContext(Dispatchers.Default) {
         accountRepository.deleteAccount(metaId)
         if (!accountRepository.isAccountSelected()) {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/common/listing/MetaAccountWithBalanceListingMixin.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/common/listing/MetaAccountWithBalanceListingMixin.kt
@@ -1,14 +1,23 @@
 package io.novafoundation.nova.feature_account_impl.presentation.account.common.listing
 
+import io.novafoundation.nova.common.list.GroupedList
 import io.novafoundation.nova.common.list.toListWithHeaders
 import io.novafoundation.nova.common.utils.flowOf
 import io.novafoundation.nova.common.utils.images.Icon
 import io.novafoundation.nova.common.utils.shareInBackground
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountInteractor
 import io.novafoundation.nova.feature_account_api.domain.interfaces.MetaAccountGroupingInteractor
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccountListingItem
+import io.novafoundation.nova.feature_account_api.domain.model.ProxiedMetaAccount
 import io.novafoundation.nova.feature_account_api.presenatation.account.common.listing.MetaAccountTypePresentationMapper
+import io.novafoundation.nova.common.utils.images.asIcon
+import io.novafoundation.nova.common.view.ChipLabelModel
+import io.novafoundation.nova.feature_account_api.presenatation.account.listing.items.AccountChipGroupRvItem
 import io.novafoundation.nova.feature_account_api.presenatation.account.listing.items.AccountUi
 import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.WalletUiUseCase
 import io.novafoundation.nova.feature_account_api.presenatation.chain.iconOrFallback
@@ -18,10 +27,15 @@ import io.novafoundation.nova.feature_currency_api.presentation.formatters.forma
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 
 class MetaAccountWithBalanceListingMixinFactory(
     private val walletUiUseCase: WalletUiUseCase,
     private val metaAccountGroupingInteractor: MetaAccountGroupingInteractor,
+    private val accountInteractor: AccountInteractor,
+    private val chainRegistry: ChainRegistry,
+    private val resourceManager: ResourceManager,
     private val accountTypePresentationMapper: MetaAccountTypePresentationMapper,
     private val multisigFormatter: MultisigFormatter,
     private val proxyFormatter: ProxyFormatter,
@@ -30,16 +44,23 @@ class MetaAccountWithBalanceListingMixinFactory(
     fun create(
         coroutineScope: CoroutineScope,
         showUpdatedMetaAccountsBadge: Boolean = true,
+        showFavouriteToggle: Boolean = false,
+        searchQueryFlow: Flow<String> = flowOf { "" },
         metaAccountSelectedFlow: Flow<SelectedMetaAccountState> = flowOf { SelectedMetaAccountState.CurrentlySelected }
     ): MetaAccountListingMixin {
         return MetaAccountWithBalanceListingMixin(
             walletUiUseCase = walletUiUseCase,
             metaAccountGroupingInteractor = metaAccountGroupingInteractor,
+            accountInteractor = accountInteractor,
+            chainRegistry = chainRegistry,
+            resourceManager = resourceManager,
             coroutineScope = coroutineScope,
             metaAccountSelectedFlow = metaAccountSelectedFlow,
             accountTypePresentationMapper = accountTypePresentationMapper,
             proxyFormatter = proxyFormatter,
             showUpdatedMetaAccountsBadge = showUpdatedMetaAccountsBadge,
+            showFavouriteToggle = showFavouriteToggle,
+            searchQueryFlow = searchQueryFlow,
             multisigFormatter = multisigFormatter
         )
     }
@@ -47,27 +68,182 @@ class MetaAccountWithBalanceListingMixinFactory(
 
 private class MetaAccountWithBalanceListingMixin(
     private val metaAccountGroupingInteractor: MetaAccountGroupingInteractor,
+    private val accountInteractor: AccountInteractor,
+    private val chainRegistry: ChainRegistry,
+    private val resourceManager: ResourceManager,
     private val walletUiUseCase: WalletUiUseCase,
     private val metaAccountSelectedFlow: Flow<SelectedMetaAccountState>,
     private val accountTypePresentationMapper: MetaAccountTypePresentationMapper,
     private val proxyFormatter: ProxyFormatter,
     private val multisigFormatter: MultisigFormatter,
     private val showUpdatedMetaAccountsBadge: Boolean,
+    private val showFavouriteToggle: Boolean,
+    private val searchQueryFlow: Flow<String>,
     coroutineScope: CoroutineScope,
 ) : MetaAccountListingMixin, CoroutineScope by coroutineScope {
 
     override val metaAccountsFlow = combine(
         metaAccountGroupingInteractor.metaAccountsWithTotalBalanceFlow(),
-        metaAccountSelectedFlow
-    ) { groupedList, selected ->
-        groupedList.toListWithHeaders(
-            keyMapper = { type, _ -> accountTypePresentationMapper.mapMetaAccountTypeToUi(type) },
-            valueMapper = { mapMetaAccountToUi(it, selected) }
-        )
+        metaAccountSelectedFlow,
+        accountInteractor.observeFavouriteMetaIds(),
+        searchQueryFlow,
+        // Project chains to (id → name) so we only re-emit when the names we
+        // actually search against change. Avoids re-running the lambda on
+        // every chain icon / runtime metadata refresh.
+        chainRegistry.currentChains
+            .map { chains -> chains.toSearchableProjection() }
+            .distinctUntilChanged()
+    ) { groupedList, selected, favouriteIds, query, chainsProjection ->
+        val favSet = favouriteIds.toSet()
+        val q = query.trim().lowercase()
+        val metaById = groupedList.values
+            .flatten()
+            .associateBy { it.metaAccount.id }
+
+        val baseItems = buildBaseItems(groupedList, selected, favSet)
+
+        if (q.isNotEmpty()) {
+            filterForSearch(baseItems, metaById, chainsProjection, q)
+        } else {
+            prependFavourites(baseItems, metaById, favSet)
+        }
     }
         .shareInBackground()
 
-    private suspend fun mapMetaAccountToUi(metaAccountWithBalance: MetaAccountListingItem, selected: SelectedMetaAccountState) =
+    private suspend fun buildBaseItems(
+        groupedList: GroupedList<LightMetaAccount.Type, MetaAccountListingItem>,
+        selected: SelectedMetaAccountState,
+        favSet: Set<Long>
+    ): List<Any> = groupedList.toListWithHeaders(
+        keyMapper = { type, _ ->
+            accountTypePresentationMapper.mapMetaAccountTypeToUi(type)
+                ?: if (type == LightMetaAccount.Type.SECRETS) {
+                    AccountChipGroupRvItem(
+                        ChipLabelModel(
+                            title = resourceManager.getString(io.novafoundation.nova.common.R.string.wallets_section_header),
+                            icon = null
+                        )
+                    )
+                } else {
+                    null
+                }
+        },
+        valueMapper = { mapMetaAccountToUi(it, selected, favSet) }
+    )
+
+    private fun filterForSearch(
+        baseItems: List<Any>,
+        metaById: Map<Long, MetaAccountListingItem>,
+        chainsProjection: ChainSearchProjection,
+        query: String
+    ): List<Any> {
+        val normalizedQuery = query.replace("-", "").replace(" ", "")
+        val isProxyTypeQuery = !normalizedQuery.isEmpty() &&
+            PROXY_TYPE_KEYWORDS.any { it.contains(normalizedQuery) }
+
+        return baseItems.filter { item ->
+            if (item !is AccountUi) return@filter false
+            val meta = metaById[item.id]?.metaAccount ?: return@filter false
+
+            if (isProxyTypeQuery) {
+                if (meta !is ProxiedMetaAccount) return@filter false
+                return@filter meta.proxy.proxyType.name.lowercase().contains(normalizedQuery)
+            }
+
+            // Name match
+            if (item.title.toString().lowercase().contains(query)) return@filter true
+
+            // Chain name match — wallet's explicit chain accounts
+            val chainAccountNames = meta.chainAccounts.keys
+                .mapNotNull { chainsProjection.namesById[it]?.lowercase() }
+            if (chainAccountNames.any { it.contains(query) }) return@filter true
+
+            // Chain name match — substrate / EVM base wallets implicitly
+            // support any chain of that type
+            val supportsSubstrate = meta.substrateAccountId != null
+            val supportsEvm = meta.ethereumAddress != null
+            if (supportsSubstrate && chainsProjection.matchesSubstrate(query)) return@filter true
+            if (supportsEvm && chainsProjection.matchesEvm(query)) return@filter true
+
+            // Proxied wallets without substrate base — match by proxy type
+            if (meta is ProxiedMetaAccount &&
+                meta.proxy.proxyType.name.lowercase().contains(normalizedQuery)
+            ) {
+                return@filter true
+            }
+
+            false
+        }
+    }
+
+    private fun prependFavourites(
+        baseItems: List<Any>,
+        metaById: Map<Long, MetaAccountListingItem>,
+        favSet: Set<Long>
+    ): List<Any> {
+        if (favSet.isEmpty()) return baseItems
+
+        val favouriteUis = baseItems
+            .filterIsInstance<AccountUi>()
+            .filter { it.id in favSet }
+            .map { ui -> wrapForFavouritesSection(ui, metaById[ui.id]) }
+
+        if (favouriteUis.isEmpty()) return baseItems
+
+        val favouritesHeader = AccountChipGroupRvItem(
+            ChipLabelModel(
+                title = resourceManager.getString(io.novafoundation.nova.common.R.string.favourites_section_header),
+                icon = null
+            )
+        )
+        return listOf<Any>(favouritesHeader) + favouriteUis + baseItems
+    }
+
+    private fun wrapForFavouritesSection(
+        ui: AccountUi,
+        meta: MetaAccountListingItem?
+    ): AccountUi {
+        // For multisigs without a network-specific chain icon, surface the
+        // multisig icon over the identicon so the type stays visible in the
+        // Favourites section.
+        val chainIcon = if (
+            meta is MetaAccountListingItem.Multisig && ui.chainIcon == null
+        ) {
+            io.novafoundation.nova.common.R.drawable.ic_multisig.asIcon()
+        } else {
+            ui.chainIcon
+        }
+        return AccountUi(
+            id = ui.id,
+            title = ui.title,
+            subtitle = ui.subtitle,
+            isSelected = ui.isSelected,
+            isEditable = ui.isEditable,
+            isClickable = ui.isClickable,
+            picture = ui.picture,
+            chainIcon = chainIcon,
+            updateIndicator = ui.updateIndicator,
+            subtitleIconRes = ui.subtitleIconRes,
+            chainIconOpacity = ui.chainIconOpacity,
+            isFavourite = true,
+            showFavouriteToggle = ui.showFavouriteToggle,
+            typeBadge = ui.typeBadge,
+            groupTag = "favourites"
+        )
+    }
+
+    companion object {
+        private val PROXY_TYPE_KEYWORDS = setOf(
+            "any", "nontransfer", "governance", "staking",
+            "identityjudgement", "cancelproxy", "auction", "nominationpools"
+        )
+    }
+
+    private suspend fun mapMetaAccountToUi(
+        metaAccountWithBalance: MetaAccountListingItem,
+        selected: SelectedMetaAccountState,
+        favouriteIds: Set<Long>
+    ) =
         with(metaAccountWithBalance) {
             AccountUi(
                 id = metaAccount.id,
@@ -79,7 +255,9 @@ private class MetaAccountWithBalanceListingMixin(
                 picture = walletUiUseCase.walletIcon(metaAccount),
                 chainIcon = chainIcon(),
                 updateIndicator = hasUpdates && showUpdatedMetaAccountsBadge,
-                subtitleIconRes = null
+                subtitleIconRes = null,
+                isFavourite = favouriteIds.contains(metaAccount.id),
+                showFavouriteToggle = showFavouriteToggle
             )
         }
 
@@ -128,4 +306,31 @@ private class MetaAccountWithBalanceListingMixin(
             LightMetaAccount.Type.MULTISIG -> false
         }
     }
+}
+
+/**
+ * Lightweight projection of the chain registry that only carries the fields
+ * the wallet search filter actually needs (id, name, ethereum-or-substrate
+ * type). Used with `distinctUntilChanged()` to avoid re-running the listing
+ * combine on unrelated chain field updates (icon refreshes, runtime metadata,
+ * etc.).
+ */
+private data class ChainSearchProjection(
+    val namesById: Map<String, String>,
+    private val substrateNames: List<String>,
+    private val evmNames: List<String>
+) {
+    fun matchesSubstrate(query: String): Boolean = substrateNames.any { it.contains(query) }
+    fun matchesEvm(query: String): Boolean = evmNames.any { it.contains(query) }
+}
+
+private fun List<Chain>.toSearchableProjection(): ChainSearchProjection {
+    val names = associate { it.id to it.name }
+    val substrate = filterNot { it.isEthereumBased }.map { it.name.lowercase() }
+    val evm = filter { it.isEthereumBased }.map { it.name.lowercase() }
+    return ChainSearchProjection(
+        namesById = names,
+        substrateNames = substrate,
+        evmNames = evm
+    )
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/list/WalletListFragment.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/list/WalletListFragment.kt
@@ -28,6 +28,13 @@ abstract class WalletListFragment<T : WalletListViewModel> :
 
     override fun initViews() {
         binder.walletListContent.adapter = adapter
+        binder.walletListSearch.addTextChangedListener(object : android.text.TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                viewModel.onSearchQueryChanged(s?.toString().orEmpty())
+            }
+            override fun afterTextChanged(s: android.text.Editable?) {}
+        })
     }
 
     override fun subscribe(viewModel: T) {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/list/WalletListViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/list/WalletListViewModel.kt
@@ -4,12 +4,19 @@ import io.novafoundation.nova.common.base.BaseViewModel
 import io.novafoundation.nova.feature_account_api.presenatation.account.listing.holders.AccountHolder.Mode
 import io.novafoundation.nova.feature_account_api.presenatation.account.listing.items.AccountUi
 import io.novafoundation.nova.feature_account_impl.presentation.account.common.listing.MetaAccountListingMixin
+import kotlinx.coroutines.flow.MutableStateFlow
 
 abstract class WalletListViewModel : BaseViewModel() {
 
     abstract val walletsListingMixin: MetaAccountListingMixin
 
     abstract val mode: Mode
+
+    val searchQueryFlow = MutableStateFlow("")
+
+    fun onSearchQueryChanged(query: String) {
+        searchQueryFlow.value = query
+    }
 
     abstract fun accountClicked(accountModel: AccountUi)
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/list/switching/SwitchWalletViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/list/switching/SwitchWalletViewModel.kt
@@ -19,7 +19,10 @@ class SwitchWalletViewModel(
     accountListingMixinFactory: MetaAccountWithBalanceListingMixinFactory,
 ) : WalletListViewModel() {
 
-    override val walletsListingMixin = accountListingMixinFactory.create(this)
+    override val walletsListingMixin = accountListingMixinFactory.create(
+        coroutineScope = this,
+        searchQueryFlow = searchQueryFlow
+    )
 
     override val mode: AccountHolder.Mode = AccountHolder.Mode.SWITCH
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/management/WalletManagmentFragment.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/management/WalletManagmentFragment.kt
@@ -39,6 +39,14 @@ class WalletManagmentFragment : BaseFragment<WalletManagmentViewModel, FragmentA
         binder.accountListToolbar.setHomeButtonListener { viewModel.backClicked() }
 
         binder.addAccount.setOnClickListener { viewModel.addAccountClicked() }
+
+        binder.accountsSearch.addTextChangedListener(object : android.text.TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                viewModel.onSearchQueryChanged(s?.toString().orEmpty())
+            }
+            override fun afterTextChanged(s: android.text.Editable?) {}
+        })
     }
 
     override fun inject() {
@@ -78,5 +86,9 @@ class WalletManagmentFragment : BaseFragment<WalletManagmentViewModel, FragmentA
 
     override fun deleteClicked(accountModel: AccountUi) {
         viewModel.deleteClicked(accountModel)
+    }
+
+    override fun favouriteClicked(accountModel: AccountUi) {
+        viewModel.favouriteClicked(accountModel)
     }
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/management/WalletManagmentViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/management/WalletManagmentViewModel.kt
@@ -32,7 +32,17 @@ class WalletManagmentViewModel(
 
     val cloudBackupChangingWarningMixin = cloudBackupChangingWarningMixinFactory.create(viewModelScope)
 
-    val walletsListingMixin = accountListingMixinFactory.create(this)
+    val searchQueryFlow = MutableStateFlow("")
+
+    fun onSearchQueryChanged(query: String) {
+        searchQueryFlow.value = query
+    }
+
+    val walletsListingMixin = accountListingMixinFactory.create(
+        coroutineScope = this,
+        showFavouriteToggle = true,
+        searchQueryFlow = searchQueryFlow
+    )
 
     val mode = MutableStateFlow(Mode.SELECT)
 
@@ -57,6 +67,12 @@ class WalletManagmentViewModel(
         val newMode = if (mode.value == Mode.SELECT) Mode.EDIT else Mode.SELECT
 
         mode.value = newMode
+    }
+
+    fun favouriteClicked(account: AccountUi) {
+        launch {
+            accountInteractor.setFavourite(account.id, !account.isFavourite)
+        }
     }
 
     fun deleteClicked(account: AccountUi) {

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/mixin/selectWallet/SelectWalletViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/mixin/selectWallet/SelectWalletViewModel.kt
@@ -24,6 +24,7 @@ class SelectWalletViewModel(
 
     override val walletsListingMixin = accountListingMixinFactory.create(
         coroutineScope = this,
+        searchQueryFlow = searchQueryFlow,
         metaAccountSelectedFlow = currentSelectedIdFlow
     )
 

--- a/feature-account-impl/src/main/res/layout/fragment_accounts.xml
+++ b/feature-account-impl/src/main/res/layout/fragment_accounts.xml
@@ -25,6 +25,21 @@
             app:textRight="@string/common_edit"
             app:titleText="@string/profile_accounts_title_2_0" />
 
+        <EditText
+            android:id="@+id/accountsSearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/bg_primary_list_item"
+            android:hint="@string/search_wallets_placeholder"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
+            android:padding="12dp"
+            android:singleLine="true"
+            android:textColor="@color/text_primary"
+            android:textColorHint="@color/text_secondary" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/accountsList"
             android:layout_width="match_parent"

--- a/feature-account-impl/src/main/res/layout/fragment_wallet_list.xml
+++ b/feature-account-impl/src/main/res/layout/fragment_wallet_list.xml
@@ -39,6 +39,21 @@
             app:tint="@color/actions_color" />
     </LinearLayout>
 
+    <EditText
+        android:id="@+id/walletListSearch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/bg_primary_list_item"
+        android:hint="@string/search_wallets_placeholder"
+        android:imeOptions="actionSearch"
+        android:inputType="text"
+        android:padding="12dp"
+        android:singleLine="true"
+        android:textColor="@color/text_primary"
+        android:textColorHint="@color/text_secondary" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/walletListContent"
         android:layout_width="match_parent"


### PR DESCRIPTION
Adds a per-wallet isFavourite flag so users can pin wallets to a Favourites section at the top of the wallet selection screen, together with a search bar that filters by wallet name, address, chain name, and proxy type. Favourite state is toggled from the wallet management screen.

- Room database migrated from v73 to v74 to add the isFavourite column on meta_accounts; new 73_74_AddWalletFavourites migration
- MetaAccountDao, AccountRepository and AccountInteractor expose setFavourite / observe favourites
- MetaAccountWithBalanceListingMixin: the metaAccountsFlow lambda has been split into named private functions for readability, and currentChains is now wrapped in distinctUntilChanged to avoid redundant re-emissions when chain state is unchanged
- Wallet management fragment adds a star toggle; wallet list and select-wallet screens render the Favourites section and search bar
- strings.xml updated for all 13 supported locales