### PR TITLE
POC: Anonymous analytics tracking with opt-out consent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "nova-wallet-dapp-js"]
 	path = nova-wallet-dapp-js
-	url = git@github.com:nova-wallet/nova-wallet-dapp-js.git
+	url = https://github.com/novasamatech/nova-wallet-dapp-js.git
 [submodule "nova-wallet-metamask-js"]
 	path = nova-wallet-metamask-js
-	url = git@github.com:nova-wallet/nova-wallet-metamask-js.git
+	url = https://github.com/novasamatech/nova-wallet-metamask-js.git

--- a/app/src/main/java/io/novafoundation/nova/app/root/di/RootDependencies.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/di/RootDependencies.kt
@@ -2,7 +2,10 @@ package io.novafoundation.nova.app.root.di
 
 import android.content.Context
 import coil.ImageLoader
+import io.novafoundation.nova.common.data.analytics.AnalyticsOptOutManager
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
+import io.novafoundation.nova.common.data.storage.Preferences
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.mixin.api.NetworkStateMixin
 import io.novafoundation.nova.common.resources.ContextManager
@@ -137,6 +140,12 @@ interface RootDependencies {
     val chainMigrationDetailsSelectToShowUseCase: ChainMigrationDetailsSelectToShowUseCase
 
     val deviceNetworkStateObserver: DeviceNetworkStateObserver
+
+    val analyticsOptOutManager: AnalyticsOptOutManager
+
+    val analyticsService: AnalyticsService
+
+    fun providePreferences(): Preferences
 
     fun updateNotificationsInteractor(): UpdateNotificationsInteractor
 

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/governance/GovernanceNavigator.kt
@@ -241,7 +241,7 @@ class GovernanceNavigator(
     }
 
     override fun openDAppBrowser(url: String) {
-        dAppRouter.openDAppBrowser(DAppBrowserPayload.Address(url))
+        dAppRouter.openDAppBrowser(DAppBrowserPayload.Address(url, source = "governance"))
     }
 
     override fun openReferendumDescription(payload: DescriptionPayload) {

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
@@ -279,7 +279,7 @@ class RelayStakingNavigator(
     }
 
     override fun openDAppBrowser(url: String) {
-        dAppRouter.openDAppBrowser(DAppBrowserPayload.Address(url))
+        dAppRouter.openDAppBrowser(DAppBrowserPayload.Address(url, source = "staking"))
     }
 
     override fun openStakingDashboard() {

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/main/MainFragment.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/main/MainFragment.kt
@@ -14,6 +14,7 @@ import io.novafoundation.nova.app.root.di.RootComponent
 import io.novafoundation.nova.app.root.navigation.navigators.staking.StakingDashboardNavigator
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.view.dialog.dialog
 
 import javax.inject.Inject
 
@@ -54,8 +55,28 @@ class MainFragment : BaseFragment<MainViewModel, FragmentMainBinding>() {
 
         requireActivity().onBackPressedDispatcher.addCallback(backCallback)
 
+        var isFirstTabLoad = true
+        var currentTabName: String? = null
         navController!!.addOnDestinationChangedListener { _, destination, _ ->
             backCallback.isEnabled = !isAtHomeTab(destination)
+
+            val tabName = when (destination.id) {
+                R.id.walletFragment -> "assets"
+                R.id.voteFragment -> "vote"
+                R.id.dAppsFragment -> "dapps"
+                R.id.stakingDashboardFragment -> "staking"
+                R.id.profileFragment -> "settings"
+                else -> null
+            }
+            if (tabName != null) {
+                if (isFirstTabLoad) {
+                    isFirstTabLoad = false
+                    currentTabName = tabName
+                } else if (tabName != currentTabName) {
+                    currentTabName = tabName
+                    viewModel.onTabSwitched(tabName)
+                }
+            }
         }
     }
 
@@ -66,7 +87,24 @@ class MainFragment : BaseFragment<MainViewModel, FragmentMainBinding>() {
             .inject(this)
     }
 
-    override fun subscribe(viewModel: MainViewModel) {}
+    override fun subscribe(viewModel: MainViewModel) {
+        viewModel.showAnalyticsPromptEvent.observeEvent {
+            showAnalyticsConsentDialog()
+        }
+    }
+
+    private fun showAnalyticsConsentDialog() {
+        dialog(requireContext()) {
+            setTitle(io.novafoundation.nova.common.R.string.analytics_prompt_title)
+            setMessage(io.novafoundation.nova.common.R.string.analytics_prompt_message)
+            setPositiveButton(io.novafoundation.nova.common.R.string.analytics_prompt_enable) { _, _ ->
+                viewModel.onAnalyticsEnabled()
+            }
+            setNegativeButton(io.novafoundation.nova.common.R.string.analytics_prompt_later) { _, _ ->
+                viewModel.onAnalyticsDismissed()
+            }
+        }
+    }
 
     private fun isAtHomeTab(destination: NavDestination) =
         destination.id == navController!!.graph.startDestination

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/main/MainViewModel.kt
@@ -1,7 +1,14 @@
 package io.novafoundation.nova.app.root.presentation.main
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsOptOutManager
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.storage.Preferences
+import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.common.utils.sequrity.AutomaticInteractionGate
 import io.novafoundation.nova.feature_ahm_api.domain.ChainMigrationDetailsSelectToShowUseCase
 import io.novafoundation.nova.feature_push_notifications.domain.interactor.WelcomePushNotificationsInteractor
@@ -13,8 +20,18 @@ class MainViewModel(
     private val automaticInteractionGate: AutomaticInteractionGate,
     private val welcomePushNotificationsInteractor: WelcomePushNotificationsInteractor,
     private val rootRouter: RootRouter,
-    private val chainMigrationDetailsSelectToShowUseCase: ChainMigrationDetailsSelectToShowUseCase
+    private val chainMigrationDetailsSelectToShowUseCase: ChainMigrationDetailsSelectToShowUseCase,
+    private val analyticsOptOutManager: AnalyticsOptOutManager,
+    private val analyticsService: AnalyticsService,
+    private val preferences: Preferences
 ) : BaseViewModel() {
+
+    companion object {
+        private const val PREF_IS_FIRST_LAUNCH = "is_first_launch"
+    }
+
+    private val _showAnalyticsPromptEvent = MutableLiveData<Event<Unit>>()
+    val showAnalyticsPromptEvent: LiveData<Event<Unit>> = _showAnalyticsPromptEvent
 
     init {
         updateNotificationsInteractor.allowInAppUpdateCheck()
@@ -28,6 +45,40 @@ class MainViewModel(
             val chainIdsToShowMigrationDetails = chainMigrationDetailsSelectToShowUseCase.getChainIdsToShowMigrationDetails()
             chainIdsToShowMigrationDetails.forEach {
                 rootRouter.openChainMigrationDetails(it)
+            }
+        }
+
+        checkAnalyticsPrompt()
+        trackAppOpened()
+    }
+
+    fun onAnalyticsEnabled() {
+        analyticsOptOutManager.setAnalyticsEnabled(true)
+        analyticsOptOutManager.setAnalyticsPromptSeen()
+        // Fire app_opened now that analytics is enabled
+        trackAppOpened()
+    }
+
+    fun onAnalyticsDismissed() {
+        analyticsOptOutManager.setAnalyticsPromptSeen()
+    }
+
+    private fun checkAnalyticsPrompt() {
+        if (!analyticsOptOutManager.hasSeenAnalyticsPrompt()) {
+            _showAnalyticsPromptEvent.value = Event(Unit)
+        }
+    }
+
+    fun onTabSwitched(tab: String) {
+        analyticsService.track(AnalyticsEvent.TabSwitched(tab))
+    }
+
+    private fun trackAppOpened() {
+        val isFirstLaunch = !preferences.contains(PREF_IS_FIRST_LAUNCH)
+        if (analyticsService.isEnabled) {
+            analyticsService.track(AnalyticsEvent.AppOpened(isFirstLaunch))
+            if (isFirstLaunch) {
+                preferences.putBoolean(PREF_IS_FIRST_LAUNCH, false)
             }
         }
     }

--- a/app/src/main/java/io/novafoundation/nova/app/root/presentation/main/di/MainFragmentModule.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/presentation/main/di/MainFragmentModule.kt
@@ -8,6 +8,9 @@ import dagger.Provides
 import dagger.multibindings.IntoMap
 import io.novafoundation.nova.app.root.presentation.RootRouter
 import io.novafoundation.nova.app.root.presentation.main.MainViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsOptOutManager
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.storage.Preferences
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.utils.sequrity.AutomaticInteractionGate
@@ -30,14 +33,20 @@ class MainFragmentModule {
         automaticInteractionGate: AutomaticInteractionGate,
         welcomePushNotificationsInteractor: WelcomePushNotificationsInteractor,
         chainMigrationDetailsSelectToShowUseCase: ChainMigrationDetailsSelectToShowUseCase,
-        rootRouter: RootRouter
+        rootRouter: RootRouter,
+        analyticsOptOutManager: AnalyticsOptOutManager,
+        analyticsService: AnalyticsService,
+        preferences: Preferences
     ): ViewModel {
         return MainViewModel(
             updateNotificationsInteractor,
             automaticInteractionGate,
             welcomePushNotificationsInteractor,
             rootRouter,
-            chainMigrationDetailsSelectToShowUseCase
+            chainMigrationDetailsSelectToShowUseCase,
+            analyticsOptOutManager,
+            analyticsService,
+            preferences
         )
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,6 +4,8 @@ android {
 
     defaultConfig {
 
+        buildConfigField "String", "ANALYTICS_API_KEY", "\"phc_sGA7fK8DPZTBqrc2dNKrzjeF9mr2nWJ2stIlWX3e9ZD\""
+
         buildConfigField "String", "WEBSITE_URL", "\"https://novawallet.io\""
         buildConfigField "String", "PRIVACY_URL", "\"https://novawallet.io/privacy\""
         buildConfigField "String", "TERMS_URL", "\"https://novawallet.io/terms\""

--- a/common/src/main/java/io/novafoundation/nova/common/data/analytics/AnalyticsEvent.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/analytics/AnalyticsEvent.kt
@@ -1,0 +1,484 @@
+package io.novafoundation.nova.common.data.analytics
+
+sealed class AnalyticsEvent(
+    val name: String,
+    val properties: Map<String, Any>
+) {
+
+    // App lifecycle
+
+    class AppOpened(isFirstLaunch: Boolean) : AnalyticsEvent(
+        name = "app_opened",
+        properties = mapOf(
+            "is_first_launch" to isFirstLaunch,
+            "\$ip" to false
+        )
+    )
+
+    object SessionStarted : AnalyticsEvent(
+        name = "session_started",
+        properties = mapOf(
+            "\$ip" to false
+        )
+    )
+
+    class SessionEnded(durationBucket: DurationBucket) : AnalyticsEvent(
+        name = "session_ended",
+        properties = mapOf(
+            "duration_bucket" to durationBucket.value,
+            "\$ip" to false
+        )
+    )
+
+    // Onboarding
+
+    class OnboardingStarted(source: OnboardingSource) : AnalyticsEvent(
+        name = "onboarding_started",
+        properties = mapOf(
+            "source" to source.value,
+            "\$ip" to false
+        )
+    )
+
+    class WalletCreationMethodSelected(method: WalletCreationMethod) : AnalyticsEvent(
+        name = "wallet_creation_method_selected",
+        properties = mapOf(
+            "method" to method.value,
+            "\$ip" to false
+        )
+    )
+
+    class WalletCreationStarted(method: WalletCreationMethod) : AnalyticsEvent(
+        name = "wallet_creation_started",
+        properties = mapOf(
+            "method" to method.value,
+            "\$ip" to false
+        )
+    )
+
+    class WalletCreationCompleted(
+        method: WalletCreationMethod,
+        durationBucket: DurationBucket? = null
+    ) : AnalyticsEvent(
+        name = "wallet_creation_completed",
+        properties = buildMap {
+            put("method", method.value)
+            if (durationBucket != null) put("duration_bucket", durationBucket.value)
+            put("\$ip", false)
+        }
+    )
+
+    class WalletCreationAbandoned(lastStep: WalletCreationStep) : AnalyticsEvent(
+        name = "wallet_creation_abandoned",
+        properties = mapOf(
+            "last_step" to lastStep.value,
+            "\$ip" to false
+        )
+    )
+
+    class FirstActionAfterWallet(action: FirstAction) : AnalyticsEvent(
+        name = "first_action_after_wallet",
+        properties = mapOf(
+            "action" to action.value,
+            "\$ip" to false
+        )
+    )
+
+    // Features
+
+    class FeatureOpened(featureId: FeatureId) : AnalyticsEvent(
+        name = "feature_opened",
+        properties = mapOf(
+            "feature_id" to featureId.value,
+            "\$ip" to false
+        )
+    )
+
+    // Swap
+
+    class SwapScreenOpened(source: SwapSource) : AnalyticsEvent(
+        name = "swap_screen_opened",
+        properties = mapOf(
+            "source" to source.value,
+            "\$ip" to false
+        )
+    )
+
+    class SwapInitiated(
+        source: SwapSource,
+        assetInCategory: AssetCategory,
+        assetOutCategory: AssetCategory,
+        assetIn: String,
+        assetOut: String,
+        networkIn: String,
+        networkOut: String,
+        amountBucket: AmountBucket
+    ) : AnalyticsEvent(
+        name = "swap_initiated",
+        properties = mapOf(
+            "source" to source.value,
+            "asset_in_category" to assetInCategory.value,
+            "asset_out_category" to assetOutCategory.value,
+            "asset_in" to assetIn,
+            "asset_out" to assetOut,
+            "network_in" to networkIn,
+            "network_out" to networkOut,
+            "amount_bucket" to amountBucket.value,
+            "\$ip" to false
+        )
+    )
+
+    class SwapConfirmed(
+        amountBucket: AmountBucket,
+        slippageBucket: SlippageBucket,
+        assetIn: String,
+        assetOut: String,
+        networkIn: String,
+        networkOut: String
+    ) : AnalyticsEvent(
+        name = "swap_confirmed",
+        properties = mapOf(
+            "amount_bucket" to amountBucket.value,
+            "slippage_bucket" to slippageBucket.value,
+            "asset_in" to assetIn,
+            "asset_out" to assetOut,
+            "network_in" to networkIn,
+            "network_out" to networkOut,
+            "\$ip" to false
+        )
+    )
+
+    class SwapCompleted(
+        amountBucket: AmountBucket,
+        durationBucket: DurationBucket,
+        assetIn: String,
+        assetOut: String,
+        networkIn: String,
+        networkOut: String
+    ) : AnalyticsEvent(
+        name = "swap_completed",
+        properties = mapOf(
+            "amount_bucket" to amountBucket.value,
+            "duration_bucket" to durationBucket.value,
+            "asset_in" to assetIn,
+            "asset_out" to assetOut,
+            "network_in" to networkIn,
+            "network_out" to networkOut,
+            "\$ip" to false
+        )
+    )
+
+    class SwapFailed(reason: SwapFailureReason) : AnalyticsEvent(
+        name = "swap_failed",
+        properties = mapOf(
+            "reason" to reason.value,
+            "\$ip" to false
+        )
+    )
+
+    class SwapAbandoned(stage: SwapStage) : AnalyticsEvent(
+        name = "swap_abandoned",
+        properties = mapOf(
+            "stage" to stage.value,
+            "\$ip" to false
+        )
+    )
+
+    // Staking
+
+    class StakingFlowOpened(network: String, source: String) : AnalyticsEvent(
+        name = "staking_flow_opened",
+        properties = mapOf(
+            "network" to network,
+            "source" to source,
+            "\$ip" to false
+        )
+    )
+
+    class StakingTypeSelected(stakingType: String, network: String) : AnalyticsEvent(
+        name = "staking_type_selected",
+        properties = mapOf(
+            "staking_type" to stakingType,
+            "network" to network,
+            "\$ip" to false
+        )
+    )
+
+    class StakingInitiated(stakingType: String, network: String, amountBucket: AmountBucket) : AnalyticsEvent(
+        name = "staking_initiated",
+        properties = mapOf(
+            "staking_type" to stakingType,
+            "network" to network,
+            "amount_bucket" to amountBucket.value,
+            "\$ip" to false
+        )
+    )
+
+    class StakingConfirmed(stakingType: String, network: String, amountBucket: AmountBucket) : AnalyticsEvent(
+        name = "staking_confirmed",
+        properties = mapOf(
+            "staking_type" to stakingType,
+            "network" to network,
+            "amount_bucket" to amountBucket.value,
+            "\$ip" to false
+        )
+    )
+
+    class StakingCompleted(stakingType: String, network: String, amountBucket: AmountBucket) : AnalyticsEvent(
+        name = "staking_completed",
+        properties = mapOf(
+            "staking_type" to stakingType,
+            "network" to network,
+            "amount_bucket" to amountBucket.value,
+            "\$ip" to false
+        )
+    )
+
+    class StakingFailed(stakingType: String, network: String, reason: String) : AnalyticsEvent(
+        name = "staking_failed",
+        properties = mapOf(
+            "staking_type" to stakingType,
+            "network" to network,
+            "reason" to reason,
+            "\$ip" to false
+        )
+    )
+
+    class UnstakeInitiated(stakingType: String, network: String, amountBucket: AmountBucket) : AnalyticsEvent(
+        name = "unstake_initiated",
+        properties = mapOf(
+            "staking_type" to stakingType,
+            "network" to network,
+            "amount_bucket" to amountBucket.value,
+            "\$ip" to false
+        )
+    )
+
+    class UnstakeCompleted(stakingType: String, network: String, amountBucket: AmountBucket) : AnalyticsEvent(
+        name = "unstake_completed",
+        properties = mapOf(
+            "staking_type" to stakingType,
+            "network" to network,
+            "amount_bucket" to amountBucket.value,
+            "\$ip" to false
+        )
+    )
+
+    class UnstakeFailed(stakingType: String, network: String, reason: String) : AnalyticsEvent(
+        name = "unstake_failed",
+        properties = mapOf(
+            "staking_type" to stakingType,
+            "network" to network,
+            "reason" to reason,
+            "\$ip" to false
+        )
+    )
+
+    // Transfers
+
+    class SendInitiated(
+        asset: String,
+        network: String,
+        destinationNetwork: String? = null,
+        assetCategory: AssetCategory,
+        amountBucket: AmountBucket,
+        isCrossChain: Boolean
+    ) : AnalyticsEvent(
+        name = "send_initiated",
+        properties = buildMap {
+            put("asset", asset)
+            put("network", network)
+            if (destinationNetwork != null) put("destination_network", destinationNetwork)
+            put("asset_category", assetCategory.value)
+            put("amount_bucket", amountBucket.value)
+            put("is_cross_chain", isCrossChain)
+            put("\$ip", false)
+        }
+    )
+
+    class SendCompleted(asset: String, network: String, amountBucket: AmountBucket, destinationNetwork: String? = null) : AnalyticsEvent(
+        name = "send_completed",
+        properties = buildMap {
+            put("asset", asset)
+            put("network", network)
+            put("amount_bucket", amountBucket.value)
+            if (destinationNetwork != null) put("destination_network", destinationNetwork)
+            put("\$ip", false)
+        }
+    )
+
+    class SendFailed(asset: String, network: String, reason: String, destinationNetwork: String? = null) : AnalyticsEvent(
+        name = "send_failed",
+        properties = buildMap {
+            put("asset", asset)
+            put("network", network)
+            put("reason", reason)
+            if (destinationNetwork != null) put("destination_network", destinationNetwork)
+            put("\$ip", false)
+        }
+    )
+
+    // DApp
+
+    class DappOpened(dappHost: String, source: String, isKnownDapp: Boolean) : AnalyticsEvent(
+        name = "dapp_opened",
+        properties = mapOf(
+            "dapp_host" to dappHost,
+            "source" to source,
+            "is_known_dapp" to isKnownDapp,
+            "\$ip" to false
+        )
+    )
+
+    // Governance
+
+    class GovernanceVoteCast(
+        voteDirection: String,
+        network: String,
+        amountBucket: AmountBucket,
+        convictionLevel: String
+    ) : AnalyticsEvent(
+        name = "governance_vote_cast",
+        properties = mapOf(
+            "vote_direction" to voteDirection,
+            "network" to network,
+            "amount_bucket" to amountBucket.value,
+            "conviction_level" to convictionLevel,
+            "\$ip" to false
+        )
+    )
+
+    // General
+
+    class TabSwitched(tab: String) : AnalyticsEvent(
+        name = "tab_switched",
+        properties = mapOf(
+            "tab" to tab,
+            "\$ip" to false
+        )
+    )
+
+    class BuyInitiated(provider: String, asset: String, network: String) : AnalyticsEvent(
+        name = "buy_initiated",
+        properties = mapOf(
+            "provider" to provider,
+            "asset" to asset,
+            "network" to network,
+            "\$ip" to false
+        )
+    )
+
+    // Banner
+
+    class BannerClicked(bannerId: String, bannerTitle: String, screen: String) : AnalyticsEvent(
+        name = "banner_clicked",
+        properties = mapOf(
+            "banner_id" to bannerId,
+            "banner_title" to bannerTitle,
+            "screen" to screen,
+            "\$ip" to false
+        )
+    )
+
+    // Nova Card
+
+    object NovaCardOpened : AnalyticsEvent(
+        name = "nova_card_opened",
+        properties = mapOf(
+            "\$ip" to false
+        )
+    )
+
+    // NFT
+
+    class NftSectionOpened(nftCount: Int) : AnalyticsEvent(
+        name = "nft_section_opened",
+        properties = mapOf(
+            "nft_count" to nftCount,
+            "\$ip" to false
+        )
+    )
+}
+
+// Supporting Enums
+
+enum class AssetCategory(val value: String) {
+    NATIVE_TOKEN("native_token"),
+    STABLECOIN("stablecoin"),
+    WRAPPED_TOKEN("wrapped_token"),
+    OTHER("other")
+}
+
+enum class WalletCreationMethod(val value: String) {
+    CREATE("create"),
+    IMPORT_MNEMONIC("import_mnemonic"),
+    IMPORT_SEED("import_seed"),
+    IMPORT_JSON("import_json"),
+    IMPORT_LEDGER("import_ledger"),
+    IMPORT_PARITY_SIGNER("import_parity_signer"),
+    IMPORT_POLKADOT_VAULT("import_polkadot_vault"),
+    IMPORT_WATCH_ONLY("import_watch_only"),
+    CLOUD_BACKUP("cloud_backup")
+}
+
+enum class SwapSource(val value: String) {
+    ASSET_DETAILS("asset_details"),
+    MAIN_SCREEN("main_screen"),
+    DEEP_LINK("deep_link")
+}
+
+enum class SwapFailureReason(val value: String) {
+    INSUFFICIENT_BALANCE("insufficient_balance"),
+    SLIPPAGE_EXCEEDED("slippage_exceeded"),
+    NETWORK_ERROR("network_error"),
+    EXECUTION_REVERTED("execution_reverted"),
+    USER_CANCELLED("user_cancelled"),
+    SIGNING_UNAVAILABLE("signing_unavailable"),
+    UNKNOWN("unknown")
+}
+
+enum class SwapStage(val value: String) {
+    SETUP("setup"),
+    CONFIRM("confirm"),
+    EXECUTING("executing")
+}
+
+enum class FeatureId(val value: String) {
+    STAKING("staking"),
+    GOVERNANCE("governance"),
+    CROWDLOANS("crowdloans"),
+    DAPPS("dapps"),
+    NFT("nft"),
+    SWAP("swap"),
+    BUY("buy"),
+    SEND("send"),
+    RECEIVE("receive"),
+    SETTINGS("settings")
+}
+
+enum class OnboardingSource(val value: String) {
+    FRESH_INSTALL("fresh_install"),
+    ADD_WALLET("add_wallet")
+}
+
+enum class FirstAction(val value: String) {
+    SWAP("swap"),
+    SEND("send"),
+    RECEIVE("receive"),
+    STAKING("staking"),
+    DAPP("dapp"),
+    BUY("buy"),
+    OTHER("other")
+}
+
+enum class WalletCreationStep(val value: String) {
+    WELCOME("welcome"),
+    BACKUP("backup"),
+    CONFIRM_MNEMONIC("confirm_mnemonic"),
+    PIN_SETUP("pin_setup"),
+    NETWORK_SELECTION("network_selection"),
+    SEED_ENTRY("seed_entry"),
+    JSON_UPLOAD("json_upload"),
+    LEDGER_CONNECT("ledger_connect"),
+    OTHER("other")
+}

--- a/common/src/main/java/io/novafoundation/nova/common/data/analytics/AnalyticsOptOutManager.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/analytics/AnalyticsOptOutManager.kt
@@ -1,0 +1,68 @@
+package io.novafoundation.nova.common.data.analytics
+
+import io.novafoundation.nova.common.data.storage.Preferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+interface AnalyticsOptOutManager {
+
+    val isAnalyticsEnabled: Boolean
+
+    fun setAnalyticsEnabled(enabled: Boolean)
+
+    fun toggleAnalytics()
+
+    fun observeAnalyticsEnabled(): Flow<Boolean>
+
+    fun hasSeenAnalyticsPrompt(): Boolean
+
+    fun setAnalyticsPromptSeen()
+}
+
+class RealAnalyticsOptOutManager(
+    private val preferences: Preferences,
+    private val analyticsService: AnalyticsService
+) : AnalyticsOptOutManager {
+
+    companion object {
+        private const val PREF_ANALYTICS_ENABLED = "analytics_enabled"
+        private const val DEFAULT_ANALYTICS_ENABLED = false
+        private const val PREF_HAS_SEEN_ANALYTICS_PROMPT = "hasSeenAnalyticsPrompt"
+    }
+
+    private val analyticsEnabledFlow = MutableStateFlow(getPersistedState())
+
+    init {
+        // Sync initial state from persisted settings
+        analyticsService.isEnabled = getPersistedState()
+    }
+
+    override val isAnalyticsEnabled: Boolean
+        get() = analyticsEnabledFlow.value
+
+    override fun setAnalyticsEnabled(enabled: Boolean) {
+        preferences.putBoolean(PREF_ANALYTICS_ENABLED, enabled)
+        analyticsService.isEnabled = enabled
+        analyticsEnabledFlow.value = enabled
+    }
+
+    override fun toggleAnalytics() {
+        setAnalyticsEnabled(!isAnalyticsEnabled)
+    }
+
+    override fun observeAnalyticsEnabled(): Flow<Boolean> {
+        return analyticsEnabledFlow
+    }
+
+    override fun hasSeenAnalyticsPrompt(): Boolean {
+        return preferences.getBoolean(PREF_HAS_SEEN_ANALYTICS_PROMPT, false)
+    }
+
+    override fun setAnalyticsPromptSeen() {
+        preferences.putBoolean(PREF_HAS_SEEN_ANALYTICS_PROMPT, true)
+    }
+
+    private fun getPersistedState(): Boolean {
+        return preferences.getBoolean(PREF_ANALYTICS_ENABLED, DEFAULT_ANALYTICS_ENABLED)
+    }
+}

--- a/common/src/main/java/io/novafoundation/nova/common/data/analytics/AnalyticsService.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/analytics/AnalyticsService.kt
@@ -1,0 +1,8 @@
+package io.novafoundation.nova.common.data.analytics
+
+interface AnalyticsService {
+
+    var isEnabled: Boolean
+
+    fun track(event: AnalyticsEvent)
+}

--- a/common/src/main/java/io/novafoundation/nova/common/data/analytics/AssetCategoryClassifier.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/analytics/AssetCategoryClassifier.kt
@@ -1,0 +1,34 @@
+package io.novafoundation.nova.common.data.analytics
+
+object AssetCategoryClassifier {
+
+    private val STABLECOINS = setOf(
+        "USDT", "USDC", "DAI", "BUSD", "TUSD", "FRAX", "LUSD",
+        "USDP", "GUSD", "USDD", "CRVUSD", "GHO", "PYUSD",
+        "AUSD", "IUSD"
+    )
+
+    private val WRAPPED_TOKENS = setOf(
+        "WETH", "WBTC", "WBNB", "WAVAX", "WMATIC", "WFTM",
+        "WGLMR", "WMOVR", "WDOT", "WKSM"
+    )
+
+    private val NATIVE_TOKENS = setOf(
+        "DOT", "KSM", "ETH", "BTC", "BNB", "AVAX", "MATIC",
+        "SOL", "FTM", "GLMR", "MOVR", "ASTR", "ACA", "CFG",
+        "HDX", "INTR", "KINT", "PHA", "ZTG", "NODL", "RING",
+        "TEER", "TUR", "UNQ", "AZERO"
+    )
+
+    fun classify(symbol: String): AssetCategory {
+        val upperSymbol = symbol.uppercase()
+
+        return when {
+            NATIVE_TOKENS.contains(upperSymbol) -> AssetCategory.NATIVE_TOKEN
+            STABLECOINS.contains(upperSymbol) -> AssetCategory.STABLECOIN
+            WRAPPED_TOKENS.contains(upperSymbol) -> AssetCategory.WRAPPED_TOKEN
+            upperSymbol.startsWith("W") && NATIVE_TOKENS.contains(upperSymbol.removePrefix("W")) -> AssetCategory.WRAPPED_TOKEN
+            else -> AssetCategory.OTHER
+        }
+    }
+}

--- a/common/src/main/java/io/novafoundation/nova/common/data/analytics/NoOpAnalyticsService.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/analytics/NoOpAnalyticsService.kt
@@ -1,0 +1,10 @@
+package io.novafoundation.nova.common.data.analytics
+
+class NoOpAnalyticsService : AnalyticsService {
+
+    override var isEnabled: Boolean = false
+
+    override fun track(event: AnalyticsEvent) {
+        // No-op for tests
+    }
+}

--- a/common/src/main/java/io/novafoundation/nova/common/data/analytics/PostHogAnalyticsService.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/analytics/PostHogAnalyticsService.kt
@@ -1,0 +1,118 @@
+package io.novafoundation.nova.common.data.analytics
+
+import android.util.Log
+import io.novafoundation.nova.common.BuildConfig
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONObject
+import java.io.IOException
+import java.util.UUID
+
+class PostHogAnalyticsService(
+    private val okHttpClient: OkHttpClient,
+    private val apiKey: String,
+    private val host: String
+) : AnalyticsService {
+
+    companion object {
+        private const val TAG = "PostHogAnalytics"
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+
+    @Volatile
+    private var sessionId: String = UUID.randomUUID().toString()
+
+    @Volatile
+    override var isEnabled: Boolean = false
+        set(value) {
+            field = value
+            if (!value) {
+                // Rotate session ID on opt-out to prevent cross-session linking
+                sessionId = UUID.randomUUID().toString()
+            }
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, if (value) "Analytics enabled" else "Analytics disabled and reset")
+            }
+        }
+
+    fun initialize() {
+        sessionId = UUID.randomUUID().toString()
+
+        if (apiKey.isEmpty()) {
+            if (BuildConfig.DEBUG) {
+                Log.w(TAG, "Analytics API key not configured")
+            }
+            return
+        }
+
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "PostHog analytics initialized (enabled: $isEnabled)")
+        }
+    }
+
+    override fun track(event: AnalyticsEvent) {
+        if (!isEnabled) return
+        if (apiKey.isEmpty()) return
+
+        val props = event.properties.toMutableMap()
+        props["session_id"] = sessionId
+
+        // Suppress PII: prevent person profile creation and geo lookup
+        props["\$process_person_profile"] = false
+        props["\$geoip_disable"] = true
+        props["\$ip"] = false
+        // Suppress device fingerprinting properties
+        props["\$device_id"] = ""
+        props["\$device_type"] = ""
+        props["\$os"] = ""
+        props["\$os_version"] = ""
+        props["\$screen_height"] = ""
+        props["\$screen_width"] = ""
+        props["\$browser"] = ""
+        props["\$browser_version"] = ""
+        props["\$locale"] = ""
+        props["\$timezone"] = ""
+        props["\$app_version"] = ""
+        props["\$lib"] = ""
+        props["\$lib_version"] = ""
+
+        val body = JSONObject().apply {
+            put("api_key", apiKey)
+            put("event", event.name)
+            put("distinct_id", sessionId)
+            put("properties", JSONObject(props as Map<*, *>))
+            put("ip", "")
+        }
+
+        val request = Request.Builder()
+            .url("$host/capture/")
+            .header("X-Forwarded-For", "0.0.0.0")
+            .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+
+        // Fire and forget with async call
+        okHttpClient.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                if (BuildConfig.DEBUG) {
+                    Log.w(TAG, "Failed to send event: ${e.message}")
+                }
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                response.close()
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Event delivered: ${event.name} (status: ${response.code})")
+                }
+            }
+        })
+
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Event queued: ${event.name} properties: $props")
+        }
+    }
+}

--- a/common/src/main/java/io/novafoundation/nova/common/data/analytics/ValueBucketing.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/analytics/ValueBucketing.kt
@@ -1,0 +1,70 @@
+package io.novafoundation.nova.common.data.analytics
+
+import java.math.BigDecimal
+
+enum class AmountBucket(val value: String) {
+    UNDER_1("under_1"),
+    FROM_1_TO_10("1_to_10"),
+    FROM_10_TO_100("10_to_100"),
+    FROM_100_TO_1K("100_to_1k"),
+    FROM_1K_TO_10K("1k_to_10k"),
+    FROM_10K_TO_100K("10k_to_100k"),
+    OVER_100K("over_100k");
+
+    companion object {
+        fun from(usdAmount: BigDecimal): AmountBucket = when {
+            usdAmount < BigDecimal.ONE -> UNDER_1
+            usdAmount < BigDecimal.TEN -> FROM_1_TO_10
+            usdAmount < BigDecimal(100) -> FROM_10_TO_100
+            usdAmount < BigDecimal(1000) -> FROM_100_TO_1K
+            usdAmount < BigDecimal(10000) -> FROM_1K_TO_10K
+            usdAmount < BigDecimal(100_000) -> FROM_10K_TO_100K
+            else -> OVER_100K
+        }
+
+        fun from(usdValue: Double): AmountBucket = from(BigDecimal.valueOf(usdValue))
+    }
+}
+
+enum class DurationBucket(val value: String) {
+    UNDER_5S("under_5s"),
+    FROM_5S_TO_15S("5s_to_15s"),
+    FROM_15S_TO_30S("15s_to_30s"),
+    FROM_30S_TO_60S("30s_to_60s"),
+    FROM_1M_TO_5M("1m_to_5m"),
+    OVER_5M("over_5m");
+
+    companion object {
+        fun from(milliseconds: Long): DurationBucket {
+            val seconds = milliseconds / 1000
+            return when {
+                seconds < 5 -> UNDER_5S
+                seconds < 15 -> FROM_5S_TO_15S
+                seconds < 30 -> FROM_15S_TO_30S
+                seconds < 60 -> FROM_30S_TO_60S
+                seconds < 300 -> FROM_1M_TO_5M
+                else -> OVER_5M
+            }
+        }
+
+        fun from(seconds: Double): DurationBucket = from((seconds * 1000).toLong())
+    }
+}
+
+enum class SlippageBucket(val value: String) {
+    LOW("low"),
+    MEDIUM("medium"),
+    HIGH("high"),
+    CUSTOM("custom");
+
+    companion object {
+        fun from(percentage: Double): SlippageBucket = when {
+            percentage <= 0.5 -> LOW
+            percentage <= 1.0 -> MEDIUM
+            percentage <= 3.0 -> HIGH
+            else -> CUSTOM
+        }
+
+        fun from(slippagePercent: BigDecimal): SlippageBucket = from(slippagePercent.toDouble())
+    }
+}

--- a/common/src/main/java/io/novafoundation/nova/common/di/CommonApi.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/di/CommonApi.kt
@@ -8,6 +8,8 @@ import com.google.gson.Gson
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.format.AddressSchemeFormatter
 import io.novafoundation.nova.common.address.format.EthereumAddressFormat
+import io.novafoundation.nova.common.data.analytics.AnalyticsOptOutManager
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.GoogleApiAvailabilityProvider
 import io.novafoundation.nova.common.data.config.GlobalConfigDataSource
 import io.novafoundation.nova.common.data.memory.ComputationalCache
@@ -143,6 +145,10 @@ interface CommonApi {
     val deviceNetworkStateObserver: DeviceNetworkStateObserver
 
     val deviceIdProvider: DeviceIdProvider
+
+    val analyticsService: AnalyticsService
+
+    val analyticsOptOutManager: AnalyticsOptOutManager
 
     fun copyTextMixin(): CopyTextLauncher.Presentation
 

--- a/common/src/main/java/io/novafoundation/nova/common/di/modules/CommonModule.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/di/modules/CommonModule.kt
@@ -14,6 +14,10 @@ import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.CachingAddressIconGenerator
 import io.novafoundation.nova.common.address.StatelessAddressIconGenerator
 import io.novafoundation.nova.common.address.format.EthereumAddressFormat
+import io.novafoundation.nova.common.data.analytics.AnalyticsOptOutManager
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.PostHogAnalyticsService
+import io.novafoundation.nova.common.data.analytics.RealAnalyticsOptOutManager
 import io.novafoundation.nova.common.data.FileProviderImpl
 import io.novafoundation.nova.common.data.GoogleApiAvailabilityProvider
 import io.novafoundation.nova.common.data.RealGoogleApiAvailabilityProvider
@@ -114,6 +118,7 @@ import io.novafoundation.nova.common.view.input.selector.ListSelectorMixin
 import io.novafoundation.nova.common.view.input.selector.RealListSelectorMixinFactory
 import io.novasama.substrate_sdk_android.encrypt.Signer
 import io.novasama.substrate_sdk_android.icon.IconGenerator
+import okhttp3.OkHttpClient
 import java.security.SecureRandom
 import java.util.Random
 import javax.inject.Qualifier
@@ -505,5 +510,24 @@ class CommonModule {
     @ApplicationScope
     fun provideDeviceIdProvider(context: Context): DeviceIdProvider {
         return AndroidDeviceIdProvider(context)
+    }
+
+    @Provides
+    @ApplicationScope
+    fun provideAnalyticsService(okHttpClient: OkHttpClient): AnalyticsService {
+        return PostHogAnalyticsService(
+            okHttpClient = okHttpClient,
+            apiKey = BuildConfig.ANALYTICS_API_KEY,
+            host = "https://us.i.posthog.com"
+        ).also { it.initialize() }
+    }
+
+    @Provides
+    @ApplicationScope
+    fun provideAnalyticsOptOutManager(
+        preferences: Preferences,
+        analyticsService: AnalyticsService
+    ): AnalyticsOptOutManager {
+        return RealAnalyticsOptOutManager(preferences, analyticsService)
     }
 }

--- a/common/src/main/java/io/novafoundation/nova/common/utils/Event.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/Event.kt
@@ -21,9 +21,9 @@ class Event<T>(private val content: T) {
 }
 
 class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Observer<Event<T>> {
-    override fun onChanged(event: Event<T>?) {
-        event?.getContentIfNotHandled()?.let { value ->
-            onEventUnhandledContent(value)
+    override fun onChanged(value: Event<T>) {
+        value.getContentIfNotHandled()?.let { content ->
+            onEventUnhandledContent(content)
         }
     }
 }

--- a/common/src/main/java/io/novafoundation/nova/common/utils/LiveDatExt.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/utils/LiveDatExt.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.LiveDataScope
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.Transformations
+import androidx.lifecycle.distinctUntilChanged
 import kotlinx.coroutines.flow.Flow
 
 fun MutableLiveData<Event<Unit>>.sendEvent() {
@@ -135,8 +135,6 @@ fun <FROM, TO> LiveData<FROM>.switchMap(
 
     return result
 }
-
-fun <T> LiveData<T>.distinctUntilChanged() = Transformations.distinctUntilChanged(this)
 
 fun EditText.bindTo(liveData: MutableLiveData<String>, lifecycleOwner: LifecycleOwner) {
     onTextChanged {

--- a/common/src/main/java/io/novafoundation/nova/common/view/SlideShowView.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/view/SlideShowView.kt
@@ -68,9 +68,7 @@ class SlideShowView @JvmOverloads constructor(
         slideVisibilityLyfeCycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     }
 
-    override fun getLifecycle(): Lifecycle {
-        return slideVisibilityLyfeCycle
-    }
+    override fun getLifecycle(): Lifecycle = slideVisibilityLyfeCycle
 
     private fun setupSlideShow() {
         slideUpdateJob?.cancel()

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -2762,4 +2762,12 @@
     <string name="wallet_send_phishing_warning_title">Scam alert</string>
     <string name="wallet_transfer_details_title">Transfer details</string>
     <string name="yesterday">Yesterday</string>
+
+    <string name="settings_analytics_title">Anonymous Analytics</string>
+    <string name="settings_analytics_subtitle">Help improve Nova Wallet</string>
+
+    <string name="analytics_prompt_title">Help Improve Nova Wallet</string>
+    <string name="analytics_prompt_message">Share anonymous usage data to help us build a better wallet.\n\n• No personal data collected\n• No wallet addresses tracked\n• You can change this anytime in Settings</string>
+    <string name="analytics_prompt_enable">Enable Analytics</string>
+    <string name="analytics_prompt_later">Maybe Later</string>
 </resources>

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureDependencies.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureDependencies.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.format.AddressSchemeFormatter
 import io.novafoundation.nova.common.data.config.GlobalConfigDataSource
 import io.novafoundation.nova.common.data.memory.ComputationalCache
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.data.network.NetworkApiCreator
 import io.novafoundation.nova.common.data.network.rpc.SocketSingleRequestExecutor
@@ -79,6 +80,8 @@ import java.util.Random
 import javax.inject.Named
 
 interface AccountFeatureDependencies {
+
+    val analyticsService: AnalyticsService
 
     val maskableValueFormatterProvider: MaskableValueFormatterProvider
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/management/WalletManagmentViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/management/WalletManagmentViewModel.kt
@@ -2,6 +2,10 @@ package io.novafoundation.nova.feature_account_impl.presentation.account.managem
 
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.OnboardingSource
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.mixin.actionAwaitable.awaitAction
 import io.novafoundation.nova.common.mixin.actionAwaitable.confirmingOrDenyingAction
@@ -28,6 +32,7 @@ class WalletManagmentViewModel(
     private val accountListingMixinFactory: MetaAccountWithBalanceListingMixinFactory,
     cloudBackupChangingWarningMixinFactory: CloudBackupChangingWarningMixinFactory,
     listSelectorMixinFactory: ListSelectorMixin.Factory,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel() {
 
     val cloudBackupChangingWarningMixin = cloudBackupChangingWarningMixinFactory.create(viewModelScope)
@@ -106,10 +111,13 @@ class WalletManagmentViewModel(
     }
 
     private fun onImportWalletClicked() {
+        analyticsService.track(AnalyticsEvent.OnboardingStarted(OnboardingSource.ADD_WALLET))
         accountRouter.openImportOptionsScreen()
     }
 
     private fun onCreateNewWalletClicked() {
+        analyticsService.track(AnalyticsEvent.OnboardingStarted(OnboardingSource.ADD_WALLET))
+        analyticsService.track(AnalyticsEvent.WalletCreationMethodSelected(WalletCreationMethod.CREATE))
         cloudBackupChangingWarningMixin.launchChangingConfirmationIfNeeded {
             accountRouter.openCreateWallet(StartCreateWalletPayload(FlowType.SECOND_WALLET))
         }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/management/di/WalletManagmentModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/account/management/di/WalletManagmentModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
@@ -30,7 +31,8 @@ class WalletManagmentModule {
         actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
         metaAccountListingMixinFactory: MetaAccountWithBalanceListingMixinFactory,
         cloudBackupChangingWarningMixinFactory: CloudBackupChangingWarningMixinFactory,
-        listSelectorMixinFactory: ListSelectorMixin.Factory
+        listSelectorMixinFactory: ListSelectorMixin.Factory,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return WalletManagmentViewModel(
             interactor,
@@ -39,7 +41,8 @@ class WalletManagmentModule {
             actionAwaitableMixinFactory,
             metaAccountListingMixinFactory,
             cloudBackupChangingWarningMixinFactory,
-            listSelectorMixinFactory
+            listSelectorMixinFactory,
+            analyticsService
         )
     }
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/cloudBackup/createPassword/createWallet/CreateWalletBackupPasswordViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/cloudBackup/createPassword/createWallet/CreateWalletBackupPasswordViewModel.kt
@@ -1,6 +1,9 @@
 package io.novafoundation.nova.feature_account_impl.presentation.cloudBackup.createPassword.createWallet
 
 import io.novafoundation.nova.common.base.showError
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.view.bottomSheet.action.ActionBottomSheetLauncherFactory
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountInteractor
@@ -16,6 +19,7 @@ class CreateWalletBackupPasswordViewModel(
     actionBottomSheetLauncherFactory: ActionBottomSheetLauncherFactory,
     private val payload: CreateBackupPasswordPayload,
     private val accountInteractor: AccountInteractor,
+    private val analyticsService: AnalyticsService
 ) : BackupCreatePasswordViewModel(
     router,
     resourceManager,
@@ -25,7 +29,10 @@ class CreateWalletBackupPasswordViewModel(
 
     override suspend fun internalContinueClicked(password: String) {
         interactor.createAndBackupAccount(payload.walletName, password)
-            .onSuccess { continueBasedOnCodeStatus() }
+            .onSuccess {
+                analyticsService.track(AnalyticsEvent.WalletCreationCompleted(WalletCreationMethod.CLOUD_BACKUP))
+                continueBasedOnCodeStatus()
+            }
             .onFailure {
                 val titleAndMessage = mapWriteBackupFailureToUi(resourceManager, it)
                 showError(titleAndMessage)

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/cloudBackup/createPassword/createWallet/di/CreateWalletBackupPasswordModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/cloudBackup/createPassword/createWallet/di/CreateWalletBackupPasswordModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
@@ -28,7 +29,8 @@ class CreateWalletBackupPasswordModule {
         interactor: CreateCloudBackupPasswordInteractor,
         actionBottomSheetLauncherFactory: ActionBottomSheetLauncherFactory,
         payload: CreateBackupPasswordPayload,
-        accountInteractor: AccountInteractor
+        accountInteractor: AccountInteractor,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return CreateWalletBackupPasswordViewModel(
             router,
@@ -36,7 +38,8 @@ class CreateWalletBackupPasswordModule {
             interactor,
             actionBottomSheetLauncherFactory,
             payload,
-            accountInteractor
+            accountInteractor,
+            analyticsService
         )
     }
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/cloudBackup/enterPassword/restoreBackup/RestoreCloudBackupViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/cloudBackup/enterPassword/restoreBackup/RestoreCloudBackupViewModel.kt
@@ -1,6 +1,9 @@
 package io.novafoundation.nova.feature_account_impl.presentation.cloudBackup.enterPassword.restoreBackup
 
 import io.novafoundation.nova.common.base.showError
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.view.bottomSheet.action.ActionBottomSheetLauncherFactory
@@ -18,6 +21,7 @@ class RestoreCloudBackupViewModel(
     interactor: EnterCloudBackupInteractor,
     actionBottomSheetLauncherFactory: ActionBottomSheetLauncherFactory,
     actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
+    private val analyticsService: AnalyticsService
 ) : EnterCloudBackupPasswordViewModel(
     router,
     resourceManager,
@@ -28,7 +32,10 @@ class RestoreCloudBackupViewModel(
 
     override suspend fun continueInternal(password: String) {
         interactor.restoreCloudBackup(password)
-            .onSuccess { continueBasedOnCodeStatus() }
+            .onSuccess {
+                analyticsService.track(AnalyticsEvent.WalletCreationCompleted(WalletCreationMethod.CLOUD_BACKUP))
+                continueBasedOnCodeStatus()
+            }
             .onFailure {
                 val titleAndMessage = mapRestoreBackupFailureToUi(
                     resourceManager,

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/cloudBackup/enterPassword/restoreBackup/di/RestoreCloudBackupModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/cloudBackup/enterPassword/restoreBackup/di/RestoreCloudBackupModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
@@ -28,7 +29,8 @@ class RestoreCloudBackupModule {
         interactor: EnterCloudBackupInteractor,
         accountInteractor: AccountInteractor,
         actionBottomSheetLauncherFactory: ActionBottomSheetLauncherFactory,
-        actionAwaitableMixinFactory: ActionAwaitableMixin.Factory
+        actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return RestoreCloudBackupViewModel(
             accountInteractor,
@@ -36,7 +38,8 @@ class RestoreCloudBackupModule {
             resourceManager,
             interactor,
             actionBottomSheetLauncherFactory,
-            actionAwaitableMixinFactory
+            actionAwaitableMixinFactory,
+            analyticsService
         )
     }
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/importing/ImportAccountViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/importing/ImportAccountViewModel.kt
@@ -3,6 +3,9 @@ package io.novafoundation.nova.feature_account_impl.presentation.importing
 import android.content.Intent
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.mixin.MixinFactory
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.withFlagSet
@@ -10,6 +13,7 @@ import io.novafoundation.nova.common.view.ButtonState
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountAlreadyExistsException
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountInteractor
 import io.novafoundation.nova.feature_account_api.presenatation.account.add.ImportAccountPayload
+import io.novafoundation.nova.feature_account_api.presenatation.account.add.ImportType
 import io.novafoundation.nova.feature_account_impl.R
 import io.novafoundation.nova.feature_account_impl.data.mappers.mapAddAccountPayloadToAddAccountType
 import io.novafoundation.nova.feature_account_impl.presentation.AccountRouter
@@ -32,6 +36,7 @@ class ImportAccountViewModel(
     accountNameChooserFactory: MixinFactory<AccountNameChooserMixin.Presentation>,
     private val payload: ImportAccountPayload,
     private val importSourceFactory: ImportSourceFactory,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(),
     WithAccountNameChooserMixin {
 
@@ -74,7 +79,15 @@ class ImportAccountViewModel(
             val addAccountType = mapAddAccountPayloadToAddAccountType(payload.addAccountPayload, nameState)
 
             importSource.performImport(addAccountType)
-                .onSuccess { continueBasedOnCodeStatus() }
+                .onSuccess {
+                    val method = when (payload.importType) {
+                        is ImportType.Mnemonic -> WalletCreationMethod.IMPORT_MNEMONIC
+                        ImportType.Seed -> WalletCreationMethod.IMPORT_SEED
+                        ImportType.Json -> WalletCreationMethod.IMPORT_JSON
+                    }
+                    analyticsService.track(AnalyticsEvent.WalletCreationCompleted(method))
+                    continueBasedOnCodeStatus()
+                }
                 .onFailure(::handleCreateAccountError)
         }
     }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/importing/di/ImportAccountModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/importing/di/ImportAccountModule.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -67,6 +68,7 @@ class ImportAccountModule {
         accountNameChooserFactory: MixinFactory<AccountNameChooserMixin.Presentation>,
         importSourceFactory: ImportSourceFactory,
         payload: ImportAccountPayload,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return ImportAccountViewModel(
             interactor,
@@ -74,7 +76,8 @@ class ImportAccountModule {
             resourceManager,
             accountNameChooserFactory,
             payload,
-            importSourceFactory
+            importSourceFactory,
+            analyticsService
         )
     }
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/mnemonic/confirm/ConfirmMnemonicViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/mnemonic/confirm/ConfirmMnemonicViewModel.kt
@@ -2,6 +2,9 @@ package io.novafoundation.nova.feature_account_impl.presentation.mnemonic.confir
 
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.presentation.DescriptiveButtonState
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.added
@@ -30,7 +33,8 @@ class ConfirmMnemonicViewModel(
     private val deviceVibrator: DeviceVibrator,
     private val resourceManager: ResourceManager,
     private val config: ConfirmMnemonicConfig,
-    private val payload: ConfirmMnemonicPayload
+    private val payload: ConfirmMnemonicPayload,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel() {
 
     private val originMnemonic = payload.mnemonic
@@ -143,7 +147,10 @@ class ConfirmMnemonicViewModel(
                 val advancedEncryption = advancedEncryptionModel.toAdvancedEncryption()
 
                 addAccountInteractor.createAccount(mnemonicString, advancedEncryption, addAccountType)
-                    .onSuccess { continueBasedOnCodeStatus() }
+                    .onSuccess {
+                        analyticsService.track(AnalyticsEvent.WalletCreationCompleted(WalletCreationMethod.CREATE))
+                        continueBasedOnCodeStatus()
+                    }
                     .onFailure(::showAccountCreationError)
             }
         }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/mnemonic/confirm/di/ConfirmMnemonicModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/mnemonic/confirm/di/ConfirmMnemonicModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -38,9 +39,10 @@ class ConfirmMnemonicModule {
         deviceVibrator: DeviceVibrator,
         resourceManager: ResourceManager,
         config: ConfirmMnemonicConfig,
-        payload: ConfirmMnemonicPayload
+        payload: ConfirmMnemonicPayload,
+        analyticsService: AnalyticsService
     ): ViewModel {
-        return ConfirmMnemonicViewModel(interactor, addAccountInteractor, router, deviceVibrator, resourceManager, config, payload)
+        return ConfirmMnemonicViewModel(interactor, addAccountInteractor, router, deviceVibrator, resourceManager, config, payload, analyticsService)
     }
 
     @Provides

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/connect/finish/FinishImportParitySignerViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/connect/finish/FinishImportParitySignerViewModel.kt
@@ -1,5 +1,8 @@
 package io.novafoundation.nova.feature_account_impl.presentation.paritySigner.connect.finish
 
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.launchUnit
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountInteractor
@@ -14,7 +17,8 @@ class FinishImportParitySignerViewModel(
     private val resourceManager: ResourceManager,
     private val payload: ParitySignerAccountPayload,
     private val accountInteractor: AccountInteractor,
-    private val interactor: FinishImportParitySignerInteractor
+    private val interactor: FinishImportParitySignerInteractor,
+    private val analyticsService: AnalyticsService
 ) : CreateWalletNameViewModel(router, resourceManager) {
 
     override fun proceed(name: String) = launchUnit {
@@ -32,7 +36,14 @@ class FinishImportParitySignerViewModel(
             )
         }
 
-        result.onSuccess { continueBasedOnCodeStatus() }
+        result.onSuccess {
+                val method = when (payload.variant) {
+                    io.novafoundation.nova.feature_account_api.domain.model.PolkadotVaultVariant.PARITY_SIGNER -> WalletCreationMethod.IMPORT_PARITY_SIGNER
+                    io.novafoundation.nova.feature_account_api.domain.model.PolkadotVaultVariant.POLKADOT_VAULT -> WalletCreationMethod.IMPORT_POLKADOT_VAULT
+                }
+                analyticsService.track(AnalyticsEvent.WalletCreationCompleted(method))
+                continueBasedOnCodeStatus()
+            }
             .onFailure(::showError)
     }
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/connect/finish/di/FinishImportParitySignerModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/paritySigner/connect/finish/di/FinishImportParitySignerModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -46,14 +47,16 @@ class FinishImportParitySignerModule {
         resourceManager: ResourceManager,
         payload: ParitySignerAccountPayload,
         accountInteractor: AccountInteractor,
-        interactor: FinishImportParitySignerInteractor
+        interactor: FinishImportParitySignerInteractor,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return FinishImportParitySignerViewModel(
             router = router,
             resourceManager = resourceManager,
             payload = payload,
             accountInteractor = accountInteractor,
-            interactor = interactor
+            interactor = interactor,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/watchOnly/create/CreateWatchWalletViewModel.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/watchOnly/create/CreateWatchWalletViewModel.kt
@@ -4,6 +4,9 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.presentation.DescriptiveButtonState
 import io.novafoundation.nova.common.resources.ResourceManager
@@ -36,7 +39,8 @@ class CreateWatchWalletViewModel(
     private val interactor: CreateWatchWalletInteractor,
     private val accountInteractor: AccountInteractor,
     private val resourceManager: ResourceManager,
-    private val appLinksProvider: AppLinksProvider
+    private val appLinksProvider: AppLinksProvider,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel() {
 
     private val customPage = createCustomPage()
@@ -111,7 +115,10 @@ class CreateWatchWalletViewModel(
         }
 
         result
-            .onSuccess { continueBasedOnCodeStatus() }
+            .onSuccess {
+                analyticsService.track(AnalyticsEvent.WalletCreationCompleted(WalletCreationMethod.IMPORT_WATCH_ONLY))
+                continueBasedOnCodeStatus()
+            }
             .onFailure { it.printStackTrace(); showError(it) }
     }
 

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/watchOnly/create/di/CreateWatchWalletModule.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/presentation/watchOnly/create/di/CreateWatchWalletModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
@@ -41,9 +42,10 @@ class CreateWatchWalletModule {
         interactor: CreateWatchWalletInteractor,
         accountInteractor: AccountInteractor,
         resourceManager: ResourceManager,
-        appLinksProvider: AppLinksProvider
+        appLinksProvider: AppLinksProvider,
+        analyticsService: AnalyticsService
     ): ViewModel {
-        return CreateWatchWalletViewModel(router, addressInputMixinFactory, interactor, accountInteractor, resourceManager, appLinksProvider)
+        return CreateWatchWalletViewModel(router, addressInputMixinFactory, interactor, accountInteractor, resourceManager, appLinksProvider, analyticsService)
     }
 
     @Provides

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/di/AssetsFeatureDependencies.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/di/AssetsFeatureDependencies.kt
@@ -5,6 +5,7 @@ import coil.ImageLoader
 import com.google.gson.Gson
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.format.EthereumAddressFormat
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.memory.ComputationalCache
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.data.network.HttpExceptionHandler
@@ -123,6 +124,8 @@ import okhttp3.OkHttpClient
 import javax.inject.Named
 
 interface AssetsFeatureDependencies {
+
+    val analyticsService: AnalyticsService
 
     val maskingModeUseCase: MaskingModeUseCase
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/BalanceListViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/BalanceListViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.formatAmountToAmountModel
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.model.AssetViewMode
 import io.novafoundation.nova.common.data.model.MaskingMode
 import io.novafoundation.nova.common.data.network.AppLinksProvider
@@ -102,7 +104,8 @@ class BalanceListViewModel(
     private val novaCardRestrictionCheckMixin: NovaCardRestrictionCheckMixin,
     private val maskingModeUseCase: MaskingModeUseCase,
     private val giftsRestrictionCheckMixin: GiftsRestrictionCheckMixin,
-    private val appLinksProvider: AppLinksProvider
+    private val appLinksProvider: AppLinksProvider,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(), Browserable {
 
     private val maskableAmountFormatterFlow = maskableValueFormatterProvider.provideFormatter()
@@ -288,6 +291,10 @@ class BalanceListViewModel(
     }
 
     fun goToNftsClicked() {
+        launch {
+            val nftCount = nftsPreviews.first().totalNftsCount
+            analyticsService.track(AnalyticsEvent.NftSectionOpened(nftCount = nftCount))
+        }
         router.openNfts()
     }
 
@@ -403,6 +410,7 @@ class BalanceListViewModel(
 
     fun novaCardClicked() = launchUnit {
         novaCardRestrictionCheckMixin.checkRestrictionAndDo {
+            analyticsService.track(AnalyticsEvent.NovaCardOpened)
             router.openNovaCard()
         }
     }

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/di/BalanceListModule.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/list/di/BalanceListModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.data.repository.AssetsViewModeRepository
 import io.novafoundation.nova.common.di.scope.ScreenScope
@@ -104,7 +105,8 @@ class BalanceListModule {
         maskingModeUseCase: MaskingModeUseCase,
         fiatFormatter: FiatFormatter,
         giftsRestrictionCheckMixin: GiftsRestrictionCheckMixin,
-        appLinksProvider: AppLinksProvider
+        appLinksProvider: AppLinksProvider,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return BalanceListViewModel(
             promotionBannersMixinFactory = promotionBannersMixinFactory,
@@ -127,7 +129,8 @@ class BalanceListModule {
             maskingModeUseCase = maskingModeUseCase,
             fiatFormatter = fiatFormatter,
             giftsRestrictionCheckMixin = giftsRestrictionCheckMixin,
-            appLinksProvider = appLinksProvider
+            appLinksProvider = appLinksProvider,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmSendViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/ConfirmSendViewModel.kt
@@ -3,6 +3,10 @@ package io.novafoundation.nova.feature_assets.presentation.send.confirm
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AmountBucket
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.AssetCategoryClassifier
 import io.novafoundation.nova.common.mixin.api.Validatable
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.flowOf
@@ -15,6 +19,7 @@ import io.novafoundation.nova.common.view.ButtonState
 import io.novafoundation.nova.feature_account_api.data.mappers.mapChainToUi
 import io.novafoundation.nova.feature_account_api.data.model.FeeBase
 import io.novafoundation.nova.feature_account_api.domain.interfaces.SelectedAccountUseCase
+import io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount
 import io.novafoundation.nova.feature_account_api.domain.model.requireAddressIn
 import io.novafoundation.nova.feature_account_api.presenatation.account.AddressDisplayUseCase
 import io.novafoundation.nova.feature_account_api.presenatation.account.icon.createAddressModel
@@ -83,7 +88,8 @@ class ConfirmSendViewModel(
     private val extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
     feeLoaderMixinFactory: FeeLoaderMixinV2.Factory,
     val transferDraft: TransferDraft,
-    private val amountFormatter: AmountFormatter
+    private val amountFormatter: AmountFormatter,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(),
     ExternalActions by externalActions,
     Validatable by validationExecutor,
@@ -202,7 +208,7 @@ class ConfirmSendViewModel(
                 )
             },
         ) { validPayload ->
-            performTransfer(validPayload.transfer, validPayload.originFee, validPayload.crossChainFee)
+            trackSendInitiatedAndPerformTransfer(validPayload.transfer, validPayload.originFee, validPayload.crossChainFee)
         }
     }
 
@@ -246,17 +252,63 @@ class ConfirmSendViewModel(
         addressDisplayUseCase = addressDisplayUseCase.takeIf { resolveName }
     )
 
-    private fun performTransfer(
+    private fun trackSendInitiatedAndPerformTransfer(
         transfer: WeightedAssetTransfer,
         originFee: OriginFee,
         crossChainFee: FeeBase?
     ) = launch {
+        val assetName = transfer.originChainAsset.symbol.value
+        val networkName = transfer.originChain.name
+        val asset = assetFlow.first()
+        val usdAmount = asset.token.amountToFiat(transfer.amount)
+        val amountBucket = AmountBucket.from(usdAmount)
+
+        // Track SendInitiated here - after validation passes but before transfer
+        val destNetworkName = if (isCrossChain) destinationChain().name else null
+        analyticsService.track(
+            AnalyticsEvent.SendInitiated(
+                asset = assetName,
+                network = networkName,
+                destinationNetwork = destNetworkName,
+                assetCategory = AssetCategoryClassifier.classify(assetName),
+                amountBucket = amountBucket,
+                isCrossChain = isCrossChain
+            )
+        )
+
+        performTransfer(transfer, originFee, crossChainFee, assetName, networkName, amountBucket, destNetworkName)
+    }
+
+    private suspend fun performTransfer(
+        transfer: WeightedAssetTransfer,
+        originFee: OriginFee,
+        crossChainFee: FeeBase?,
+        assetName: String,
+        networkName: String,
+        amountBucket: AmountBucket,
+        destNetworkName: String? = null
+    ) {
+        val isWatchOnly = currentAccount.first().type == LightMetaAccount.Type.WATCH_ONLY
+
         sendInteractor.performTransfer(transfer, originFee, crossChainFee, viewModelScope)
             .onSuccess {
+                analyticsService.track(AnalyticsEvent.SendCompleted(assetName, networkName, amountBucket, destNetworkName))
+
                 showToast(resourceManager.getString(R.string.common_transaction_submitted))
 
                 startNavigation(it.submissionHierarchy) { finishSendFlow() }
-            }.onFailure(::showError)
+            }.onFailure {
+                val reason = when {
+                    isWatchOnly -> "signing_unavailable"
+                    it is io.novafoundation.nova.common.base.errors.SigningCancelledException -> "user_cancelled"
+                    it is java.io.IOException -> "network_error"
+                    it.message?.contains("signing") == true -> "signing_unavailable"
+                    else -> "unknown"
+                }
+                analyticsService.track(AnalyticsEvent.SendFailed(assetName, networkName, reason, destNetworkName))
+
+                showError(it)
+            }
 
         _transferSubmittingLiveData.value = false
     }

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/di/ConfirmSendModule.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/send/confirm/di/ConfirmSendModule.kt
@@ -7,6 +7,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -60,7 +61,8 @@ class ConfirmSendModule {
         walletUiUseCase: WalletUiUseCase,
         confirmSendHintsMixinFactory: ConfirmSendHintsMixinFactory,
         extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return ConfirmSendViewModel(
             interactor = interactor,
@@ -78,7 +80,8 @@ class ConfirmSendModule {
             transferDraft = transferDraft,
             hintsFactory = confirmSendHintsMixinFactory,
             extrinsicNavigationWrapper = extrinsicNavigationWrapper,
-            amountFormatter = amountFormatter
+            amountFormatter = amountFormatter,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-banners-api/src/main/java/io/novafoundation/nova/feature_banners_api/presentation/source/BannersSource.kt
+++ b/feature-banners-api/src/main/java/io/novafoundation/nova/feature_banners_api/presentation/source/BannersSource.kt
@@ -5,10 +5,12 @@ import io.novafoundation.nova.feature_banners_api.domain.PromotionBanner
 import kotlinx.coroutines.flow.Flow
 
 interface BannersSourceFactory {
-    fun create(bannersUrl: String, localisationUrl: String): BannersSource
+    fun create(bannersUrl: String, localisationUrl: String, screenName: String = "unknown"): BannersSource
 }
 
 interface BannersSource {
+    val screenName: String get() = "unknown"
+
     fun observeBanners(): Flow<List<PromotionBanner>>
 }
 
@@ -21,6 +23,6 @@ fun BannersSourceFactory.forDirectory(directory: String): BannersSource {
     return create(bannersUrl, localisationsUrl)
 }
 
-fun BannersSourceFactory.dappsSource() = create(BuildConfig.DAPPS_BANNERS_URL, BuildConfig.DAPPS_BANNERS_LOCALISATION_URL)
+fun BannersSourceFactory.dappsSource() = create(BuildConfig.DAPPS_BANNERS_URL, BuildConfig.DAPPS_BANNERS_LOCALISATION_URL, "dapps")
 
-fun BannersSourceFactory.assetsSource() = create(BuildConfig.ASSETS_BANNERS_URL, BuildConfig.ASSETS_BANNERS_LOCALISATION_URL)
+fun BannersSourceFactory.assetsSource() = create(BuildConfig.ASSETS_BANNERS_URL, BuildConfig.ASSETS_BANNERS_LOCALISATION_URL, "assets")

--- a/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/di/BannersFeatureDependencies.kt
+++ b/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/di/BannersFeatureDependencies.kt
@@ -5,6 +5,7 @@ import coil.ImageLoader
 import io.novafoundation.nova.common.data.network.NetworkApiCreator
 import io.novafoundation.nova.common.data.storage.Preferences
 import io.novafoundation.nova.common.resources.LanguagesHolder
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.utils.sequrity.AutomaticInteractionGate
 
 interface BannersFeatureDependencies {
@@ -20,4 +21,6 @@ interface BannersFeatureDependencies {
     val networkApiCreator: NetworkApiCreator
 
     val automaticInteractionGate: AutomaticInteractionGate
+
+    val analyticsService: AnalyticsService
 }

--- a/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/di/BannersFeatureModule.kt
+++ b/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/di/BannersFeatureModule.kt
@@ -6,6 +6,7 @@ import dagger.Module
 import dagger.Provides
 import io.novafoundation.nova.common.data.network.NetworkApiCreator
 import io.novafoundation.nova.common.data.storage.Preferences
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.resources.LanguagesHolder
 import io.novafoundation.nova.feature_banners_api.presentation.PromotionBannersMixinFactory
@@ -56,8 +57,9 @@ class BannersFeatureModule {
     fun providePromotionBannersMixinFactory(
         promotionBannersInteractor: PromotionBannersInteractor,
         imageLoader: ImageLoader,
-        context: Context
+        context: Context,
+        analyticsService: AnalyticsService
     ): PromotionBannersMixinFactory {
-        return RealPromotionBannersMixinFactory(imageLoader, context, promotionBannersInteractor)
+        return RealPromotionBannersMixinFactory(imageLoader, context, promotionBannersInteractor, analyticsService)
     }
 }

--- a/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/presentation/banner/PromotionBannersMixin.kt
+++ b/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/presentation/banner/PromotionBannersMixin.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import coil.ImageLoader
 import coil.request.ImageRequest
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.utils.launchDeepLink
 import io.novafoundation.nova.feature_banners_api.domain.PromotionBanner
 import io.novafoundation.nova.common.utils.scopeAsync
@@ -21,7 +23,8 @@ import kotlinx.coroutines.flow.map
 class RealPromotionBannersMixinFactory(
     private val imageLoader: ImageLoader,
     private val context: Context,
-    private val promotionBannersInteractor: PromotionBannersInteractor
+    private val promotionBannersInteractor: PromotionBannersInteractor,
+    private val analyticsService: AnalyticsService
 ) : PromotionBannersMixinFactory {
 
     override fun create(source: BannersSource, coroutineScope: CoroutineScope): PromotionBannersMixin {
@@ -30,7 +33,8 @@ class RealPromotionBannersMixinFactory(
             imageLoader,
             context,
             source,
-            coroutineScope
+            coroutineScope,
+            analyticsService
         )
     }
 }
@@ -40,7 +44,8 @@ class RealPromotionBannersMixin(
     private val imageLoader: ImageLoader,
     private val context: Context,
     private val bannersSource: BannersSource,
-    coroutineScope: CoroutineScope
+    coroutineScope: CoroutineScope,
+    private val analyticsService: AnalyticsService
 ) : PromotionBannersMixin, CoroutineScope by coroutineScope {
 
     override val bannersFlow = bannersSource.observeBanners()
@@ -55,6 +60,14 @@ class RealPromotionBannersMixin(
     }
 
     override fun startBannerAction(page: BannerPageModel) {
+        analyticsService.track(
+            AnalyticsEvent.BannerClicked(
+                bannerId = page.id,
+                bannerTitle = page.title,
+                screen = bannersSource.screenName
+            )
+        )
+
         val url = page.actionUrl ?: return
 
         context.launchDeepLink(url)

--- a/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/presentation/banner/source/RealBannersSource.kt
+++ b/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/presentation/banner/source/RealBannersSource.kt
@@ -9,7 +9,8 @@ import kotlinx.coroutines.flow.Flow
 class RealBannersSource(
     private val bannersUrl: String,
     private val localisationUrl: String,
-    private val bannersInteractor: PromotionBannersInteractor
+    private val bannersInteractor: PromotionBannersInteractor,
+    override val screenName: String
 ) : BannersSource {
 
     override fun observeBanners(): Flow<List<PromotionBanner>> {

--- a/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/presentation/banner/source/RealBannersSourceFactory.kt
+++ b/feature-banners-impl/src/main/java/io/novafoundation/nova/feature_banners_impl/presentation/banner/source/RealBannersSourceFactory.kt
@@ -8,7 +8,7 @@ class RealBannersSourceFactory(
     private val bannersInteractor: PromotionBannersInteractor
 ) : BannersSourceFactory {
 
-    override fun create(bannersUrl: String, localisationUrl: String): BannersSource {
-        return RealBannersSource(bannersUrl, localisationUrl, bannersInteractor)
+    override fun create(bannersUrl: String, localisationUrl: String, screenName: String): BannersSource {
+        return RealBannersSource(bannersUrl, localisationUrl, bannersInteractor, screenName)
     }
 }

--- a/feature-dapp-api/src/main/java/io/novafoundation/nova/feature_dapp_api/presentation/browser/main/DAppBrowserPayload.kt
+++ b/feature-dapp-api/src/main/java/io/novafoundation/nova/feature_dapp_api/presentation/browser/main/DAppBrowserPayload.kt
@@ -9,5 +9,5 @@ interface DAppBrowserPayload : Parcelable {
     class Tab(val id: String) : DAppBrowserPayload
 
     @Parcelize
-    class Address(val address: String) : DAppBrowserPayload
+    class Address(val address: String, val source: String = "address_bar") : DAppBrowserPayload
 }

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/di/DAppFeatureDependencies.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/di/DAppFeatureDependencies.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import coil.ImageLoader
 import com.google.gson.Gson
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.data.network.NetworkApiCreator
 import io.novafoundation.nova.common.data.providers.deviceid.DeviceIdProvider
@@ -42,6 +43,8 @@ import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.runtime.repository.RuntimeVersionsRepository
 
 interface DAppFeatureDependencies {
+
+    val analyticsService: AnalyticsService
 
     val amountFormatter: AmountFormatter
 

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/DAppBrowserViewModel.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/DAppBrowserViewModel.kt
@@ -3,6 +3,8 @@ package io.novafoundation.nova.feature_dapp_impl.presentation.browser.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.mixin.actionAwaitable.confirmingAction
 import io.novafoundation.nova.common.utils.Event
@@ -78,7 +80,8 @@ class DAppBrowserViewModel(
     private val selectedAccountUseCase: SelectedAccountUseCase,
     private val actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
     private val chainRegistry: ChainRegistry,
-    private val browserTabService: BrowserTabService
+    private val browserTabService: BrowserTabService,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(), Web3StateMachineHost {
 
     val removeFromFavouritesConfirmation = actionAwaitableMixinFactory.confirmingAction<RemoveFavouritesPayload>()
@@ -181,6 +184,29 @@ class DAppBrowserViewModel(
 
     fun onPageChanged(url: String?, title: String?) {
         updateCurrentPage(url ?: "", title, synchronizedWithBrowser = true)
+
+        if (url != null) {
+            trackDappOpened(url)
+        }
+    }
+
+    private var lastTrackedDappHost: String? = null
+
+    private fun trackDappOpened(url: String) = launch {
+        try {
+            val host = Urls.hostOf(url)
+            if (host == lastTrackedDappHost) return@launch
+            lastTrackedDappHost = host
+            val source = when (payload) {
+                is DAppBrowserPayload.Tab -> "tab"
+                is DAppBrowserPayload.Address -> payload.source
+                else -> "unknown"
+            }
+            val isKnown = dAppInteractor.getDAppInfo(url).metadata != null || source.startsWith("catalog_")
+            analyticsService.track(AnalyticsEvent.DappOpened(dappHost = host, source = source, isKnownDapp = isKnown))
+        } catch (_: Exception) {
+            // Skip tracking for malformed URLs
+        }
     }
 
     fun closeClicked() = launch {

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/deeplink/DAppDeepLinkHandler.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/deeplink/DAppDeepLinkHandler.kt
@@ -43,7 +43,7 @@ class DAppDeepLinkHandler(
         if (browserTabService.hasSelectedTab()) {
             browserTabService.createAndSelectTab(normalizedUrl)
         } else {
-            router.openDAppBrowser(DAppBrowserPayload.Address(url))
+            router.openDAppBrowser(DAppBrowserPayload.Address(url, source = "deep_link"))
         }
     }
 

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/di/DAppBrowserModule.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/browser/main/di/DAppBrowserModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -103,7 +104,8 @@ class DAppBrowserModule {
         dAppInteractor: DappInteractor,
         actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
         chainRegistry: ChainRegistry,
-        browserTabService: BrowserTabService
+        browserTabService: BrowserTabService,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return DAppBrowserViewModel(
             router = router,
@@ -116,7 +118,8 @@ class DAppBrowserModule {
             extensionStoreFactory = extensionStoreFactory,
             actionAwaitableMixinFactory = actionAwaitableMixinFactory,
             chainRegistry = chainRegistry,
-            browserTabService = browserTabService
+            browserTabService = browserTabService,
+            analyticsService = analyticsService
         )
     }
 }

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/favorites/DAppFavoritesViewModel.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/favorites/DAppFavoritesViewModel.kt
@@ -40,7 +40,7 @@ class DAppFavoritesViewModel(
     }
 
     fun openDApp(dapp: DappModel) {
-        router.openDAppBrowser(DAppBrowserPayload.Address(dapp.url))
+        router.openDAppBrowser(DAppBrowserPayload.Address(dapp.url, source = "favorites"))
     }
 
     fun onFavoriteClicked(dapp: DappModel) = launch {

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/main/MainDAppViewModel.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/main/MainDAppViewModel.kt
@@ -23,6 +23,7 @@ import io.novafoundation.nova.feature_dapp_impl.presentation.common.mapDAppCatal
 import io.novafoundation.nova.feature_dapp_impl.presentation.common.mapFavoriteDappToDappModel
 import io.novafoundation.nova.feature_dapp_impl.presentation.main.model.DAppCategoryState
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -89,7 +90,21 @@ class MainDAppViewModel(
     }
 
     fun dappClicked(dapp: DappModel) {
-        router.openDAppBrowser(DAppBrowserPayload.Address(dapp.url))
+        launch {
+            val source = determineDappSource(dapp)
+            router.openDAppBrowser(DAppBrowserPayload.Address(dapp.url, source = source))
+        }
+    }
+
+    private suspend fun determineDappSource(dapp: DappModel): String {
+        val catalog = groupedDAppsFlow.first()
+        val isPopular = catalog.popular.any { it.url == dapp.url }
+        if (isPopular) return "catalog_popular"
+
+        val category = catalog.categoriesWithDApps.entries.firstOrNull { (_, dapps) ->
+            dapps.any { it.url == dapp.url }
+        }
+        return category?.let { "catalog_${it.key.id}" } ?: "catalog_unknown"
     }
 
     fun searchClicked() {

--- a/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/search/DAppSearchViewModel.kt
+++ b/feature-dapp-impl/src/main/java/io/novafoundation/nova/feature_dapp_impl/presentation/search/DAppSearchViewModel.kt
@@ -138,7 +138,13 @@ class DAppSearchViewModel(
                     router.finishDappSearch()
                 }
 
-                SearchPayload.Request.OPEN_NEW_URL -> router.openDAppBrowser(DAppBrowserPayload.Address(newUrl))
+                SearchPayload.Request.OPEN_NEW_URL -> {
+                    val source = when (searchResult) {
+                        is DappSearchResult.Dapp -> "search"
+                        else -> "address_bar"
+                    }
+                    router.openDAppBrowser(DAppBrowserPayload.Address(newUrl, source = source))
+                }
             }
         }
     }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/GovernanceFeatureDependencies.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/di/GovernanceFeatureDependencies.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import coil.ImageLoader
 import com.google.gson.Gson
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.memory.ComputationalCache
 import io.novafoundation.nova.common.data.network.NetworkApiCreator
 import io.novafoundation.nova.common.data.repository.BannerVisibilityRepository
@@ -59,6 +60,8 @@ import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import javax.inject.Named
 
 interface GovernanceFeatureDependencies {
+
+    val analyticsService: AnalyticsService
 
     val maskableValueFormatterFactory: MaskableValueFormatterFactory
 

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmReferendumVoteViewModel.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/ConfirmReferendumVoteViewModel.kt
@@ -2,6 +2,9 @@ package io.novafoundation.nova.feature_governance_impl.presentation.referenda.vo
 
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AmountBucket
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.flowOf
 import io.novafoundation.nova.common.validation.ValidationExecutor
@@ -62,7 +65,8 @@ class ConfirmReferendumVoteViewModel(
     private val referendumFormatter: ReferendumFormatter,
     private val locksChangeFormatter: LocksChangeFormatter,
     private val extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
-    private val amountFormatter: AmountFormatter
+    private val amountFormatter: AmountFormatter,
+    private val analyticsService: AnalyticsService
 ) : ConfirmVoteViewModel(
     router,
     feeLoaderMixinFactory,
@@ -131,12 +135,22 @@ class ConfirmReferendumVoteViewModel(
 
     private fun performVote() = launch {
         val accountVote = accountVoteFlow.first()
+        val (chain, _) = governanceSharedState.chainAndAsset()
 
         val result = withContext(Dispatchers.Default) {
             interactor.voteReferendum(payload.referendumId, accountVote)
         }
 
         result.onSuccess {
+            analyticsService.track(
+                AnalyticsEvent.GovernanceVoteCast(
+                    voteDirection = payload.vote.voteType.name.lowercase(),
+                    network = chain.name,
+                    amountBucket = AmountBucket.from(assetFlow.first().token.amountToFiat(payload.vote.amount)),
+                    convictionLevel = payload.vote.conviction.name.lowercase()
+                )
+            )
+
             showToast(resourceManager.getString(R.string.common_transaction_submitted))
 
             startNavigation(it.submissionHierarchy) { router.backToReferendumDetails() }

--- a/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/di/ConfirmReferendumVoteModule.kt
+++ b/feature-governance-impl/src/main/java/io/novafoundation/nova/feature_governance_impl/presentation/referenda/vote/confirm/di/ConfirmReferendumVoteModule.kt
@@ -7,6 +7,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
@@ -52,7 +53,8 @@ class ConfirmReferendumVoteModule {
         referendumFormatter: ReferendumFormatter,
         locksChangeFormatter: LocksChangeFormatter,
         extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return ConfirmReferendumVoteViewModel(
             router = router,
@@ -72,7 +74,8 @@ class ConfirmReferendumVoteModule {
             referendumFormatter = referendumFormatter,
             locksChangeFormatter = locksChangeFormatter,
             extrinsicNavigationWrapper = extrinsicNavigationWrapper,
-            amountFormatter = amountFormatter
+            amountFormatter = amountFormatter,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/di/LedgerFeatureDependencies.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/di/LedgerFeatureDependencies.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_ledger_impl.di
 import coil.ImageLoader
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.format.AddressSchemeFormatter
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.data.network.NetworkApiCreator
 import io.novafoundation.nova.common.data.secrets.v2.SecretStoreV2
@@ -31,6 +32,8 @@ import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.network.rpc.RpcCalls
 
 interface LedgerFeatureDependencies {
+
+    val analyticsService: AnalyticsService
 
     val amountFormatter: AmountFormatter
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/generic/finish/FinishImportGenericLedgerViewModel.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/generic/finish/FinishImportGenericLedgerViewModel.kt
@@ -1,5 +1,8 @@
 package io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.generic.finish
 
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountInteractor
 import io.novafoundation.nova.feature_account_api.presenatation.account.createName.CreateWalletNameViewModel
@@ -13,13 +16,17 @@ class FinishImportGenericLedgerViewModel(
     private val resourceManager: ResourceManager,
     private val payload: FinishImportGenericLedgerPayload,
     private val accountInteractor: AccountInteractor,
-    private val interactor: FinishImportGenericLedgerInteractor
+    private val interactor: FinishImportGenericLedgerInteractor,
+    private val analyticsService: AnalyticsService
 ) : CreateWalletNameViewModel(router, resourceManager) {
 
     override fun proceed(name: String) {
         launch {
             interactor.createWallet(name, payload.substrateAccount.toDomain(), payload.evmAccount?.toDomain())
-                .onSuccess { continueBasedOnCodeStatus() }
+                .onSuccess {
+                    analyticsService.track(AnalyticsEvent.WalletCreationCompleted(WalletCreationMethod.IMPORT_LEDGER))
+                    continueBasedOnCodeStatus()
+                }
                 .onFailure(::showError)
         }
     }

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/generic/finish/di/FinishImportGenericLedgerModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/generic/finish/di/FinishImportGenericLedgerModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -40,14 +41,16 @@ class FinishImportGenericLedgerModule {
         resourceManager: ResourceManager,
         payload: FinishImportGenericLedgerPayload,
         accountInteractor: AccountInteractor,
-        interactor: FinishImportGenericLedgerInteractor
+        interactor: FinishImportGenericLedgerInteractor,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return FinishImportGenericLedgerViewModel(
             router = router,
             resourceManager = resourceManager,
             payload = payload,
             accountInteractor = accountInteractor,
-            interactor = interactor
+            interactor = interactor,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/finish/FinishImportLedgerViewModel.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/finish/FinishImportLedgerViewModel.kt
@@ -1,5 +1,8 @@
 package io.novafoundation.nova.feature_ledger_impl.presentation.account.connect.legacy.finish
 
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountInteractor
 import io.novafoundation.nova.feature_account_api.presenatation.account.createName.CreateWalletNameViewModel
@@ -14,13 +17,17 @@ class FinishImportLedgerViewModel(
     private val resourceManager: ResourceManager,
     private val payload: FinishImportLedgerPayload,
     private val accountInteractor: AccountInteractor,
-    private val interactor: FinishImportLedgerInteractor
+    private val interactor: FinishImportLedgerInteractor,
+    private val analyticsService: AnalyticsService
 ) : CreateWalletNameViewModel(router, resourceManager) {
 
     override fun proceed(name: String) {
         launch {
             interactor.createWallet(name, constructAccountsMap())
-                .onSuccess { continueBasedOnCodeStatus() }
+                .onSuccess {
+                    analyticsService.track(AnalyticsEvent.WalletCreationCompleted(WalletCreationMethod.IMPORT_LEDGER))
+                    continueBasedOnCodeStatus()
+                }
                 .onFailure(::showError)
         }
     }

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/finish/di/FinishImportLedgerModule.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/presentation/account/connect/legacy/finish/di/FinishImportLedgerModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -37,14 +38,16 @@ class FinishImportLedgerModule {
         resourceManager: ResourceManager,
         payload: FinishImportLedgerPayload,
         accountInteractor: AccountInteractor,
-        interactor: FinishImportLedgerInteractor
+        interactor: FinishImportLedgerInteractor,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return FinishImportLedgerViewModel(
             router = router,
             resourceManager = resourceManager,
             payload = payload,
             accountInteractor = accountInteractor,
-            interactor = interactor
+            interactor = interactor,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/di/OnboardingFeatureDependencies.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/di/OnboardingFeatureDependencies.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_onboarding_impl.di
 
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.mixin.api.CustomDialogDisplayer
@@ -35,4 +36,6 @@ interface OnboardingFeatureDependencies {
     val cloudBackupService: CloudBackupService
 
     val cloudBackupChangingWarningMixinFactory: CloudBackupChangingWarningMixinFactory
+
+    val analyticsService: AnalyticsService
 }

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/WelcomeViewModel.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/WelcomeViewModel.kt
@@ -3,6 +3,10 @@ package io.novafoundation.nova.feature_onboarding_impl.presentation.welcome
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.OnboardingSource
+import io.novafoundation.nova.common.data.analytics.WalletCreationMethod
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.mixin.api.Browserable
 import io.novafoundation.nova.common.utils.Event
@@ -15,7 +19,8 @@ class WelcomeViewModel(
     private val router: OnboardingRouter,
     private val appLinksProvider: AppLinksProvider,
     private val addAccountPayload: AddAccountPayload,
-    updateNotificationsInteractor: UpdateNotificationsInteractor
+    updateNotificationsInteractor: UpdateNotificationsInteractor,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(),
     Browserable {
 
@@ -25,9 +30,15 @@ class WelcomeViewModel(
 
     init {
         updateNotificationsInteractor.allowInAppUpdateCheck()
+
+        // Only track for add_wallet flow — fresh install can't fire (user hasn't consented to analytics yet)
+        if (shouldShowBack) {
+            analyticsService.track(AnalyticsEvent.OnboardingStarted(OnboardingSource.ADD_WALLET))
+        }
     }
 
     fun createAccountClicked() {
+        analyticsService.track(AnalyticsEvent.WalletCreationMethodSelected(WalletCreationMethod.CREATE))
         when (addAccountPayload) {
             is AddAccountPayload.MetaAccount -> router.openCreateFirstWallet()
             is AddAccountPayload.ChainAccount -> router.openMnemonicScreen(accountName = null, addAccountPayload)
@@ -35,6 +46,7 @@ class WelcomeViewModel(
     }
 
     fun importAccountClicked() {
+        analyticsService.track(AnalyticsEvent.WalletCreationMethodSelected(WalletCreationMethod.IMPORT_MNEMONIC))
         router.openImportOptionsScreen()
     }
 

--- a/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/di/WelcomeModule.kt
+++ b/feature-onboarding-impl/src/main/java/io/novafoundation/nova/feature_onboarding_impl/presentation/welcome/di/WelcomeModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -28,13 +29,15 @@ class WelcomeModule {
         addAccountPayload: AddAccountPayload,
         updateNotificationsInteractor: UpdateNotificationsInteractor,
         ledgerMigrationTracker: LedgerMigrationTracker,
+        analyticsService: AnalyticsService,
     ): ViewModel {
         return WelcomeViewModel(
             shouldShowBack,
             router,
             appLinksProvider,
             addAccountPayload,
-            updateNotificationsInteractor
+            updateNotificationsInteractor,
+            analyticsService
         )
     }
 

--- a/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/di/SettingsFeatureDependencies.kt
+++ b/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/di/SettingsFeatureDependencies.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_settings_impl.di
 
 import android.content.Context
 import coil.ImageLoader
+import io.novafoundation.nova.common.data.analytics.AnalyticsOptOutManager
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.data.network.coingecko.CoinGeckoLinkParser
@@ -44,6 +45,8 @@ import io.novafoundation.nova.runtime.repository.PreConfiguredChainsRepository
 import io.novafoundation.nova.feature_assets.domain.tokens.add.validations.CoinGeckoLinkValidationFactory
 
 interface SettingsFeatureDependencies {
+
+    val analyticsOptOutManager: AnalyticsOptOutManager
 
     val maskingModeUseCase: MaskingModeUseCase
 

--- a/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/presentation/settings/SettingsFragment.kt
+++ b/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/presentation/settings/SettingsFragment.kt
@@ -58,6 +58,8 @@ class SettingsFragment : BaseFragment<SettingsViewModel, FragmentSettingsBinding
 
         binder.settingsWalletConnect.setOnClickListener { viewModel.walletConnectClicked() }
 
+        binder.settingsAnalytics.setOnClickListener { viewModel.changeAnalytics() }
+
         binder.settingsAvatar.setOnClickListener { viewModel.selectedWalletClicked() }
     }
 
@@ -123,6 +125,10 @@ class SettingsFragment : BaseFragment<SettingsViewModel, FragmentSettingsBinding
         viewModel.openEmailEvent.observeEvent { requireContext().sendEmailIntent(it) }
 
         viewModel.walletConnectSessionsUi.observe(binder.settingsWalletConnect::setValue)
+
+        viewModel.analyticsEnabledState.observe {
+            binder.settingsAnalytics.setChecked(it)
+        }
     }
 
     override fun onResume() {

--- a/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/presentation/settings/SettingsViewModel.kt
+++ b/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/presentation/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_settings_impl.presentation.settings
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsOptOutManager
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.domain.usecase.MaskingModeUseCase
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
@@ -55,7 +56,8 @@ class SettingsViewModel(
     private val twoFactorVerificationService: TwoFactorVerificationService,
     private val biometricService: BiometricService,
     private val pushNotificationsInteractor: PushNotificationsInteractor,
-    private val maskingModeUseCase: MaskingModeUseCase
+    private val maskingModeUseCase: MaskingModeUseCase,
+    private val analyticsOptOutManager: AnalyticsOptOutManager
 ) : BaseViewModel(), Browserable {
 
     val confirmationAwaitableAction = actionAwaitableMixinFactory.confirmingAction<ConfirmationDialogInfo>()
@@ -91,6 +93,8 @@ class SettingsViewModel(
     val safeModeStatus = safeModeService.safeModeStatusFlow()
 
     val hideBalancesOnLaunchState = maskingModeUseCase.observeHideBalancesOnLaunchEnabled()
+
+    val analyticsEnabledState = analyticsOptOutManager.observeAnalyticsEnabled()
 
     override val openBrowserEvent = MutableLiveData<Event<String>>()
 
@@ -204,6 +208,10 @@ class SettingsViewModel(
 
     fun changeHideBalances() {
         maskingModeUseCase.toggleHideBalancesOnLaunch()
+    }
+
+    fun changeAnalytics() {
+        analyticsOptOutManager.toggleAnalytics()
     }
 
     fun changePinCodeClicked() {

--- a/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/presentation/settings/di/SettingsModule.kt
+++ b/feature-settings-impl/src/main/java/io/novafoundation/nova/feature_settings_impl/presentation/settings/di/SettingsModule.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsOptOutManager
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -51,7 +52,8 @@ class SettingsModule {
         twoFactorVerificationService: TwoFactorVerificationService,
         biometricService: BiometricService,
         pushNotificationsInteractor: PushNotificationsInteractor,
-        maskingModeUseCase: MaskingModeUseCase
+        maskingModeUseCase: MaskingModeUseCase,
+        analyticsOptOutManager: AnalyticsOptOutManager
     ): ViewModel {
         return SettingsViewModel(
             languageUseCase,
@@ -67,7 +69,8 @@ class SettingsModule {
             twoFactorVerificationService,
             biometricService,
             pushNotificationsInteractor,
-            maskingModeUseCase
+            maskingModeUseCase,
+            analyticsOptOutManager
         )
     }
 

--- a/feature-settings-impl/src/main/res/layout/fragment_settings.xml
+++ b/feature-settings-impl/src/main/res/layout/fragment_settings.xml
@@ -117,6 +117,13 @@
                 app:icon="@drawable/ic_settings_appearance"
                 app:title="@string/appearance_title" />
 
+            <io.novafoundation.nova.common.view.settings.SettingsSwitcherView
+                android:id="@+id/settingsAnalytics"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:icon="@drawable/ic_planet_outline"
+                app:title="@string/settings_analytics_title" />
+
         </io.novafoundation.nova.common.view.settings.SettingsGroupView>
 
         <io.novafoundation.nova.common.view.settings.SettingsGroupHeaderView

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureDependencies.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureDependencies.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import coil.ImageLoader
 import com.google.gson.Gson
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.config.GlobalConfigDataSource
 import io.novafoundation.nova.common.data.memory.ComputationalCache
 import io.novafoundation.nova.common.data.network.AppLinksProvider
@@ -78,6 +79,8 @@ import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import javax.inject.Named
 
 interface StakingFeatureDependencies {
+
+    val analyticsService: AnalyticsService
 
     val maskableValueFormatterFactory: MaskableValueFormatterFactory
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/NominationPoolsConfirmUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/NominationPoolsConfirmUnbondViewModel.kt
@@ -2,6 +2,9 @@ package io.novafoundation.nova.feature_staking_impl.presentation.nominationPools
 
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AmountBucket
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.mixin.api.Validatable
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.validation.ValidationExecutor
@@ -50,7 +53,8 @@ class NominationPoolsConfirmUnbondViewModel(
     private val extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
     assetUseCase: AssetUseCase,
     hintsFactory: NominationPoolsUnbondHintsFactory,
-    private val amountFormatter: AmountFormatter
+    private val amountFormatter: AmountFormatter,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(),
     ExternalActions by externalActions,
     Validatable by validationExecutor,
@@ -132,14 +136,30 @@ class NominationPoolsConfirmUnbondViewModel(
     private fun sendTransaction(validationPayload: NominationPoolsUnbondValidationPayload) = launch {
         val token = validationPayload.asset.token
         val amountInPlanks = token.planksFromAmount(payload.amount)
+        val network = stakingSharedState.chain().name
+        val stakingType = "nomination_pools"
+        val usdAmount = token.amountToFiat(payload.amount)
+        val amountBucket = AmountBucket.from(usdAmount)
+
+        analyticsService.track(AnalyticsEvent.UnstakeInitiated(stakingType, network, amountBucket))
 
         interactor.unbond(validationPayload.poolMember, amountInPlanks)
             .onSuccess {
+                analyticsService.track(AnalyticsEvent.UnstakeCompleted(stakingType, network, amountBucket))
+
                 showToast(resourceManager.getString(R.string.common_transaction_submitted))
 
                 startNavigation(it.submissionHierarchy) { finishFlow() }
             }
-            .onFailure(::showError)
+            .onFailure {
+                val reason = when {
+                    it is io.novafoundation.nova.common.base.errors.SigningCancelledException -> "user_cancelled"
+                    it is java.io.IOException -> "network_error"
+                    else -> "unknown"
+                }
+                analyticsService.track(AnalyticsEvent.UnstakeFailed(stakingType, network, reason))
+                showError(it)
+            }
 
         _showNextProgress.value = false
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/di/NominationPoolsConfirmUnbondModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/nominationPools/unbond/confirm/di/NominationPoolsConfirmUnbondModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
@@ -45,7 +46,8 @@ class NominationPoolsConfirmUnbondModule {
         assetUseCase: AssetUseCase,
         hintsFactory: NominationPoolsUnbondHintsFactory,
         extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return NominationPoolsConfirmUnbondViewModel(
             router = router,
@@ -61,7 +63,8 @@ class NominationPoolsConfirmUnbondModule {
             assetUseCase = assetUseCase,
             hintsFactory = hintsFactory,
             extrinsicNavigationWrapper = extrinsicNavigationWrapper,
-            amountFormatter = amountFormatter
+            amountFormatter = amountFormatter,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/confirm/ConfirmMultiStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/confirm/ConfirmMultiStakingViewModel.kt
@@ -2,6 +2,9 @@ package io.novafoundation.nova.feature_staking_impl.presentation.staking.start.c
 
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.AmountBucket
 import io.novafoundation.nova.common.mixin.api.Validatable
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.flowOfAll
@@ -15,6 +18,8 @@ import io.novafoundation.nova.feature_account_api.presenatation.navigation.Extri
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.chain
 import io.novafoundation.nova.feature_staking_impl.data.components
+import io.novafoundation.nova.feature_staking_impl.data.stakingType
+import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.selection.stakeAmount
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.StakingStartedDetectionService
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.StartMultiStakingInteractor
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.activateDetection
@@ -56,10 +61,11 @@ class ConfirmMultiStakingViewModel(
     selectionTypeProviderFactory: MultiStakingSelectionTypeProviderFactory,
     assetUseCase: ArbitraryAssetUseCase,
     walletUiUseCase: WalletUiUseCase,
-    selectedAccountUseCase: SelectedAccountUseCase,
+    private val selectedAccountUseCase: SelectedAccountUseCase,
     private val stakingStartedDetectionService: StakingStartedDetectionService,
     private val extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
-    private val amountFormatter: AmountFormatter
+    private val amountFormatter: AmountFormatter,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(),
     ExternalActions by externalActions,
     Validatable by validationExecutor,
@@ -159,15 +165,36 @@ class ConfirmMultiStakingViewModel(
     }
 
     private fun sendTransaction(validationPayload: StartMultiStakingValidationPayload) = launch {
+        val selection = validationPayload.selection
+        val stakingTypeName = selection.stakingOption.stakingType.name.lowercase()
+        val networkName = selection.stakingOption.chain.name
+        val asset = assetFlow.first()
+        val usdAmount = asset.token.amountToFiat(selection.stakeAmount())
+        val amountBucket = AmountBucket.from(usdAmount)
+
+        analyticsService.track(AnalyticsEvent.StakingInitiated(stakingTypeName, networkName, amountBucket))
+
         stakingStartedDetectionService.pauseDetection(viewModelScope)
 
         interactor.startStaking(validationPayload.selection)
             .onSuccess {
+                analyticsService.track(AnalyticsEvent.StakingConfirmed(stakingTypeName, networkName, amountBucket))
+                // StakingCompleted removed - fires at same time as Confirmed, no on-chain tracking available
+
                 showToast(resourceManager.getString(R.string.common_transaction_submitted))
 
                 startNavigation(it.submissionHierarchy) { finishFlow() }
             }
             .onFailure {
+                val isWatchOnly = selectedAccountUseCase.getSelectedMetaAccount().type == io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount.Type.WATCH_ONLY
+                val reason = when {
+                    isWatchOnly -> "signing_unavailable"
+                    it is io.novafoundation.nova.common.base.errors.SigningCancelledException -> "user_cancelled"
+                    it is java.io.IOException -> "network_error"
+                    else -> "unknown"
+                }
+                analyticsService.track(AnalyticsEvent.StakingFailed(stakingTypeName, networkName, reason))
+
                 showError(it)
 
                 stakingStartedDetectionService.activateDetection(viewModelScope)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/confirm/di/ConfirmMultiStakingModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/confirm/di/ConfirmMultiStakingModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -68,7 +69,8 @@ class ConfirmMultiStakingModule {
         selectionTypeProviderFactory: MultiStakingSelectionTypeProviderFactory,
         stakingStartedDetectionService: StakingStartedDetectionService,
         extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return ConfirmMultiStakingViewModel(
             router = router,
@@ -85,7 +87,8 @@ class ConfirmMultiStakingModule {
             selectionTypeProviderFactory = selectionTypeProviderFactory,
             stakingStartedDetectionService = stakingStartedDetectionService,
             extrinsicNavigationWrapper = extrinsicNavigationWrapper,
-            amountFormatter = amountFormatter
+            amountFormatter = amountFormatter,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
@@ -5,6 +5,8 @@ import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.domain.isLoading
 import io.novafoundation.nova.common.domain.mapLoading
@@ -102,7 +104,8 @@ class StartStakingLandingViewModel(
     private val stakingStartedDetectionService: StakingStartedDetectionService,
     private val chainRegistry: ChainRegistry,
     private val contextManager: ContextManager,
-    private val amountFormatter: AmountFormatter
+    private val amountFormatter: AmountFormatter,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(),
     Browserable,
     Validatable by validationExecutor {
@@ -163,6 +166,13 @@ class StartStakingLandingViewModel(
         launchSync()
 
         closeOnStakingStarted()
+
+        trackStakingFlowOpened()
+    }
+
+    private fun trackStakingFlowOpened() = launch {
+        val chain = chainRegistry.getChain(availableStakingOptionsPayload.chainId)
+        analyticsService.track(AnalyticsEvent.StakingFlowOpened(chain.name, "staking"))
     }
 
     fun back() {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/di/StartStakingLandingModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/di/StartStakingLandingModule.kt
@@ -10,6 +10,7 @@ import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.resources.ContextManager
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.validation.ValidationExecutor
@@ -57,7 +58,8 @@ class StartStakingLandingModule {
         stakingStartedDetectionService: StakingStartedDetectionService,
         chainRegistry: ChainRegistry,
         contextManager: ContextManager,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return StartStakingLandingViewModel(
             router = router,
@@ -72,7 +74,8 @@ class StartStakingLandingModule {
             stakingStartedDetectionService = stakingStartedDetectionService,
             chainRegistry = chainRegistry,
             contextManager = contextManager,
-            amountFormatter = amountFormatter
+            amountFormatter = amountFormatter,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeViewModel.kt
@@ -2,6 +2,8 @@ package io.novafoundation.nova.feature_staking_impl.presentation.staking.start.s
 
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.mixin.actionAwaitable.ConfirmationDialogInfo
 import io.novafoundation.nova.common.mixin.actionAwaitable.confirmingAction
@@ -48,7 +50,8 @@ class SetupStakingTypeViewModel(
     private val setupStakingTypeFlowExecutorFactory: SetupStakingTypeFlowExecutorFactory,
     private val setupStakingTypeSelectionMixinFactory: SetupStakingTypeSelectionMixinFactory,
     private val actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
-    chainRegistry: ChainRegistry
+    chainRegistry: ChainRegistry,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(), Validatable by validationExecutor {
 
     val closeConfirmationAction = actionAwaitableMixinFactory.confirmingAction<ConfirmationDialogInfo>()
@@ -156,12 +159,14 @@ class SetupStakingTypeViewModel(
             val compoundStakingTypeDetailsProvider = compoundStakingTypeDetailsProviderFlow.first()
             val validationSystem = compoundStakingTypeDetailsProvider.getValidationSystem(stakingType)
             val payload = compoundStakingTypeDetailsProvider.getValidationPayload(stakingType) ?: return@launch
+            val network = chainWithAssetFlow.first().chain.name
 
             validationExecutor.requireValid(
                 validationSystem = validationSystem,
                 payload = payload,
                 validationFailureTransformer = { handleSetupStakingTypeValidationFailure(chainAsset, it, resourceManager) },
             ) {
+                analyticsService.track(AnalyticsEvent.StakingTypeSelected(stakingType.name.lowercase(), network))
                 setRecommendedSelection(enteredAmount, stakingType)
             }
         }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/di/SetupStakingTypeModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/di/SetupStakingTypeModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
@@ -73,7 +74,8 @@ class SetupStakingTypeModule {
         setupStakingTypeSelectionMixinFactory: SetupStakingTypeSelectionMixinFactory,
         chainRegistry: ChainRegistry,
         actionAwaitableMixinFactory: ActionAwaitableMixin.Factory,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return SetupStakingTypeViewModel(
             stakingRouter,
@@ -88,7 +90,8 @@ class SetupStakingTypeModule {
             setupStakingTypeFlowExecutorFactory,
             setupStakingTypeSelectionMixinFactory,
             actionAwaitableMixinFactory,
-            chainRegistry
+            chainRegistry,
+            analyticsService
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/ConfirmUnbondViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/ConfirmUnbondViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AmountBucket
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.mixin.api.Validatable
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.inBackground
@@ -52,7 +55,8 @@ class ConfirmUnbondViewModel(
     private val extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
     unbondHintsMixinFactory: UnbondHintsMixinFactory,
     walletUiUseCase: WalletUiUseCase,
-    private val amountFormatter: AmountFormatter
+    private val amountFormatter: AmountFormatter,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(),
     ExternalActions by externalActions,
     Validatable by validationExecutor,
@@ -135,14 +139,30 @@ class ConfirmUnbondViewModel(
 
     private fun sendTransaction(validPayload: UnbondValidationPayload) = launch {
         val amountInPlanks = validPayload.asset.token.configuration.planksFromAmount(payload.amount)
+        val network = selectedAssetState.chain().name
+        val stakingType = "relaychain"
+        val usdAmount = validPayload.asset.token.amountToFiat(payload.amount)
+        val amountBucket = AmountBucket.from(usdAmount)
+
+        analyticsService.track(AnalyticsEvent.UnstakeInitiated(stakingType, network, amountBucket))
 
         unbondInteractor.unbond(validPayload.stash, validPayload.asset.bondedInPlanks, amountInPlanks)
             .onSuccess {
+                analyticsService.track(AnalyticsEvent.UnstakeCompleted(stakingType, network, amountBucket))
+
                 showToast(resourceManager.getString(R.string.common_transaction_submitted))
 
                 startNavigation(it.submissionHierarchy) { router.returnToStakingMain() }
             }
-            .onFailure(::showError)
+            .onFailure {
+                val reason = when {
+                    it is io.novafoundation.nova.common.base.errors.SigningCancelledException -> "user_cancelled"
+                    it is java.io.IOException -> "network_error"
+                    else -> "unknown"
+                }
+                analyticsService.track(AnalyticsEvent.UnstakeFailed(stakingType, network, reason))
+                showError(it)
+            }
 
         _showNextProgress.value = false
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/di/ConfirmUnbondModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/unbond/confirm/di/ConfirmUnbondModule.kt
@@ -7,6 +7,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
@@ -44,7 +45,8 @@ class ConfirmUnbondModule {
         unbondHintsMixinFactory: UnbondHintsMixinFactory,
         walletUiUseCase: WalletUiUseCase,
         extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return ConfirmUnbondViewModel(
             router = router,
@@ -60,7 +62,8 @@ class ConfirmUnbondModule {
             unbondHintsMixinFactory = unbondHintsMixinFactory,
             walletUiUseCase = walletUiUseCase,
             extrinsicNavigationWrapper = extrinsicNavigationWrapper,
-            amountFormatter = amountFormatter
+            amountFormatter = amountFormatter,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureDependencies.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureDependencies.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_swap_impl.di
 import coil.ImageLoader
 import com.google.gson.Gson
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.data.memory.ComputationalCache
 import io.novafoundation.nova.common.data.network.NetworkApiCreator
 import io.novafoundation.nova.common.data.storage.Preferences
@@ -170,4 +171,6 @@ interface SwapFeatureDependencies {
     val hydrationAcceptedFeeCurrenciesFetcher: HydrationAcceptedFeeCurrenciesFetcher
 
     fun maxActionProviderFactory(): MaxActionProviderFactory
+
+    val analyticsService: AnalyticsService
 }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/SwapConfirmationViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/SwapConfirmationViewModel.kt
@@ -4,6 +4,12 @@ import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.address.AddressModel
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AmountBucket
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.DurationBucket
+import io.novafoundation.nova.common.data.analytics.SlippageBucket
+import io.novafoundation.nova.common.data.analytics.SwapFailureReason
 import io.novafoundation.nova.common.mixin.api.Validatable
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.combineToPair
@@ -68,6 +74,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import io.novafoundation.nova.common.base.errors.SigningCancelledException
 import kotlinx.coroutines.launch
 
 private data class SwapConfirmationState(
@@ -99,7 +106,8 @@ class SwapConfirmationViewModel(
     private val swapConfirmationDetailsFormatter: SwapConfirmationDetailsFormatter,
     private val resourceManager: ResourceManager,
     private val swapFlowScopeAggregator: SwapFlowScopeAggregator,
-    private val extrinsicNavigationWrapper: ExtrinsicNavigationWrapper
+    private val extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
+    private val analyticsService: AnalyticsService
 ) : BaseViewModel(),
     ExternalActions by externalActions,
     Validatable by validationExecutor,
@@ -250,19 +258,54 @@ class SwapConfirmationViewModel(
     }
 
     private fun executeSwap(validPayload: SwapValidationPayload) = launchUnit {
+        val isWatchOnly = accountRepository.getSelectedMetaAccount().type == io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount.Type.WATCH_ONLY
+        if (!isWatchOnly) {
+            trackSwapConfirmed(validPayload)
+        }
+
         if (swapInteractor.isDeepSwapAvailable()) {
             swapStateStoreProvider.setState(validPayload.toSwapState())
 
             swapRouter.openSwapExecution()
         } else {
-            executeFirstSwapStep(validPayload.fee)
+            executeFirstSwapStep(validPayload)
         }
     }
 
-    private suspend fun executeFirstSwapStep(fee: SwapFee) {
-        swapInteractor.submitFirstSwapStep(fee)
+    private suspend fun trackSwapConfirmed(payload: SwapValidationPayload) {
+        try {
+            val quote = payload.swapQuote
+            val assetIn = assetInFlow.first()
+            val usdAmount = assetIn.token.planksToFiat(quote.planksIn)
+            val amountBucket = AmountBucket.from(usdAmount)
+            val slippageBucket = SlippageBucket.from(slippageFlow.first().inPercents)
+
+            val chainIn = chainRegistry.getChain(quote.assetIn.chainId)
+            val chainOut = chainRegistry.getChain(quote.assetOut.chainId)
+
+            analyticsService.track(
+                AnalyticsEvent.SwapConfirmed(
+                    amountBucket = amountBucket,
+                    slippageBucket = slippageBucket,
+                    assetIn = quote.assetIn.symbol.value,
+                    assetOut = quote.assetOut.symbol.value,
+                    networkIn = chainIn.name,
+                    networkOut = chainOut.name
+                )
+            )
+        } catch (_: Exception) {
+            // Don't let analytics tracking break user flow
+        }
+    }
+
+    private suspend fun executeFirstSwapStep(validPayload: SwapValidationPayload) {
+        val swapStartTime = System.currentTimeMillis()
+
+        swapInteractor.submitFirstSwapStep(validPayload.fee)
             .onSuccess {
                 _validationInProgress.value = false
+
+                trackSwapCompletedLegacy(validPayload, swapStartTime)
 
                 this.showToast(resourceManager.getString(R.string.common_transaction_submitted))
 
@@ -273,8 +316,50 @@ class SwapConfirmationViewModel(
             }.onFailure {
                 _validationInProgress.value = false
 
+                trackSwapFailedLegacy(it)
+
                 showFirstSwapStepFailure(it)
             }
+    }
+
+    private suspend fun trackSwapCompletedLegacy(payload: SwapValidationPayload, startTime: Long) {
+        try {
+            val durationMs = System.currentTimeMillis() - startTime
+            val durationBucket = DurationBucket.from(durationMs)
+            val quote = payload.swapQuote
+            val assetIn = assetInFlow.first()
+            val usdAmount = assetIn.token.planksToFiat(quote.planksIn)
+            val amountBucket = AmountBucket.from(usdAmount)
+
+            val chainIn = chainRegistry.getChain(quote.assetIn.chainId)
+            val chainOut = chainRegistry.getChain(quote.assetOut.chainId)
+
+            analyticsService.track(
+                AnalyticsEvent.SwapCompleted(
+                    amountBucket = amountBucket,
+                    durationBucket = durationBucket,
+                    assetIn = quote.assetIn.symbol.value,
+                    assetOut = quote.assetOut.symbol.value,
+                    networkIn = chainIn.name,
+                    networkOut = chainOut.name
+                )
+            )
+        } catch (_: Exception) {
+            // Don't let analytics tracking break user flow
+        }
+    }
+
+    private fun trackSwapFailedLegacy(error: Throwable) = launch {
+        val isWatchOnly = accountRepository.getSelectedMetaAccount().type == io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount.Type.WATCH_ONLY
+        val reason = when {
+            isWatchOnly -> SwapFailureReason.SIGNING_UNAVAILABLE
+            error is SigningCancelledException -> SwapFailureReason.USER_CANCELLED
+            error is SwapOperationSubmissionException.SimulationFailed -> SwapFailureReason.EXECUTION_REVERTED
+            error is java.io.IOException -> SwapFailureReason.NETWORK_ERROR
+            else -> SwapFailureReason.UNKNOWN
+        }
+
+        analyticsService.track(AnalyticsEvent.SwapFailed(reason))
     }
 
     private fun showFirstSwapStepFailure(error: Throwable) {

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/di/SwapConfirmationModule.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/confirmation/di/SwapConfirmationModule.kt
@@ -7,6 +7,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
 import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
@@ -54,7 +55,8 @@ class SwapConfirmationModule {
         confirmationDetailsFormatter: SwapConfirmationDetailsFormatter,
         resourceManager: ResourceManager,
         swapFlowScopeAggregator: SwapFlowScopeAggregator,
-        extrinsicNavigationWrapper: ExtrinsicNavigationWrapper
+        extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
+        analyticsService: AnalyticsService
     ): ViewModel {
         return SwapConfirmationViewModel(
             swapRouter = swapRouter,
@@ -75,7 +77,8 @@ class SwapConfirmationModule {
             swapConfirmationDetailsFormatter = confirmationDetailsFormatter,
             resourceManager = resourceManager,
             swapFlowScopeAggregator = swapFlowScopeAggregator,
-            extrinsicNavigationWrapper = extrinsicNavigationWrapper
+            extrinsicNavigationWrapper = extrinsicNavigationWrapper,
+            analyticsService = analyticsService
         )
     }
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/execution/SwapExecutionViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/execution/SwapExecutionViewModel.kt
@@ -2,6 +2,11 @@ package io.novafoundation.nova.feature_swap_impl.presentation.execution
 
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AmountBucket
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.DurationBucket
+import io.novafoundation.nova.common.data.analytics.SwapFailureReason
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.flowOf
 import io.novafoundation.nova.common.utils.formatting.format
@@ -32,6 +37,7 @@ import io.novafoundation.nova.feature_swap_impl.presentation.common.state.SwapSt
 import io.novafoundation.nova.feature_swap_impl.presentation.common.state.SwapStateStoreProvider
 import io.novafoundation.nova.feature_swap_impl.presentation.common.state.getStateOrThrow
 import io.novafoundation.nova.feature_swap_impl.presentation.execution.model.SwapProgressModel
+import io.novafoundation.nova.feature_wallet_api.domain.interfaces.TokenRepository
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
 import io.novafoundation.nova.feature_wallet_api.presentation.model.toAssetPayload
 import io.novafoundation.nova.runtime.ext.fullId
@@ -43,6 +49,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import io.novafoundation.nova.common.base.errors.SigningCancelledException
+import java.io.IOException
 
 class SwapExecutionViewModel(
     private val swapStateStoreProvider: SwapStateStoreProvider,
@@ -55,6 +63,9 @@ class SwapExecutionViewModel(
     private val descriptionBottomSheetLauncher: DescriptionBottomSheetLauncher,
     private val swapFlowScopeAggregator: SwapFlowScopeAggregator,
     private val extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
+    private val analyticsService: AnalyticsService,
+    private val tokenRepository: TokenRepository,
+    private val accountRepository: io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository,
 ) : BaseViewModel(),
     DescriptionBottomSheetLauncher by descriptionBottomSheetLauncher,
     ExtrinsicNavigationWrapper by extrinsicNavigationWrapper {
@@ -136,12 +147,65 @@ class SwapExecutionViewModel(
     }
 
     private fun executeSwap() = launchUnit {
-        val fee = swapStateFlow.first().fee
+        val swapState = swapStateFlow.first()
+        val fee = swapState.fee
+        val swapStartTime = System.currentTimeMillis()
 
         swapInteractor.executeSwap(fee)
-            .onEach(swapProgressFlow::emit)
+            .onEach { progress ->
+                swapProgressFlow.emit(progress)
+
+                when (progress) {
+                    is SwapProgress.Done -> {
+                        trackSwapCompleted(swapState, swapStartTime)
+                    }
+                    is SwapProgress.Failure -> trackSwapFailed(progress)
+                    is SwapProgress.StepStarted -> { /* no tracking needed */ }
+                }
+            }
             .inBackground()
             .collect()
+    }
+
+    private suspend fun trackSwapCompleted(swapState: SwapState, startTime: Long) {
+        try {
+            val durationMs = System.currentTimeMillis() - startTime
+            val durationBucket = DurationBucket.from(durationMs)
+
+            val quote = swapState.quote
+            val token = tokenRepository.getToken(quote.assetIn)
+            val usdAmount = token.planksToFiat(quote.planksIn)
+            val amountBucket = AmountBucket.from(usdAmount)
+
+            val chainIn = chainRegistry.getChain(quote.assetIn.chainId)
+            val chainOut = chainRegistry.getChain(quote.assetOut.chainId)
+
+            analyticsService.track(
+                AnalyticsEvent.SwapCompleted(
+                    amountBucket = amountBucket,
+                    durationBucket = durationBucket,
+                    assetIn = quote.assetIn.symbol.value,
+                    assetOut = quote.assetOut.symbol.value,
+                    networkIn = chainIn.name,
+                    networkOut = chainOut.name
+                )
+            )
+        } catch (_: Exception) {
+            // Don't let analytics tracking break user flow
+        }
+    }
+
+    private suspend fun trackSwapFailed(failure: SwapProgress.Failure) {
+        val isWatchOnly = accountRepository.getSelectedMetaAccount().type == io.novafoundation.nova.feature_account_api.domain.model.LightMetaAccount.Type.WATCH_ONLY
+        val reason = when {
+            isWatchOnly -> SwapFailureReason.SIGNING_UNAVAILABLE
+            failure.error is SigningCancelledException -> SwapFailureReason.USER_CANCELLED
+            failure.error is SwapOperationSubmissionException.SimulationFailed -> SwapFailureReason.EXECUTION_REVERTED
+            failure.error is IOException -> SwapFailureReason.NETWORK_ERROR
+            else -> SwapFailureReason.UNKNOWN
+        }
+
+        analyticsService.track(AnalyticsEvent.SwapFailed(reason))
     }
 
     private suspend fun SwapProgress.toUi(swapState: SwapState): SwapProgressModel {

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/execution/di/SwapExecutionModule.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/execution/di/SwapExecutionModule.kt
@@ -6,10 +6,12 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.view.bottomSheet.description.DescriptionBottomSheetLauncher
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_account_api.presenatation.navigation.ExtrinsicNavigationWrapper
 import io.novafoundation.nova.feature_swap_api.presentation.navigation.SwapFlowScopeAggregator
 import io.novafoundation.nova.feature_swap_impl.domain.interactor.SwapInteractor
@@ -17,6 +19,7 @@ import io.novafoundation.nova.feature_swap_impl.presentation.SwapRouter
 import io.novafoundation.nova.feature_swap_impl.presentation.common.details.SwapConfirmationDetailsFormatter
 import io.novafoundation.nova.feature_swap_impl.presentation.common.state.SwapStateStoreProvider
 import io.novafoundation.nova.feature_swap_impl.presentation.execution.SwapExecutionViewModel
+import io.novafoundation.nova.feature_wallet_api.domain.interfaces.TokenRepository
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 
@@ -37,6 +40,9 @@ class SwapExecutionModule {
         descriptionBottomSheetLauncher: DescriptionBottomSheetLauncher,
         swapFlowScopeAggregator: SwapFlowScopeAggregator,
         extrinsicNavigationWrapper: ExtrinsicNavigationWrapper,
+        analyticsService: AnalyticsService,
+        tokenRepository: TokenRepository,
+        accountRepository: AccountRepository,
     ): ViewModel {
         return SwapExecutionViewModel(
             swapStateStoreProvider = swapStateStoreProvider,
@@ -48,7 +54,10 @@ class SwapExecutionModule {
             feeLoaderMixinFactory = feeLoaderMixinFactory,
             descriptionBottomSheetLauncher = descriptionBottomSheetLauncher,
             swapFlowScopeAggregator = swapFlowScopeAggregator,
-            extrinsicNavigationWrapper = extrinsicNavigationWrapper
+            extrinsicNavigationWrapper = extrinsicNavigationWrapper,
+            analyticsService = analyticsService,
+            tokenRepository = tokenRepository,
+            accountRepository = accountRepository
         )
     }
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/SwapMainSettingsViewModel.kt
@@ -4,6 +4,11 @@ import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.analytics.AmountBucket
+import io.novafoundation.nova.common.data.analytics.AnalyticsEvent
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
+import io.novafoundation.nova.common.data.analytics.AssetCategoryClassifier
+import io.novafoundation.nova.common.data.analytics.SwapSource
 import io.novafoundation.nova.common.domain.ExtendedLoadingState
 import io.novafoundation.nova.common.mixin.actionAwaitable.ActionAwaitableMixin
 import io.novafoundation.nova.common.mixin.api.Validatable
@@ -144,6 +149,7 @@ class SwapMainSettingsViewModel(
     private val swapStateStoreProvider: SwapStateStoreProvider,
     private val swapFlowScopeAggregator: SwapFlowScopeAggregator,
     private val getAssetOptionsMixinFactory: GetAssetOptionsMixin.Factory,
+    private val analyticsService: AnalyticsService,
     swapAmountInputMixinFactory: SwapAmountInputMixinFactory,
     feeLoaderMixinFactory: FeeLoaderMixinV2.Factory,
     actionAwaitableFactory: ActionAwaitableMixin.Factory,
@@ -284,6 +290,9 @@ class SwapMainSettingsViewModel(
     private var quotingJob: Job? = null
 
     init {
+        val swapSource = if (payload is SwapSettingsPayload.RepeatOperation) SwapSource.ASSET_DETAILS else SwapSource.MAIN_SCREEN
+        analyticsService.track(AnalyticsEvent.SwapScreenOpened(swapSource))
+
         initPayload()
 
         launch { swapInteractor.warmUpSwapCommonlyUsedChains(swapFlowScope) }
@@ -369,9 +378,44 @@ class SwapMainSettingsViewModel(
     }
 
     private fun openSwapConfirmation(validPayload: SwapValidationPayload) = launchUnit {
+        trackSwapInitiated(validPayload)
+
         swapStateStoreProvider.setState(validPayload.toSwapState())
 
         swapRouter.openSwapConfirmation()
+    }
+
+    private suspend fun trackSwapInitiated(validPayload: SwapValidationPayload) {
+        try {
+            val quote = validPayload.swapQuote
+            val assetIn = assetInFlow.firstOrNull()
+
+            val assetInCategory = AssetCategoryClassifier.classify(quote.assetIn.symbol.value)
+            val assetOutCategory = AssetCategoryClassifier.classify(quote.assetOut.symbol.value)
+
+            val usdAmount = assetIn?.token?.planksToFiat(quote.planksIn) ?: java.math.BigDecimal.ZERO
+            val amountBucket = AmountBucket.from(usdAmount)
+
+            val swapSource = if (payload is SwapSettingsPayload.RepeatOperation) SwapSource.ASSET_DETAILS else SwapSource.MAIN_SCREEN
+
+            val chainIn = chainRegistry.getChain(quote.assetIn.chainId)
+            val chainOut = chainRegistry.getChain(quote.assetOut.chainId)
+
+            analyticsService.track(
+                AnalyticsEvent.SwapInitiated(
+                    source = swapSource,
+                    assetInCategory = assetInCategory,
+                    assetOutCategory = assetOutCategory,
+                    assetIn = quote.assetIn.symbol.value,
+                    assetOut = quote.assetOut.symbol.value,
+                    networkIn = chainIn.name,
+                    networkOut = chainOut.name,
+                    amountBucket = amountBucket
+                )
+            )
+        } catch (_: Exception) {
+            // Don't let analytics tracking break user flow
+        }
     }
 
     private fun setSwapStateAndThen(action: suspend () -> Unit) {

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/di/SwapMainSettingsModule.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/presentation/main/di/SwapMainSettingsModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.data.analytics.AnalyticsService
 import io.novafoundation.nova.common.di.scope.ScreenScope
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
@@ -97,6 +98,7 @@ class SwapMainSettingsModule {
         swapFlowScopeAggregator: SwapFlowScopeAggregator,
         enoughAmountValidatorFactory: EnoughAmountValidatorFactory,
         getAssetOptionsMixinFactory: GetAssetOptionsMixin.Factory,
+        analyticsService: AnalyticsService,
     ): ViewModel {
         return SwapMainSettingsViewModel(
             swapRouter = swapRouter,
@@ -121,7 +123,8 @@ class SwapMainSettingsModule {
             swapStateStoreProvider = swapStateStoreProvider,
             maxActionProviderFactory = maxActionProviderFactory,
             swapRouteFormatter = swapRouteFormatter,
-            swapFlowScopeAggregator = swapFlowScopeAggregator
+            swapFlowScopeAggregator = swapFlowScopeAggregator,
+            analyticsService = analyticsService
         )
     }
 


### PR DESCRIPTION
⚠️ Requires ToS update

## Purpose

  A working proof of concept for a privacy-conscious, opt-out analytics layer. The goal is to give the team
  something concrete to evaluate before decisions are made on tooling, event scope, or rollout strategy.

  ## Solution

  **Privacy model**
  - Opt-out by default — consent prompt on first launch, Settings toggle afterwards
  - Ephemeral session ID per launch, rotated on opt-out — no persistent user identifier
  - PII suppression: IP stripping, no device fingerprints, no person profiles, 13+ PostHog properties blanked
  - Value bucketing — raw amounts, durations, and slippage are converted to coarse buckets before transmission

  **Backend**
  - PostHog, sent via direct HTTP POST to `/capture/` using `OkHttpClient` — no PostHog SDK dependency
  - Host URL and API key are config values — swapping provider or self-hosting would only require changing the
  endpoint
  - Currently pointed at a sandbox project

  **Event coverage (28 wired, 35 defined)**
  App lifecycle · Onboarding & wallet creation · Swaps · Staking · Unstaking · Transfers · DApp browser ·
  Governance voting · Tab switching · Banners · Nova Card / NFTs

  ## Caveats

  - **This is a proof of concept — the final implementation will almost certainly look different.** The branch
  deliberately includes a wide range of events to make the conversation concrete; the number, selection, and
  property shapes of events should all be considered open for discussion rather than a final proposal.
  - The PostHog project and API key currently in the branch are dev-sandbox placeholders. Production infrastructure
   decisions (org ownership, data center, retention, possible self-hosting, final consent copy) are deliberately
  left for the team.