### PR TITLE
Auto-increment versionCode for develop Firebase builds

### DIFF
--- a/.github/workflows/push_develop.yml
+++ b/.github/workflows/push_develop.yml
@@ -5,10 +5,24 @@ on:
     branches: [develop]
 
 jobs:
+  resolve-version-code:
+    name: Resolve versionCode
+    runs-on: ubuntu-latest
+    outputs:
+      ci_build_id: ${{ steps.version_code.outputs.ci_build_id }}
+    steps:
+      - name: Calculate CI build id
+        id: version_code
+        run: |
+          echo "ci_build_id=$((1000 + GITHUB_RUN_NUMBER))" >> "$GITHUB_OUTPUT"
+          echo "Using CI_BUILD_ID=$((1000 + GITHUB_RUN_NUMBER))"
+
   build:
+    needs: resolve-version-code
     uses: ./.github/workflows/reusable_android_build.yml
     with:
       gradlew-command: assembleDevelop
+      ci-build-id: ${{ needs.resolve-version-code.outputs.ci_build_id }}
     secrets: inherit
 
   upload-to-firebase:


### PR DESCRIPTION
## Summary
- Every push to `develop` currently produced an APK with the same hardcoded `versionCode = 257` from `build.gradle`, because `push_develop.yml` didn't set `CI_BUILD_ID` and `scripts/versions.gradle` fell back to the root project value. As a result, Firebase App Distribution accumulated multiple releases with identical build numbers (e.g. two `10.8.1-develop (257)` entries), which makes it impossible to distinguish builds at a glance or reference a specific one.
- Added a `resolve-version-code` job that computes `ci_build_id = 1000 + GITHUB_RUN_NUMBER` (same formula already used by `manual_gplay.yml`) and passes it into the reusable Android build via the existing `ci-build-id` input, so each develop Firebase upload now gets a unique, monotonically increasing `versionCode`.
- No changes to the GitHub release flow: `publish_github_release.yml` still relies on the `versionCode` committed in `build.gradle`, which is the intended behavior for tagged releases (reproducible build from the tagged commit).
