### PR TITLE
Staking: demote 7 networks + per-chain notice system

### DIFF
--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -2039,4 +2039,5 @@
     <string name="yield_boost_stake_increase_time">Tiempo de aumento de stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost apostará automáticamente %s todos mis tokens transferibles por encima de %s</string>
     <string name="yiled_boost_yield_boosted">Con Yield Boost</string>
+    <string name="staking_notice_chip_label">Aviso</string>
 </resources>

--- a/common/src/main/res/values-fr-rFR/strings.xml
+++ b/common/src/main/res/values-fr-rFR/strings.xml
@@ -2039,4 +2039,5 @@
     <string name="yield_boost_stake_increase_time">La mise augmente avec le temps</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost misera automatiquement %s tous mes actifs transférables au-dessus de %s</string>
     <string name="yiled_boost_yield_boosted">Rendement boosté</string>
+    <string name="staking_notice_chip_label">Avis</string>
 </resources>

--- a/common/src/main/res/values-hu/strings.xml
+++ b/common/src/main/res/values-hu/strings.xml
@@ -2039,4 +2039,5 @@
     <string name="yield_boost_stake_increase_time">Stake növekedési idő</string>
     <string name="yield_boost_terms" formatted="false">A  Yield Boost %s automatikusan stake-elni fogja a %s feletti utalható tokeneket</string>
     <string name="yiled_boost_yield_boosted">Yield Boost-olt</string>
+    <string name="staking_notice_chip_label">Értesítés</string>
 </resources>

--- a/common/src/main/res/values-in/strings.xml
+++ b/common/src/main/res/values-in/strings.xml
@@ -2025,4 +2025,5 @@
     <string name="yield_boost_stake_increase_time">Waktu peningkatan staking</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost akan secara otomatis melakukan staking %s semua token yang dapat ditransfer di atas %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="staking_notice_chip_label">Pemberitahuan</string>
 </resources>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -2039,4 +2039,5 @@
     <string name="yield_boost_stake_increase_time">Tempo di aumento dello stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost stakerà automaticamente %s tutti i miei token trasferibili oltre %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="staking_notice_chip_label">Avviso</string>
 </resources>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -2025,4 +2025,5 @@
     <string name="yield_boost_stake_increase_time">Stake増加時間</string>
     <string name="yield_boost_terms" formatted="false">Yield Boostは自動的に%s私の全ての譲渡可能なトークンを%s以上ステークします</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="staking_notice_chip_label">通知</string>
 </resources>

--- a/common/src/main/res/values-ko/strings.xml
+++ b/common/src/main/res/values-ko/strings.xml
@@ -2025,4 +2025,5 @@
     <string name="yield_boost_stake_increase_time">Stake 증가 시간</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost가 %s 모든 양도 가능한 토큰을 %s 이상 자동으로 Stake 합니다</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="staking_notice_chip_label">안내</string>
 </resources>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -2067,4 +2067,5 @@
     <string name="yield_boost_stake_increase_time">Czas zwiększenia Stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost automatycznie Stake %s wszystkie moje przenośne tokeny powyżej %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="staking_notice_chip_label">Uwaga</string>
 </resources>

--- a/common/src/main/res/values-pt/strings.xml
+++ b/common/src/main/res/values-pt/strings.xml
@@ -2039,4 +2039,5 @@
     <string name="yield_boost_stake_increase_time">Tempo de aumento de stake</string>
     <string name="yield_boost_terms" formatted="false">O Impulso de Rendimento irá automaticamente fazer o stake de %s de todos os meus tokens transferíveis acima de %s</string>
     <string name="yiled_boost_yield_boosted">Com Impulso de Rendimento</string>
+    <string name="staking_notice_chip_label">Aviso</string>
 </resources>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -2067,4 +2067,5 @@
     <string name="yield_boost_stake_increase_time">Частота увеличения стейка</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost будет автоматически стейкать %s все мои переводные токены выше %s</string>
     <string name="yiled_boost_yield_boosted">С Yield Boost</string>
+    <string name="staking_notice_chip_label">Уведомление</string>
 </resources>

--- a/common/src/main/res/values-tr/strings.xml
+++ b/common/src/main/res/values-tr/strings.xml
@@ -2039,4 +2039,5 @@
     <string name="yield_boost_stake_increase_time">Bahis artış süresi</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost, %s tüm transfer edilebilir tokenlerimi otomatik olarak %s üzerinde stake edecek</string>
     <string name="yiled_boost_yield_boosted">Yield Boost\'lu</string>
+    <string name="staking_notice_chip_label">Bildirim</string>
 </resources>

--- a/common/src/main/res/values-vi/strings.xml
+++ b/common/src/main/res/values-vi/strings.xml
@@ -2025,4 +2025,5 @@
     <string name="yield_boost_stake_increase_time">Thời gian tăng Stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost sẽ tự động stake %s tất cả token có thể chuyển được của tôi trên %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="staking_notice_chip_label">Thông báo</string>
 </resources>

--- a/common/src/main/res/values-zh-rCN/strings.xml
+++ b/common/src/main/res/values-zh-rCN/strings.xml
@@ -2025,4 +2025,5 @@
     <string name="yield_boost_stake_increase_time">加注时间</string>
     <string name="yield_boost_terms" formatted="false">收益增强将自动加注我所有可转让代币中超过%s的%s</string>
     <string name="yiled_boost_yield_boosted">已增强收益</string>
+    <string name="staking_notice_chip_label">通知</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -2762,4 +2762,5 @@
     <string name="wallet_send_phishing_warning_title">Scam alert</string>
     <string name="wallet_transfer_details_title">Transfer details</string>
     <string name="yesterday">Yesterday</string>
+    <string name="staking_notice_chip_label">Notice</string>
 </resources>

--- a/feature-staking-impl/build.gradle
+++ b/feature-staking-impl/build.gradle
@@ -10,6 +10,7 @@ android {
 
         buildConfigField "String", "GLOBAL_CONFIG_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/staking/global_config_dev.json\""
         buildConfigField "String", "RECOMMENDED_VALIDATORS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/staking/validators/v1/nova_validators_dev.json\""
+        buildConfigField "String", "STAKING_NOTICES_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/notices/staking_notices.json\""
     }
 
     buildTypes {

--- a/feature-staking-impl/build.gradle
+++ b/feature-staking-impl/build.gradle
@@ -71,6 +71,7 @@ dependencies {
 
     testImplementation jUnitDep
     testImplementation mockitoDep
+    testImplementation coroutinesTestDep
 
     implementation substrateSdkDep
     compileOnly wsDep

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/tier/StakingDashboardTierConfig.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/tier/StakingDashboardTierConfig.kt
@@ -1,0 +1,16 @@
+package io.novafoundation.nova.feature_staking_impl.data.dashboard.tier
+
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.KnownChainIds
+
+object StakingDashboardTierConfig {
+    val demotedChainIds: Set<ChainId> = setOf(
+        KnownChainIds.MANTA_ATLANTIC,
+        KnownChainIds.ALEPH_ZERO,
+        KnownChainIds.VARA,
+        KnownChainIds.ZEITGEIST,
+        KnownChainIds.MOONRIVER,
+        KnownChainIds.POLKADEX,
+        KnownChainIds.TERNOA,
+    )
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/cache/StakingNoticesDiskCache.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/cache/StakingNoticesDiskCache.kt
@@ -1,0 +1,29 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.cache
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+class StakingNoticesDiskCache(private val context: Context) {
+
+    private val cacheFile: File
+        get() = File(context.cacheDir, FILE_NAME)
+
+    suspend fun read(): String? = withContext(Dispatchers.IO) {
+        runCatching { cacheFile.takeIf { it.exists() }?.readText() }.getOrNull()
+    }
+
+    suspend fun write(rawJson: String) = withContext(Dispatchers.IO) {
+        runCatching {
+            val tmp = File(context.cacheDir, "$FILE_NAME.tmp")
+            tmp.writeText(rawJson)
+            tmp.renameTo(cacheFile)
+        }
+        Unit
+    }
+
+    companion object {
+        private const val FILE_NAME = "staking_notices.json"
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/LocalizedText.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/LocalizedText.kt
@@ -1,0 +1,21 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.model
+
+/**
+ * Resolves a user-facing string against a preferred locale, falling back through
+ * "fr-FR" -> "fr" -> "en". Used only by [StakingNoticeDto] during decoding.
+ */
+internal object LocaleResolver {
+
+    fun resolve(map: Map<String, String>, preferredLocale: String): String? {
+        val candidates = buildList {
+            add(preferredLocale)
+            val baseLanguage = preferredLocale.substringBefore('-').takeIf { it != preferredLocale }
+            if (baseLanguage != null) add(baseLanguage)
+            add("en")
+        }
+        for (candidate in candidates) {
+            map[candidate]?.let { return it }
+        }
+        return null
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/LocalizedText.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/LocalizedText.kt
@@ -1,17 +1,22 @@
 package io.novafoundation.nova.feature_staking_impl.data.notices.model
 
 /**
- * Resolves a user-facing string against a preferred locale, falling back through
- * "fr-FR" -> "fr" -> "en". Used only by [StakingNoticeDto] during decoding.
+ * Resolves a user-facing string against a preferred locale, falling back by progressively
+ * stripping trailing hyphen-segments and finally to "en". E.g.
+ * "zh-Hans-CN" -> ["zh-Hans-CN", "zh-Hans", "zh", "en"]. Matches iOS behavior.
+ * Used only by [StakingNoticeDto] during decoding.
  */
 internal object LocaleResolver {
 
     fun resolve(map: Map<String, String>, preferredLocale: String): String? {
         val candidates = buildList {
-            add(preferredLocale)
-            val baseLanguage = preferredLocale.substringBefore('-').takeIf { it != preferredLocale }
-            if (baseLanguage != null) add(baseLanguage)
-            add("en")
+            var current = preferredLocale
+            add(current)
+            while (current.contains('-')) {
+                current = current.substringBeforeLast('-')
+                add(current)
+            }
+            if ("en" !in this) add("en")
         }
         for (candidate in candidates) {
             map[candidate]?.let { return it }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/StakingNotice.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/StakingNotice.kt
@@ -1,0 +1,14 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.model
+
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import java.time.LocalDate
+
+data class StakingNotice(
+    val chainId: ChainId,
+    val severity: Severity,
+    val shortText: String,   // already locale-resolved
+    val longText: String,    // already locale-resolved
+    val endDate: LocalDate?
+) {
+    enum class Severity { INFO, CRITICAL }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/StakingNoticeDto.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/StakingNoticeDto.kt
@@ -1,0 +1,50 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.model
+
+import com.google.gson.JsonElement
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+
+internal class StakingNoticeDto(
+    val chainId: ChainId,
+    val severity: String,
+    val shortText: JsonElement,   // may be JsonPrimitive (string) or JsonObject (locale map)
+    val longText: JsonElement,
+    val endDate: String? = null
+) {
+
+    fun toDomain(preferredLocale: String, today: LocalDate = LocalDate.now()): StakingNotice? {
+        val parsedSeverity = when (severity.lowercase()) {
+            "info" -> StakingNotice.Severity.INFO
+            "critical" -> StakingNotice.Severity.CRITICAL
+            else -> return null
+        }
+
+        val resolvedShort = resolveText(shortText, preferredLocale) ?: return null
+        val resolvedLong = resolveText(longText, preferredLocale) ?: return null
+
+        val parsedEndDate: LocalDate? = endDate?.let {
+            try { LocalDate.parse(it) } catch (e: DateTimeParseException) { null }
+        }
+        if (parsedEndDate != null && !parsedEndDate.isAfter(today)) return null
+
+        return StakingNotice(
+            chainId = chainId,
+            severity = parsedSeverity,
+            shortText = resolvedShort,
+            longText = resolvedLong,
+            endDate = parsedEndDate
+        )
+    }
+
+    private fun resolveText(element: JsonElement, preferredLocale: String): String? {
+        if (element.isJsonPrimitive && element.asJsonPrimitive.isString) {
+            return element.asString
+        }
+        if (element.isJsonObject) {
+            val map = element.asJsonObject.entrySet().associate { (k, v) -> k to v.asString }
+            return LocaleResolver.resolve(map, preferredLocale)
+        }
+        return null
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/network/StakingNoticesApi.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/network/StakingNoticesApi.kt
@@ -1,0 +1,10 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.network
+
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+interface StakingNoticesApi {
+
+    @GET
+    suspend fun fetchStakingNotices(@Url url: String): String
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepository.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.util.Locale
 
 class RealStakingNoticesRepository(
     private val api: StakingNoticesApi,
@@ -74,12 +73,32 @@ class RealStakingNoticesRepository(
     private fun decode(rawJson: String): Map<ChainId, StakingNotice>? {
         return runCatching {
             val dtos = gson.fromJson(rawJson, Array<StakingNoticeDto>::class.java) ?: emptyArray()
-            val locale = Locale.getDefault().toLanguageTag()
+            val locale = preferredLocale()
             dtos.mapNotNull { it.toDomain(locale) }.associateBy { it.chainId }
         }.getOrNull()
     }
 
+    /**
+     * Reads Nova's selected language directly from SharedPreferences (NOT Locale.getDefault(),
+     * which can lag behind ContextManager.updateResources()). Maps Android's iso639-only codes
+     * to the BCP-47 tags used as JSON keys (the JSON ships iOS-style "pt-PT", "zh-Hans", "id";
+     * Android stores "pt", "zh", "in" respectively). The iterative LocaleResolver then handles
+     * the full cascade.
+     */
+    private fun preferredLocale(): String {
+        val androidCode = sharedPreferences.getString(sharedPreferencesLanguageKey, null) ?: "en"
+        return ANDROID_TO_JSON_LOCALE[androidCode] ?: androidCode
+    }
+
     companion object {
         private const val DEBOUNCE_MILLIS = 5 * 60 * 1000L
+
+        // Map Android-stored iso639 codes to the BCP-47-style keys used in nova-utils JSON.
+        // Cross-platform JSON convention follows iOS LocalizationManager naming.
+        private val ANDROID_TO_JSON_LOCALE = mapOf(
+            "pt" to "pt-PT",
+            "zh" to "zh-Hans",
+            "in" to "id",
+        )
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepository.kt
@@ -26,9 +26,10 @@ class RealStakingNoticesRepository(
     private val sharedPreferencesLanguageKey: String,
     private val remoteUrl: String,
     private val timeProvider: () -> Long = { System.currentTimeMillis() },
+    externalScope: CoroutineScope? = null,
 ) : StakingNoticesRepository {
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = externalScope ?: CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val flow = MutableSharedFlow<Map<ChainId, StakingNotice>>(
         replay = 1,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepository.kt
@@ -1,0 +1,84 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.repository
+
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import io.novafoundation.nova.feature_staking_impl.data.notices.cache.StakingNoticesDiskCache
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNoticeDto
+import io.novafoundation.nova.feature_staking_impl.data.notices.network.StakingNoticesApi
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.Locale
+
+class RealStakingNoticesRepository(
+    private val api: StakingNoticesApi,
+    private val diskCache: StakingNoticesDiskCache,
+    private val gson: Gson,
+    private val sharedPreferences: SharedPreferences,
+    private val sharedPreferencesLanguageKey: String,
+    private val remoteUrl: String,
+    private val timeProvider: () -> Long = { System.currentTimeMillis() },
+) : StakingNoticesRepository {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val flow = MutableSharedFlow<Map<ChainId, StakingNotice>>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    @Volatile
+    private var lastSuccessfulSyncAt: Long = 0L
+
+    private val syncMutex = Mutex()
+
+    private val languageChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == sharedPreferencesLanguageKey) {
+            scope.launch { decodeFromDiskAndEmit() }
+        }
+    }
+
+    init {
+        sharedPreferences.registerOnSharedPreferenceChangeListener(languageChangeListener)
+        scope.launch { decodeFromDiskAndEmit() }
+    }
+
+    override fun observeStakingNotices(): Flow<Map<ChainId, StakingNotice>> = flow
+
+    override suspend fun syncStakingNotices() {
+        syncMutex.withLock {
+            if (timeProvider() - lastSuccessfulSyncAt < DEBOUNCE_MILLIS) return
+            val rawJson = runCatching { api.fetchStakingNotices(remoteUrl) }.getOrNull() ?: return
+            runCatching { diskCache.write(rawJson) }   // best effort
+            val map = decode(rawJson) ?: return
+            flow.emit(map)
+            lastSuccessfulSyncAt = timeProvider()
+        }
+    }
+
+    private suspend fun decodeFromDiskAndEmit() {
+        val raw = diskCache.read() ?: run { flow.emit(emptyMap()); return }
+        val map = decode(raw) ?: return     // bad cache - keep prior emission
+        flow.emit(map)
+    }
+
+    private fun decode(rawJson: String): Map<ChainId, StakingNotice>? {
+        return runCatching {
+            val dtos = gson.fromJson(rawJson, Array<StakingNoticeDto>::class.java) ?: emptyArray()
+            val locale = Locale.getDefault().toLanguageTag()
+            dtos.mapNotNull { it.toDomain(locale) }.associateBy { it.chainId }
+        }.getOrNull()
+    }
+
+    companion object {
+        private const val DEBOUNCE_MILLIS = 5 * 60 * 1000L
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/StakingNoticesRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/StakingNoticesRepository.kt
@@ -1,0 +1,12 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.repository
+
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import kotlinx.coroutines.flow.Flow
+
+interface StakingNoticesRepository {
+
+    fun observeStakingNotices(): Flow<Map<ChainId, StakingNotice>>
+
+    suspend fun syncStakingNotices()
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureComponent.kt
@@ -16,6 +16,7 @@ import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.update
 import io.novafoundation.nova.feature_staking_impl.di.staking.UpdatersModule
 import io.novafoundation.nova.feature_staking_impl.di.staking.dashboard.StakingDashboardModule
 import io.novafoundation.nova.feature_staking_impl.di.staking.mythos.MythosModule
+import io.novafoundation.nova.feature_staking_impl.di.staking.notices.StakingNoticesModule
 import io.novafoundation.nova.feature_staking_impl.di.staking.nominationPool.NominationPoolModule
 import io.novafoundation.nova.feature_staking_impl.di.staking.parachain.ParachainStakingModule
 import io.novafoundation.nova.feature_staking_impl.di.staking.stakingTypeDetails.StakingTypeDetailsModule
@@ -115,7 +116,8 @@ import io.novafoundation.nova.runtime.di.RuntimeApi
         MythosModule::class,
         StakingDashboardModule::class,
         StartMultiStakingModule::class,
-        StakingTypeDetailsModule::class
+        StakingTypeDetailsModule::class,
+        StakingNoticesModule::class
     ]
 )
 @FeatureScope

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureDependencies.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureDependencies.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.di
 
+import android.content.Context
 import android.content.SharedPreferences
 import coil.ImageLoader
 import com.google.gson.Gson
@@ -154,6 +155,8 @@ interface StakingFeatureDependencies {
     val assetIconProvider: AssetIconProvider
 
     fun contextManager(): ContextManager
+
+    fun context(): Context
 
     fun computationalCache(): ComputationalCache
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/notices/StakingNoticesModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/notices/StakingNoticesModule.kt
@@ -1,0 +1,48 @@
+package io.novafoundation.nova.feature_staking_impl.di.staking.notices
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import dagger.Module
+import dagger.Provides
+import io.novafoundation.nova.common.data.network.NetworkApiCreator
+import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.feature_staking_impl.BuildConfig
+import io.novafoundation.nova.feature_staking_impl.data.notices.cache.StakingNoticesDiskCache
+import io.novafoundation.nova.feature_staking_impl.data.notices.network.StakingNoticesApi
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.RealStakingNoticesRepository
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
+
+@Module
+class StakingNoticesModule {
+
+    @Provides
+    @FeatureScope
+    fun provideStakingNoticesApi(networkApiCreator: NetworkApiCreator): StakingNoticesApi =
+        networkApiCreator.create(StakingNoticesApi::class.java)
+
+    @Provides
+    @FeatureScope
+    fun provideStakingNoticesDiskCache(context: Context): StakingNoticesDiskCache =
+        StakingNoticesDiskCache(context)
+
+    @Provides
+    @FeatureScope
+    fun provideStakingNoticesRepository(
+        api: StakingNoticesApi,
+        diskCache: StakingNoticesDiskCache,
+        gson: Gson,
+        sharedPreferences: SharedPreferences,
+    ): StakingNoticesRepository = RealStakingNoticesRepository(
+        api = api,
+        diskCache = diskCache,
+        gson = gson,
+        sharedPreferences = sharedPreferences,
+        sharedPreferencesLanguageKey = LANGUAGE_KEY,
+        remoteUrl = BuildConfig.STAKING_NOTICES_URL,
+    )
+
+    private companion object {
+        const val LANGUAGE_KEY = "selected_language"
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/dashboard/RealStakingDashboardInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/dashboard/RealStakingDashboardInteractor.kt
@@ -30,6 +30,7 @@ import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.Staking
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingOptionId
 import io.novafoundation.nova.feature_staking_api.data.dashboard.common.stakingChainsById
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardItem
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.tier.StakingDashboardTierConfig
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.StakingDashboardRepository
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.TotalStakeChainComparatorProvider
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
@@ -149,7 +150,7 @@ class RealStakingDashboardInteractor(
             val itemsByChain = itemsByChainAndAsset[chain.id]
 
             if (itemsByChain == null) {
-                if (!chain.isTestNet) {
+                if (!chain.isTestNet && chain.id !in StakingDashboardTierConfig.demotedChainIds) {
                     notYetResolved.add(notYetResolvedChainOption(chain, chain.utilityAsset))
                 }
                 return@forEach
@@ -159,7 +160,7 @@ class RealStakingDashboardInteractor(
                 val asset = chain.assetsById[assetId] ?: return@innerForEach
 
                 if (dashboardItems.isNoStakePresent()) {
-                    if (!chain.isTestNet) {
+                    if (!chain.isTestNet && chain.id !in StakingDashboardTierConfig.demotedChainIds) {
                         noStake.add(noStakeAggregatedOption(chain, asset, dashboardItems, syncingStageMap))
                     }
                 } else {
@@ -195,7 +196,7 @@ class RealStakingDashboardInteractor(
             val itemsByChain = itemsByChainAndAsset[chain.id]
 
             if (itemsByChain == null) {
-                if (chain.isTestNet) {
+                if (chain.isTestNet || chain.id in StakingDashboardTierConfig.demotedChainIds) {
                     notYetResolved.add(notYetResolvedChainOption(chain, chain.utilityAsset))
                 }
                 return@forEach
@@ -205,7 +206,7 @@ class RealStakingDashboardInteractor(
                 val asset = chain.assetsById[assetId] ?: return@innerForEach
 
                 if (dashboardItems.isNoStakePresent()) {
-                    if (chain.isTestNet) {
+                    if (chain.isTestNet || chain.id in StakingDashboardTierConfig.demotedChainIds) {
                         noStake.add(noStakeAggregatedOption(chain, asset, dashboardItems, syncingStageMap))
                     }
                 } else {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/common/view/StakingNoticeBlockView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/common/view/StakingNoticeBlockView.kt
@@ -1,0 +1,51 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.common.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+
+class StakingNoticeBlockView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : LinearLayout(context, attrs, defStyle) {
+
+    private val titleView: TextView
+    private val bodyView: TextView
+
+    init {
+        orientation = VERTICAL
+        val paddingHorizontal = dp(16)
+        val paddingVertical = dp(12)
+        setPadding(paddingHorizontal, paddingVertical, paddingHorizontal, paddingVertical)
+        LayoutInflater.from(context).inflate(R.layout.view_staking_notice_block, this)
+        titleView = findViewById(R.id.stakingNoticeBlockTitle)
+        bodyView = findViewById(R.id.stakingNoticeBlockBody)
+    }
+
+    fun bind(notice: StakingNotice) {
+        titleView.text = notice.shortText
+        bodyView.text = notice.longText
+        val (bgRes, fgRes) = when (notice.severity) {
+            StakingNotice.Severity.CRITICAL ->
+                R.color.notice_critical_bg to R.color.notice_critical_text
+            StakingNotice.Severity.INFO ->
+                R.color.notice_info_bg to R.color.notice_info_text
+        }
+        setBackgroundColor(ContextCompat.getColor(context, bgRes))
+        titleView.setTextColor(ContextCompat.getColor(context, fgRes))
+    }
+
+    private fun dp(value: Int): Int =
+        TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            value.toFloat(),
+            resources.displayMetrics
+        ).toInt()
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/common/view/StakingNoticeBlockView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/common/view/StakingNoticeBlockView.kt
@@ -1,12 +1,14 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.common.view
 
 import android.content.Context
+import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.ColorUtils
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
 
@@ -21,8 +23,8 @@ class StakingNoticeBlockView @JvmOverloads constructor(
 
     init {
         orientation = VERTICAL
-        val paddingHorizontal = dp(16)
-        val paddingVertical = dp(12)
+        val paddingHorizontal = dp(14)
+        val paddingVertical = dp(14)
         setPadding(paddingHorizontal, paddingVertical, paddingHorizontal, paddingVertical)
         LayoutInflater.from(context).inflate(R.layout.view_staking_notice_block, this)
         titleView = findViewById(R.id.stakingNoticeBlockTitle)
@@ -32,14 +34,22 @@ class StakingNoticeBlockView @JvmOverloads constructor(
     fun bind(notice: StakingNotice) {
         titleView.text = notice.shortText
         bodyView.text = notice.longText
-        val (bgRes, fgRes) = when (notice.severity) {
+        val (bgRes, fgRes, borderAlpha) = when (notice.severity) {
             StakingNotice.Severity.CRITICAL ->
-                R.color.notice_critical_bg to R.color.notice_critical_text
+                Triple(R.color.notice_critical_bg, R.color.notice_critical_text, 0.30f)
             StakingNotice.Severity.INFO ->
-                R.color.notice_info_bg to R.color.notice_info_text
+                Triple(R.color.notice_info_bg, R.color.notice_info_text, 0.25f)
         }
-        setBackgroundColor(ContextCompat.getColor(context, bgRes))
-        titleView.setTextColor(ContextCompat.getColor(context, fgRes))
+        val bgColor = ContextCompat.getColor(context, bgRes)
+        val fgColor = ContextCompat.getColor(context, fgRes)
+        val borderColor = ColorUtils.setAlphaComponent(fgColor, (borderAlpha * 255).toInt())
+
+        background = GradientDrawable().apply {
+            cornerRadius = dp(12).toFloat()
+            setColor(bgColor)
+            setStroke(dp(1), borderColor)
+        }
+        titleView.setTextColor(fgColor)
     }
 
     private fun dp(value: Int): Int =

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/common/view/StakingNoticeChipView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/common/view/StakingNoticeChipView.kt
@@ -1,0 +1,31 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.common.view
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.content.ContextCompat
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+
+class StakingNoticeChipView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : AppCompatTextView(context, attrs, defStyle) {
+
+    init {
+        text = context.getString(R.string.staking_notice_chip_label)
+        textSize = 11f
+    }
+
+    fun bind(notice: StakingNotice) {
+        val (bgRes, fgRes) = when (notice.severity) {
+            StakingNotice.Severity.CRITICAL ->
+                R.color.notice_critical_bg to R.color.notice_critical_text
+            StakingNotice.Severity.INFO ->
+                R.color.notice_info_bg to R.color.notice_info_text
+        }
+        setBackgroundColor(ContextCompat.getColor(context, bgRes))
+        setTextColor(ContextCompat.getColor(context, fgRes))
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/common/view/StakingNoticeStripView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/common/view/StakingNoticeStripView.kt
@@ -1,0 +1,38 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.common.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+
+class StakingNoticeStripView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    private val textView: TextView
+
+    init {
+        LayoutInflater.from(context).inflate(R.layout.view_staking_notice_strip, this)
+        textView = findViewById(R.id.stakingNoticeStripText)
+    }
+
+    fun bind(notice: StakingNotice) {
+        textView.text = notice.shortText
+        when (notice.severity) {
+            StakingNotice.Severity.CRITICAL -> {
+                setBackgroundColor(ContextCompat.getColor(context, R.color.notice_critical_bg))
+                textView.setTextColor(ContextCompat.getColor(context, R.color.notice_critical_text))
+            }
+            StakingNotice.Severity.INFO -> {
+                setBackgroundColor(ContextCompat.getColor(context, R.color.notice_info_bg))
+                textView.setTextColor(ContextCompat.getColor(context, R.color.notice_info_text))
+            }
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/common/list/DashboardNoStakeAdapter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/common/list/DashboardNoStakeAdapter.kt
@@ -36,6 +36,7 @@ class DashboardNoStakeAdapter(
                 NoStakeItem::tokenName -> holder.bindTokenName(item)
                 NoStakeItem::assetIcon -> holder.bindAssetIcon(item)
                 NoStakeItem::stakingTypeBadge -> holder.bindStakingType(item)
+                NoStakeItem::notice -> holder.bindNotice(item)
             }
         }
     }
@@ -56,6 +57,7 @@ class DashboardNoStakeViewHolder(
         bindTokenName(model)
         bindAssetIcon(model)
         bindStakingType(model)
+        bindNotice(model)
     }
 
     fun bindTokenName(model: NoStakeItem) {
@@ -78,6 +80,10 @@ class DashboardNoStakeViewHolder(
         containerView.setAssetIcon(model.assetIcon)
     }
 
+    fun bindNotice(model: NoStakeItem) {
+        containerView.setNotice(model.notice)
+    }
+
     override fun unbind() {
         containerView.unbind()
     }
@@ -90,7 +96,8 @@ private class DashboardNoStakeDiffCallback : DiffUtil.ItemCallback<NoStakeItem>(
         NoStakeItem::availableBalance,
         NoStakeItem::tokenName,
         NoStakeItem::assetIcon,
-        NoStakeItem::stakingTypeBadge
+        NoStakeItem::stakingTypeBadge,
+        NoStakeItem::notice
     )
 
     override fun areItemsTheSame(oldItem: NoStakeItem, newItem: NoStakeItem): Boolean {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
@@ -206,10 +206,13 @@ class StakingDashboardViewModel(
         notices: Map<ChainId, StakingNotice>
     ): ExtendedLoadingState<StakingDashboardModel> {
         return dashboardLoading.map { model ->
-            val enriched = model.hasStakeItems.map { item ->
+            val enrichedHasStake = model.hasStakeItems.map { item ->
                 item.copy(notice = notices[item.assetId.chainId])
             }
-            StakingDashboardModel(hasStakeItems = enriched, noStakeItems = model.noStakeItems)
+            val enrichedNoStake = model.noStakeItems.map { item ->
+                item.copy(notice = notices[item.assetId.chainId])
+            }
+            StakingDashboardModel(hasStakeItems = enrichedHasStake, noStakeItems = enrichedNoStake)
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.dashboard.main
 
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.domain.ExtendedLoadingState
 import io.novafoundation.nova.common.domain.map
 import io.novafoundation.nova.common.presentation.AssetIconProvider
 import io.novafoundation.nova.common.presentation.getAssetIconOrFallback
@@ -21,6 +22,9 @@ import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.isSynci
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.isSyncingSecondary
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StartMultiStakingRouter
@@ -62,7 +66,8 @@ class StakingDashboardViewModel(
     private val dashboardUpdatePeriod: Duration = 200.milliseconds,
     private val maskableValueFormatterProvider: MaskableValueFormatterProvider,
     private val amountFormatter: AmountFormatter,
-    private val assetIconProvider: AssetIconProvider
+    private val assetIconProvider: AssetIconProvider,
+    private val stakingNoticesRepository: StakingNoticesRepository,
 ) : BaseViewModel() {
 
     private val dashboardFormattersFlow = maskableValueFormatterProvider.provideFormatter()
@@ -77,15 +82,25 @@ class StakingDashboardViewModel(
     private val stakingDashboardFlow = interactor.stakingDashboardFlow()
         .shareInBackground()
 
-    val stakingDashboardUiFlow = stakingDashboardFlow
+    private val noticesFlow = stakingNoticesRepository.observeStakingNotices()
+        .shareInBackground()
+
+    private val dashboardUiWithoutNotices = stakingDashboardFlow
         .throttleLast(dashboardUpdatePeriod)
         .combine(dashboardFormattersFlow) { dashboardLoading, valueFormatter -> dashboardLoading.map { mapDashboardToUi(it, valueFormatter) } }
+
+    val stakingDashboardUiFlow = dashboardUiWithoutNotices
+        .combine(noticesFlow) { dashboardLoading, notices -> applyNotices(dashboardLoading, notices) }
         .shareInBackground()
 
     init {
         stakingDashboardUpdateSystem.start()
             .inBackground()
             .launchIn(this)
+
+        launch {
+            runCatching { stakingNoticesRepository.syncStakingNotices() }
+        }
     }
 
     fun onHasStakeItemClicked(index: Int) = launch {
@@ -183,6 +198,18 @@ class StakingDashboardViewModel(
                 text = resourceManager.getString(R.string.common_waiting),
                 textColorRes = R.color.text_primary
             )
+        }
+    }
+
+    private fun applyNotices(
+        dashboardLoading: ExtendedLoadingState<StakingDashboardModel>,
+        notices: Map<ChainId, StakingNotice>
+    ): ExtendedLoadingState<StakingDashboardModel> {
+        return dashboardLoading.map { model ->
+            val enriched = model.hasStakeItems.map { item ->
+                item.copy(notice = notices[item.assetId.chainId])
+            }
+            StakingDashboardModel(hasStakeItems = enriched, noStakeItems = model.noStakeItems)
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/di/StakingDashboardModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/di/StakingDashboardModule.kt
@@ -14,6 +14,7 @@ import io.novafoundation.nova.feature_account_api.domain.interfaces.SelectedAcco
 import io.novafoundation.nova.feature_staking_api.data.dashboard.StakingDashboardUpdateSystem
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.StakingDashboardInteractor
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StartMultiStakingRouter
@@ -41,7 +42,8 @@ class StakingDashboardModule {
         startMultiStakingRouter: StartMultiStakingRouter,
         valueFormatterProvider: MaskableValueFormatterProvider,
         amountFormatter: AmountFormatter,
-        assetIconProvider: AssetIconProvider
+        assetIconProvider: AssetIconProvider,
+        stakingNoticesRepository: StakingNoticesRepository
     ): ViewModel {
         return StakingDashboardViewModel(
             interactor = interactor,
@@ -55,7 +57,8 @@ class StakingDashboardModule {
             startMultiStakingRouter = startMultiStakingRouter,
             maskableValueFormatterProvider = valueFormatterProvider,
             amountFormatter = amountFormatter,
-            assetIconProvider = assetIconProvider
+            assetIconProvider = assetIconProvider,
+            stakingNoticesRepository = stakingNoticesRepository
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/list/DashboardHasStakeAdapter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/list/DashboardHasStakeAdapter.kt
@@ -38,6 +38,7 @@ class DashboardHasStakeAdapter(
                 HasStakeItem::assetIcon -> holder.bindAssetIcon(item)
                 HasStakeItem::assetLabel -> holder.bindAssetLabel(item)
                 HasStakeItem::stakingTypeBadge -> holder.bindStakingType(item)
+                HasStakeItem::notice -> holder.bindNotice(item)
             }
         }
     }
@@ -60,6 +61,7 @@ class DashboardHasStakeViewHolder(
         bindAssetIcon(model)
         bindAssetLabel(model)
         bindStakingType(model)
+        bindNotice(model)
     }
 
     fun bindAssetIcon(model: HasStakeItem) {
@@ -89,6 +91,10 @@ class DashboardHasStakeViewHolder(
     fun bindStatus(model: HasStakeItem) {
         containerView.setStatus(model.status)
     }
+
+    fun bindNotice(model: HasStakeItem) {
+        containerView.setNotice(model.notice)
+    }
 }
 
 private class DashboardHasStakeDiffCallback : DiffUtil.ItemCallback<HasStakeItem>() {
@@ -101,7 +107,8 @@ private class DashboardHasStakeDiffCallback : DiffUtil.ItemCallback<HasStakeItem
         HasStakeItem::rewards,
         HasStakeItem::assetIcon,
         HasStakeItem::assetLabel,
-        HasStakeItem::stakingTypeBadge
+        HasStakeItem::stakingTypeBadge,
+        HasStakeItem::notice
     )
 
     override fun areItemsTheSame(oldItem: HasStakeItem, newItem: HasStakeItem): Boolean {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/model/StakingDashboardModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/model/StakingDashboardModel.kt
@@ -4,6 +4,7 @@ import androidx.annotation.DrawableRes
 import io.novafoundation.nova.common.domain.ExtendedLoadingState
 import io.novafoundation.nova.common.presentation.masking.MaskableModel
 import io.novafoundation.nova.common.utils.images.Icon
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
 import io.novafoundation.nova.feature_staking_impl.presentation.dashboard.main.view.SyncingData
 import io.novafoundation.nova.feature_staking_impl.presentation.view.StakeStatusModel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AmountModel
@@ -23,6 +24,7 @@ class StakingDashboardModel(
         val stake: SyncingData<MaskableModel<AmountModel>>,
         val status: ExtendedLoadingState<SyncingData<StakeStatusModel>>,
         val earnings: ExtendedLoadingState<SyncingData<String>>,
+        val notice: StakingNotice? = null,
     ) : BaseItem
 
     data class NoStakeItem(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/model/StakingDashboardModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/model/StakingDashboardModel.kt
@@ -34,6 +34,7 @@ class StakingDashboardModel(
         val tokenName: SyncingData<String>,
         val availableBalance: CharSequence?,
         val earnings: ExtendedLoadingState<SyncingData<String>>,
+        val notice: StakingNotice? = null,
     ) : BaseItem
 
     interface BaseItem {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/view/StakingDashboardHasStakeView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/view/StakingDashboardHasStakeView.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.dashboard.main.
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import coil.ImageLoader
@@ -21,6 +22,8 @@ import io.novafoundation.nova.common.utils.unsafeLazy
 import io.novafoundation.nova.common.view.shape.getBlockDrawable
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.databinding.ItemDashboardHasStakeBinding
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import io.novafoundation.nova.feature_staking_impl.presentation.common.view.StakingNoticeStripView
 import io.novafoundation.nova.feature_staking_impl.presentation.dashboard.main.model.StakingDashboardModel.StakingTypeModel
 import io.novafoundation.nova.feature_staking_impl.presentation.view.StakeStatusModel
 import io.novafoundation.nova.feature_wallet_api.presentation.model.AmountModel
@@ -36,6 +39,10 @@ class StakingDashboardHasStakeView @JvmOverloads constructor(
     private val imageLoader: ImageLoader
 
     private val binder = ItemDashboardHasStakeBinding.inflate(inflater(), this)
+
+    private val noticeStripView: StakingNoticeStripView by unsafeLazy {
+        findViewById(R.id.stakingActiveCardNoticeStrip)
+    }
 
     private val rewardsAmountGroup by unsafeLazy {
         ShimmerableGroup(
@@ -115,5 +122,14 @@ class StakingDashboardHasStakeView @JvmOverloads constructor(
 
     fun setStakingTypeBadge(model: StakingTypeModel?) {
         binder.itemDashboardHasStakeStakingType.setModelOrHide(model)
+    }
+
+    fun setNotice(notice: StakingNotice?) {
+        if (notice != null) {
+            noticeStripView.bind(notice)
+            noticeStripView.visibility = View.VISIBLE
+        } else {
+            noticeStripView.visibility = View.GONE
+        }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/view/StakingDashboardNoStakeView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/view/StakingDashboardNoStakeView.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.dashboard.main.
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import coil.ImageLoader
@@ -17,7 +18,10 @@ import io.novafoundation.nova.common.utils.setShimmerShown
 import io.novafoundation.nova.common.utils.setTextOrHide
 import io.novafoundation.nova.common.utils.unsafeLazy
 import io.novafoundation.nova.common.view.shape.getBlockDrawable
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
 import io.novafoundation.nova.feature_staking_impl.databinding.ItemDashboardNoStakeBinding
+import io.novafoundation.nova.feature_staking_impl.presentation.common.view.StakingNoticeChipView
 import io.novafoundation.nova.feature_staking_impl.presentation.dashboard.main.model.StakingDashboardModel.StakingTypeModel
 
 class StakingDashboardNoStakeView @JvmOverloads constructor(
@@ -27,6 +31,10 @@ class StakingDashboardNoStakeView @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs, defStyleAttr), WithContextExtensions by WithContextExtensions(context) {
 
     private val binder = ItemDashboardNoStakeBinding.inflate(inflater(), this)
+
+    private val noticeChipView: StakingNoticeChipView by unsafeLazy {
+        findViewById(R.id.noStakeRowNoticeChip)
+    }
 
     private val imageLoader: ImageLoader
 
@@ -79,6 +87,15 @@ class StakingDashboardNoStakeView @JvmOverloads constructor(
 
     fun setStakingTypeBadge(model: StakingTypeModel?) {
         binder.itemDashboardNoStakeStakingType.setModelOrHide(model)
+    }
+
+    fun setNotice(notice: StakingNotice?) {
+        if (notice != null) {
+            noticeChipView.bind(notice)
+            noticeChipView.visibility = View.VISIBLE
+        } else {
+            noticeChipView.visibility = View.GONE
+        }
     }
 
     fun unbind() {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/more/MoreStakingOptionsViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/more/MoreStakingOptionsViewModel.kt
@@ -8,6 +8,8 @@ import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.MoreSta
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingDApp
 import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.allStakingTypes
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StartMultiStakingRouter
@@ -17,6 +19,8 @@ import io.novafoundation.nova.feature_staking_impl.presentation.dashboard.more.m
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.common.AvailableStakingOptionsPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.landing.model.StartStakingLandingPayload
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -28,17 +32,27 @@ class MoreStakingOptionsViewModel(
     private val stakingSharedState: StakingSharedState,
     private val presentationMapper: StakingDashboardPresentationMapper,
     private val stakingRouter: StakingRouter,
+    private val stakingNoticesRepository: StakingNoticesRepository,
 ) : BaseViewModel() {
 
     init {
         syncDApps()
+        launch {
+            runCatching { stakingNoticesRepository.syncStakingNotices() }
+        }
     }
 
     private val moreStakingOptionsFlow = interactor.moreStakingOptionsFlow()
         .shareInBackground()
 
-    val moreStakingOptionsUiFlow = moreStakingOptionsFlow
+    private val noticesFlow = stakingNoticesRepository.observeStakingNotices()
+        .shareInBackground()
+
+    private val moreStakingOptionsUiWithoutNotices = moreStakingOptionsFlow
         .map(::mapMoreOptionsToUi)
+
+    val moreStakingOptionsUiFlow = moreStakingOptionsUiWithoutNotices
+        .combine(noticesFlow) { model, notices -> applyNotices(model, notices) }
         .shareInBackground()
 
     fun onInAppStakingItemClicked(index: Int) = launch {
@@ -58,6 +72,13 @@ class MoreStakingOptionsViewModel(
 
     private fun syncDApps() = launch {
         interactor.syncDapps()
+    }
+
+    private fun applyNotices(model: MoreStakingOptionsModel, notices: Map<ChainId, StakingNotice>): MoreStakingOptionsModel {
+        return MoreStakingOptionsModel(
+            inAppStaking = model.inAppStaking.map { item -> item.copy(notice = notices[item.assetId.chainId]) },
+            browserStaking = model.browserStaking
+        )
     }
 
     private fun mapMoreOptionsToUi(moreStakingOptions: MoreStakingOptions): MoreStakingOptionsModel {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/more/di/MoreStakingOptionsModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/more/di/MoreStakingOptionsModule.kt
@@ -14,6 +14,7 @@ import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StartMultiStakingRouter
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
 import io.novafoundation.nova.feature_staking_impl.presentation.dashboard.common.StakingDashboardPresentationMapperFactory
 import io.novafoundation.nova.feature_staking_impl.presentation.dashboard.more.MoreStakingOptionsViewModel
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.di.components.ComponentsModule
@@ -32,7 +33,8 @@ class MoreStakingOptionsModule {
         stakingSharedState: StakingSharedState,
         presentationMapperFactory: StakingDashboardPresentationMapperFactory,
         startMultiStakingRouter: StartMultiStakingRouter,
-        maskableValueFormatterFactory: MaskableValueFormatterFactory
+        maskableValueFormatterFactory: MaskableValueFormatterFactory,
+        stakingNoticesRepository: StakingNoticesRepository
     ): ViewModel {
         return MoreStakingOptionsViewModel(
             interactor = interactor,
@@ -41,7 +43,8 @@ class MoreStakingOptionsModule {
             stakingRouter = stakingRouter,
             stakingSharedState = stakingSharedState,
             // Show all items in more staking options
-            presentationMapper = presentationMapperFactory.create(maskableValueFormatterFactory.create(MaskingMode.DISABLED))
+            presentationMapper = presentationMapperFactory.create(maskableValueFormatterFactory.create(MaskingMode.DISABLED)),
+            stakingNoticesRepository = stakingNoticesRepository
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/StakingFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/StakingFragment.kt
@@ -4,6 +4,7 @@ import android.view.View
 import coil.ImageLoader
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.setVisible
 import io.novafoundation.nova.common.mixin.impl.observeBrowserEvents
 import io.novafoundation.nova.common.mixin.impl.observeValidations
 import io.novafoundation.nova.common.utils.insets.applyNavigationBarInsets
@@ -57,6 +58,11 @@ class StakingFragment : BaseFragment<StakingViewModel, FragmentStakingBinding>()
         setupExternalActions(viewModel)
 
         viewModel.migrationAlertFlow.observe { binder.stakingMigrationAlert.setModelOrHide(it) }
+
+        viewModel.noticeForCurrentChain.observe { notice ->
+            binder.stakingDetailsNoticeBlock.setVisible(notice != null)
+            notice?.let { binder.stakingDetailsNoticeBlock.bind(it) }
+        }
 
         setupNetworkInfoComponent(viewModel.networkInfoComponent, binder.stakingNetworkInfo)
         setupStakeSummaryComponent(viewModel.stakeSummaryComponent, binder.stakingStakeSummary)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/StakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/StakingViewModel.kt
@@ -17,6 +17,8 @@ import io.novafoundation.nova.feature_ahm_api.domain.model.ChainMigrationConfig
 import io.novafoundation.nova.feature_ahm_api.presentation.getChainMigrationDateFormat
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.ComponentHostContext
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.alerts.AlertsComponentFactory
@@ -28,6 +30,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.yourPool.YourPoolComponentFactory
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.runtime.state.selectedAssetFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -56,6 +59,7 @@ class StakingViewModel(
     private val resourceManager: ResourceManager,
     private val externalActionsMixin: ExternalActions.Presentation,
     private val chainMigrationInfoUseCase: ChainMigrationInfoUseCase,
+    private val stakingNoticesRepository: StakingNoticesRepository,
     stakingUpdateSystem: UpdateSystem,
 ) : BaseViewModel(),
     Validatable by validationExecutor,
@@ -92,6 +96,12 @@ class StakingViewModel(
     val yourPoolComponent = yourPoolComponentFactory.create(componentHostContext)
 
     private val dateFormatter = getChainMigrationDateFormat()
+
+    val noticeForCurrentChain: Flow<StakingNotice?> = combine(
+        stakingNoticesRepository.observeStakingNotices(),
+        stakingSharedState.selectedOption
+    ) { notices, option -> notices[option.assetWithChain.chain.id] }
+        .shareInBackground()
 
     val migrationAlertFlow = selectedAssetFlow.flatMapLatest {
         val chainAsset = it.token.configuration
@@ -133,6 +143,8 @@ class StakingViewModel(
     init {
         stakingUpdateSystem.start()
             .launchIn(this)
+
+        launch { runCatching { stakingNoticesRepository.syncStakingNotices() } }
     }
 
     private fun learnMoreMigrationClicked(config: ChainMigrationConfig) {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/di/StakingModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/di/StakingModule.kt
@@ -24,6 +24,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.com
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.unbonding.UnbondingComponentFactory
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.userRewards.UserRewardsComponentFactory
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.components.yourPool.YourPoolComponentFactory
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.main.di.components.ComponentsModule
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 
@@ -52,7 +53,8 @@ class StakingModule {
         stakingSharedState: StakingSharedState,
         resourceManager: ResourceManager,
         externalActionsMixin: ExternalActions.Presentation,
-        chainMigrationInfoUseCase: ChainMigrationInfoUseCase
+        chainMigrationInfoUseCase: ChainMigrationInfoUseCase,
+        stakingNoticesRepository: StakingNoticesRepository
     ): ViewModel {
         return StakingViewModel(
             selectedAccountUseCase = selectedAccountUseCase,
@@ -70,7 +72,8 @@ class StakingModule {
             stakingSharedState = stakingSharedState,
             resourceManager = resourceManager,
             externalActionsMixin = externalActionsMixin,
-            chainMigrationInfoUseCase = chainMigrationInfoUseCase
+            chainMigrationInfoUseCase = chainMigrationInfoUseCase,
+            stakingNoticesRepository = stakingNoticesRepository
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingFragment.kt
@@ -12,6 +12,7 @@ import io.novafoundation.nova.common.list.CustomPlaceholderAdapter
 import io.novafoundation.nova.common.mixin.actionAwaitable.awaitableActionFlow
 import io.novafoundation.nova.common.mixin.impl.observeBrowserEvents
 import io.novafoundation.nova.common.mixin.impl.observeValidations
+import io.novafoundation.nova.common.utils.setVisible
 import io.novafoundation.nova.common.view.dialog.dialog
 import io.novafoundation.nova.common.view.setProgressState
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
@@ -66,6 +67,11 @@ class StartStakingLandingFragment :
         observeValidations(viewModel)
 
         viewModel.isContinueButtonLoading.observe(binder.startStakingLandingButton::setProgressState)
+
+        viewModel.noticeForCurrentChain.observe { notice ->
+            binder.startStakingLandingNoticeBlock.setVisible(notice != null)
+            notice?.let { binder.startStakingLandingNoticeBlock.bind(it) }
+        }
 
         viewModel.modelFlow.observe {
             val isLoaded = it.isLoaded()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingFragment.kt
@@ -19,6 +19,7 @@ import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.databinding.FragmentStartStakingLandingBinding
 import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.landing.critical.StartStakingCriticalNoticeBottomSheet
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.landing.model.StartStakingLandingPayload
 
 class StartStakingLandingFragment :
@@ -112,6 +113,14 @@ class StartStakingLandingFragment :
                     action.onSuccess(Unit)
                 }
             }
+        }
+
+        viewModel.showCriticalNoticeEvent.observe { notice ->
+            StartStakingCriticalNoticeBottomSheet(
+                context = requireContext(),
+                notice = notice,
+                onContinueClicked = { viewModel.userConfirmedCriticalNotice() }
+            ).show()
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
@@ -72,6 +72,7 @@ import io.novafoundation.nova.runtime.multiNetwork.asset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.hash.isPositive
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -167,19 +168,40 @@ class StartStakingLandingViewModel(
 
     override val openBrowserEvent = MutableLiveData<Event<String>>()
 
+    private val _showCriticalNoticeEvent = MutableSharedFlow<StakingNotice>(extraBufferCapacity = 1)
+    val showCriticalNoticeEvent: Flow<StakingNotice> = _showCriticalNoticeEvent
+
+    @Volatile
+    private var currentNotice: StakingNotice? = null
+
     init {
         launchSync()
 
         closeOnStakingStarted()
 
         launch { runCatching { stakingNoticesRepository.syncStakingNotices() } }
+
+        launch { noticeForCurrentChain.collect { currentNotice = it } }
     }
 
     fun back() {
         router.back()
     }
 
-    fun continueClicked() = launch {
+    fun continueClicked() {
+        val notice = currentNotice
+        if (notice?.severity == StakingNotice.Severity.CRITICAL) {
+            launch { _showCriticalNoticeEvent.emit(notice) }
+            return
+        }
+        proceedToStakeSetup()
+    }
+
+    fun userConfirmedCriticalNotice() {
+        proceedToStakeSetup()
+    }
+
+    private fun proceedToStakeSetup() = launch {
         val interactor = startStakingInteractor.first()
 
         val validationSystem = interactor.validationSystem()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
@@ -45,6 +45,8 @@ import io.novafoundation.nova.common.validation.progressConsumer
 import io.novafoundation.nova.feature_account_api.domain.interfaces.SelectedAccountUseCase
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.StakingLandingInfoUpdateSystemFactory
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
 import io.novafoundation.nova.feature_staking_impl.domain.model.PayoutType
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.StakingStartedDetectionService
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.awaitStakingStarted
@@ -69,6 +71,7 @@ import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.asset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novasama.substrate_sdk_android.hash.isPositive
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -102,7 +105,8 @@ class StartStakingLandingViewModel(
     private val stakingStartedDetectionService: StakingStartedDetectionService,
     private val chainRegistry: ChainRegistry,
     private val contextManager: ContextManager,
-    private val amountFormatter: AmountFormatter
+    private val amountFormatter: AmountFormatter,
+    private val stakingNoticesRepository: StakingNoticesRepository
 ) : BaseViewModel(),
     Browserable,
     Validatable by validationExecutor {
@@ -120,6 +124,10 @@ class StartStakingLandingViewModel(
             computationalScope = this
         )
     }.shareInBackground()
+
+    val noticeForCurrentChain: Flow<StakingNotice?> = stakingNoticesRepository.observeStakingNotices()
+        .map { notices -> notices[availableStakingOptionsPayload.chainId] }
+        .shareInBackground()
 
     val acknowledgeStakingStarted = actionAwaitableMixinFactory.confirmingAction<AcknowledgeStakingStartedTitle>()
 
@@ -163,6 +171,8 @@ class StartStakingLandingViewModel(
         launchSync()
 
         closeOnStakingStarted()
+
+        launch { runCatching { stakingNoticesRepository.syncStakingNotices() } }
     }
 
     fun back() {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/critical/StartStakingCriticalNoticeBottomSheet.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/critical/StartStakingCriticalNoticeBottomSheet.kt
@@ -2,6 +2,8 @@ package io.novafoundation.nova.feature_staking_impl.presentation.staking.start.l
 
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import io.novafoundation.nova.common.R as CommonR
 import io.novafoundation.nova.common.view.bottomSheet.BaseBottomSheet
 import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
@@ -20,6 +22,10 @@ class StartStakingCriticalNoticeBottomSheet(
         BottomSheetStartStakingCriticalNoticeBinding.inflate(LayoutInflater.from(context))
 
     init {
+        // Match iOS: lock the modal so back-button + outside-tap + swipe-down can't bypass
+        // the 10s friction. Cancel button or completed-countdown Continue are the only exits.
+        setCancelable(false)
+
         binder.startStakingCriticalNoticeTitle.text = notice.shortText
         binder.startStakingCriticalNoticeSubtitle.text = notice.longText
 
@@ -28,5 +34,13 @@ class StartStakingCriticalNoticeBottomSheet(
             onContinueClicked()
             dismiss()
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // Block swipe-down dismissal. Material 1.1.0 doesn't have setDraggable;
+        // isHideable=false achieves the same effect (sheet can't be dragged below peek).
+        @Suppress("UNCHECKED_CAST")
+        (behavior as BottomSheetBehavior<View>).isHideable = false
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/critical/StartStakingCriticalNoticeBottomSheet.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/critical/StartStakingCriticalNoticeBottomSheet.kt
@@ -1,0 +1,32 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.staking.start.landing.critical
+
+import android.content.Context
+import android.view.LayoutInflater
+import io.novafoundation.nova.common.R as CommonR
+import io.novafoundation.nova.common.view.bottomSheet.BaseBottomSheet
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import io.novafoundation.nova.feature_staking_impl.databinding.BottomSheetStartStakingCriticalNoticeBinding
+
+class StartStakingCriticalNoticeBottomSheet(
+    context: Context,
+    private val notice: StakingNotice,
+    private val onContinueClicked: () -> Unit,
+) : BaseBottomSheet<BottomSheetStartStakingCriticalNoticeBinding>(
+    context,
+    CommonR.style.BottomSheetDialog,
+) {
+
+    override val binder: BottomSheetStartStakingCriticalNoticeBinding =
+        BottomSheetStartStakingCriticalNoticeBinding.inflate(LayoutInflater.from(context))
+
+    init {
+        binder.startStakingCriticalNoticeTitle.text = notice.shortText
+        binder.startStakingCriticalNoticeSubtitle.text = notice.longText
+
+        binder.startStakingCriticalNoticeCancel.setOnClickListener { dismiss() }
+        binder.startStakingCriticalNoticeConfirm.setOnClickListener {
+            onContinueClicked()
+            dismiss()
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/di/StartStakingLandingModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/di/StartStakingLandingModule.kt
@@ -16,6 +16,7 @@ import io.novafoundation.nova.common.validation.ValidationExecutor
 import io.novafoundation.nova.feature_account_api.domain.interfaces.SelectedAccountUseCase
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.StakingLandingInfoUpdateSystemFactory
 import io.novafoundation.nova.feature_staking_impl.data.network.blockhain.updaters.StakingUpdaters
+import io.novafoundation.nova.feature_staking_impl.data.notices.repository.StakingNoticesRepository
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.common.StakingStartedDetectionService
 import io.novafoundation.nova.feature_staking_impl.domain.staking.start.landing.StakingTypeDetailsCompoundInteractorFactory
 import io.novafoundation.nova.feature_staking_impl.presentation.StartMultiStakingRouter
@@ -57,7 +58,8 @@ class StartStakingLandingModule {
         stakingStartedDetectionService: StakingStartedDetectionService,
         chainRegistry: ChainRegistry,
         contextManager: ContextManager,
-        amountFormatter: AmountFormatter
+        amountFormatter: AmountFormatter,
+        stakingNoticesRepository: StakingNoticesRepository
     ): ViewModel {
         return StartStakingLandingViewModel(
             router = router,
@@ -72,7 +74,8 @@ class StartStakingLandingModule {
             stakingStartedDetectionService = stakingStartedDetectionService,
             chainRegistry = chainRegistry,
             contextManager = contextManager,
-            amountFormatter = amountFormatter
+            amountFormatter = amountFormatter,
+            stakingNoticesRepository = stakingNoticesRepository
         )
     }
 

--- a/feature-staking-impl/src/main/res/layout/bottom_sheet_start_staking_critical_notice.xml
+++ b/feature-staking-impl/src/main/res/layout/bottom_sheet_start_staking_critical_notice.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
+
+    <View
+        style="@style/Widget.Nova.Puller"
+        android:layout_marginTop="6dp" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/startStakingCriticalNoticeImage"
+        android:layout_width="88dp"
+        android:layout_height="88dp"
+        android:layout_marginTop="20dp"
+        android:background="@drawable/bg_icon_big"
+        android:padding="12dp"
+        android:src="@drawable/ic_warning_filled" />
+
+    <TextView
+        android:id="@+id/startStakingCriticalNoticeTitle"
+        style="@style/TextAppearance.NovaFoundation.SemiBold.Title3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="24dp"
+        android:gravity="center"
+        android:textColor="@color/text_primary" />
+
+    <TextView
+        android:id="@+id/startStakingCriticalNoticeSubtitle"
+        style="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:textColor="@color/text_secondary"
+        tools:text="Message" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="10dp"
+        android:paddingTop="24dp"
+        android:paddingBottom="24dp">
+
+        <io.novafoundation.nova.common.view.PrimaryButtonV2
+            android:id="@+id/startStakingCriticalNoticeCancel"
+            style="@style/Widget.Nova.MaterialButton.Secondary"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="6dp"
+            android:layout_weight="1"
+            app:appearance="secondary"
+            android:text="@string/common_cancel" />
+
+        <io.novafoundation.nova.common.view.DelayedButton
+            android:id="@+id/startStakingCriticalNoticeConfirm"
+            style="@style/Widget.Nova.MaterialButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/selector_button_text"
+            android:text="@string/common_continue"
+            app:backgroundTint="@color/selector_button_background_on_gradient_negative"
+            app:delayDuration="10000"
+            app:progressColor="@color/block_background" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_staking.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_staking.xml
@@ -29,6 +29,14 @@
             android:paddingTop="16dp"
             android:paddingBottom="8dp">
 
+            <io.novafoundation.nova.feature_staking_impl.presentation.common.view.StakingNoticeBlockView
+                android:id="@+id/stakingDetailsNoticeBlock"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
             <io.novafoundation.nova.common.view.AlertView
                 android:id="@+id/stakingMigrationAlert"
                 android:layout_width="match_parent"

--- a/feature-staking-impl/src/main/res/layout/fragment_start_staking_landing.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_start_staking_landing.xml
@@ -16,6 +16,19 @@
         app:homeButtonIcon="@drawable/ic_close"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <io.novafoundation.nova.feature_staking_impl.presentation.common.view.StakingNoticeBlockView
+        android:id="@+id/startStakingLandingNoticeBlock"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="12dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/startStakingLandingToolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:visibility="visible" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/startStakingLandingList"
         android:layout_width="match_parent"
@@ -27,7 +40,7 @@
         android:paddingBottom="28dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toTopOf="@+id/startStakingLandingButtonContainer"
-        app:layout_constraintTop_toBottomOf="@+id/startStakingLandingToolbar" />
+        app:layout_constraintTop_toBottomOf="@+id/startStakingLandingNoticeBlock" />
 
     <LinearLayout
         android:id="@+id/startStakingLandingButtonContainer"

--- a/feature-staking-impl/src/main/res/layout/item_dashboard_has_stake.xml
+++ b/feature-staking-impl/src/main/res/layout/item_dashboard_has_stake.xml
@@ -7,6 +7,15 @@
     tools:background="@color/block_background"
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
+    <io.novafoundation.nova.feature_staking_impl.presentation.common.view.StakingNoticeStripView
+        android:id="@+id/stakingActiveCardNoticeStrip"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <com.facebook.shimmer.ShimmerFrameLayout
         android:id="@+id/itemDashboardHasStakeAssetContainer"
         android:layout_width="wrap_content"
@@ -18,7 +27,7 @@
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@+id/stakingActiveCardNoticeStrip">
 
         <ImageView
             android:id="@+id/itemDashboardHasStakeAssetIcon"

--- a/feature-staking-impl/src/main/res/layout/item_dashboard_has_stake.xml
+++ b/feature-staking-impl/src/main/res/layout/item_dashboard_has_stake.xml
@@ -138,7 +138,7 @@
         android:layout_marginBottom="4dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/stakingActiveCardNoticeStrip"
         app:layout_constraintWidth_min="130dp"
         tools:background="@color/block_background_dark" />
 
@@ -150,7 +150,7 @@
         android:layout_marginEnd="14dp"
         android:src="@drawable/ic_chevron_right"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/stakingActiveCardNoticeStrip"
         app:tint="@color/icon_secondary" />
 
     <com.facebook.shimmer.ShimmerFrameLayout

--- a/feature-staking-impl/src/main/res/layout/item_dashboard_no_stake.xml
+++ b/feature-staking-impl/src/main/res/layout/item_dashboard_no_stake.xml
@@ -46,6 +46,18 @@
 
     </com.facebook.shimmer.ShimmerFrameLayout>
 
+    <io.novafoundation.nova.feature_staking_impl.presentation.common.view.StakingNoticeChipView
+        android:id="@+id/noStakeRowNoticeChip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/item_dashboard_no_stake_token_name_container"
+        app:layout_constraintStart_toEndOf="@+id/item_dashboard_no_stake_token_name_container"
+        app:layout_constraintTop_toTopOf="@+id/item_dashboard_no_stake_token_name_container"
+        tools:text="Notice"
+        tools:visibility="visible" />
+
     <io.novafoundation.nova.feature_staking_impl.presentation.dashboard.main.view.StakingTypeBadgeView
         android:id="@+id/itemDashboardNoStakeStakingType"
         style="@style/Widget.Nova.StakingTypeBadge.Small"
@@ -54,7 +66,7 @@
         android:layout_marginEnd="16dp"
         app:layout_constraintBottom_toBottomOf="@+id/item_dashboard_no_stake_token_name_container"
         app:layout_constraintEnd_toStartOf="@+id/itemDashboardNoStakeEarningsContainer"
-        app:layout_constraintStart_toEndOf="@+id/item_dashboard_no_stake_token_name_container"
+        app:layout_constraintStart_toEndOf="@+id/noStakeRowNoticeChip"
         app:layout_constraintTop_toTopOf="@+id/item_dashboard_no_stake_token_name_container"
         tools:text="@string/nomination_pools_direct" />
 

--- a/feature-staking-impl/src/main/res/layout/view_staking_notice_block.xml
+++ b/feature-staking-impl/src/main/res/layout/view_staking_notice_block.xml
@@ -7,6 +7,7 @@
         android:id="@+id/stakingNoticeBlockTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center"
         android:textSize="17sp"
         android:textStyle="bold"
         tools:text="Manta Atlantic is shutting down" />
@@ -16,8 +17,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:gravity="center"
         android:textSize="14sp"
         android:lineSpacingExtra="2sp"
+        android:textColor="@color/text_primary"
         tools:text="Multi-paragraph body explaining the notice." />
 
 </merge>

--- a/feature-staking-impl/src/main/res/layout/view_staking_notice_block.xml
+++ b/feature-staking-impl/src/main/res/layout/view_staking_notice_block.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="android.widget.LinearLayout">
+
+    <TextView
+        android:id="@+id/stakingNoticeBlockTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        tools:text="Manta Atlantic is shutting down" />
+
+    <TextView
+        android:id="@+id/stakingNoticeBlockBody"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textSize="14sp"
+        android:lineSpacingExtra="2sp"
+        tools:text="Multi-paragraph body explaining the notice." />
+
+</merge>

--- a/feature-staking-impl/src/main/res/layout/view_staking_notice_chip.xml
+++ b/feature-staking-impl/src/main/res/layout/view_staking_notice_chip.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/stakingNoticeChipText"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="8dp"
+    android:paddingVertical="2dp"
+    android:textSize="11sp"
+    android:textStyle="bold"
+    android:text="@string/staking_notice_chip_label" />

--- a/feature-staking-impl/src/main/res/layout/view_staking_notice_strip.xml
+++ b/feature-staking-impl/src/main/res/layout/view_staking_notice_strip.xml
@@ -8,11 +8,11 @@
         android:layout_width="match_parent"
         android:layout_height="28dp"
         android:gravity="center"
-        android:textSize="13sp"
-        android:textStyle="bold"
+        android:textSize="14sp"
+        android:fontFamily="sans-serif-medium"
         android:maxLines="1"
         android:ellipsize="end"
-        android:paddingHorizontal="12dp"
+        android:paddingHorizontal="14dp"
         tools:text="Manta Atlantic critical notice short text" />
 
 </merge>

--- a/feature-staking-impl/src/main/res/layout/view_staking_notice_strip.xml
+++ b/feature-staking-impl/src/main/res/layout/view_staking_notice_strip.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <TextView
+        android:id="@+id/stakingNoticeStripText"
+        android:layout_width="match_parent"
+        android:layout_height="28dp"
+        android:gravity="center"
+        android:textSize="13sp"
+        android:textStyle="bold"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:paddingHorizontal="12dp"
+        tools:text="Manta Atlantic critical notice short text" />
+
+</merge>

--- a/feature-staking-impl/src/main/res/values/colors.xml
+++ b/feature-staking-impl/src/main/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Notice strip / block severity colors.
+         CRITICAL (red): references common text_negative + error_block_background.
+         INFO (yellow): references common text_warning + warning_block_background. -->
+    <color name="notice_critical_bg">@color/error_block_background</color>
+    <color name="notice_critical_text">@color/text_negative</color>
+    <color name="notice_info_bg">@color/warning_block_background</color>
+    <color name="notice_info_text">@color/text_warning</color>
+</resources>

--- a/feature-staking-impl/src/main/res/values/strings.xml
+++ b/feature-staking-impl/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="staking_notice_chip_label">Notice</string>
+</resources>

--- a/feature-staking-impl/src/main/res/values/strings.xml
+++ b/feature-staking-impl/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="staking_notice_chip_label">Notice</string>
-</resources>

--- a/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/StakingNoticeDecoderTest.kt
+++ b/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/StakingNoticeDecoderTest.kt
@@ -1,0 +1,96 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.model
+
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+class StakingNoticeDecoderTest {
+
+    private val gson = Gson()
+
+    private fun loadFixture(name: String): String =
+        javaClass.getResourceAsStream("/notices/$name")!!.bufferedReader().use { it.readText() }
+
+    private fun decode(name: String, locale: String, today: LocalDate = LocalDate.of(2026, 5, 12)): List<StakingNotice> {
+        val rawList = gson.fromJson(loadFixture(name), Array<StakingNoticeDto>::class.java).toList()
+        return rawList.mapNotNull { it.toDomain(locale, today) }
+    }
+
+    @Test
+    fun `plain string shortText is decoded for any locale`() {
+        val notices = decode("notice_plain_string.json", locale = "ru")
+        assertEquals(1, notices.size)
+        assertEquals("Plain English short", notices[0].shortText)
+        assertEquals(StakingNotice.Severity.CRITICAL, notices[0].severity)
+    }
+
+    @Test
+    fun `locale map picks the user locale when present`() {
+        val notices = decode("notice_locale_map.json", locale = "ru")
+        assertEquals("RU short", notices[0].shortText)
+        assertEquals("RU long", notices[0].longText)
+    }
+
+    @Test
+    fun `locale map falls back to en when user locale absent`() {
+        val notices = decode("notice_locale_map.json", locale = "ja")
+        assertEquals("EN short", notices[0].shortText)
+    }
+
+    @Test
+    fun `locale map missing en is dropped entirely`() {
+        val notices = decode("notice_missing_en.json", locale = "ja")
+        assertTrue("notice without en should be dropped", notices.isEmpty())
+    }
+
+    @Test
+    fun `locale falls back from pt-BR to pt to en cascade`() {
+        val notices = decode("notice_locale_map.json", locale = "pt-BR")
+        assertEquals("EN short", notices[0].shortText)
+    }
+
+    @Test
+    fun `past endDate is filtered out`() {
+        val notices = decode("notice_past_enddate.json", locale = "en", today = LocalDate.of(2026, 5, 12))
+        assertTrue("past-endDate notice should be filtered", notices.isEmpty())
+    }
+
+    @Test
+    fun `future endDate is kept`() {
+        val notices = decode("notice_future_enddate.json", locale = "en")
+        assertEquals(1, notices.size)
+        assertEquals(LocalDate.of(2099, 1, 1), notices[0].endDate)
+    }
+
+    @Test
+    fun `absent endDate is kept as null`() {
+        val notices = decode("notice_no_enddate.json", locale = "en")
+        assertEquals(1, notices.size)
+        assertNull(notices[0].endDate)
+    }
+
+    @Test
+    fun `severity info decodes to INFO`() {
+        val notices = decode("notice_locale_map.json", locale = "en")
+        assertEquals(StakingNotice.Severity.INFO, notices[0].severity)
+    }
+
+    @Test
+    fun `severity critical decodes to CRITICAL`() {
+        val notices = decode("notice_plain_string.json", locale = "en")
+        assertEquals(StakingNotice.Severity.CRITICAL, notices[0].severity)
+    }
+
+    @Test
+    fun `chainId is preserved verbatim`() {
+        val notices = decode("notice_plain_string.json", locale = "en")
+        assertEquals(
+            "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+            notices[0].chainId
+        )
+    }
+}

--- a/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/StakingNoticeDecoderTest.kt
+++ b/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/data/notices/model/StakingNoticeDecoderTest.kt
@@ -54,6 +54,13 @@ class StakingNoticeDecoderTest {
     }
 
     @Test
+    fun `locale strips multiple region segments iteratively`() {
+        // zh-Hans-CN should resolve via zh-Hans, not skip straight to en.
+        val notices = decode("notice_locale_map_with_intermediate.json", locale = "zh-Hans-CN")
+        assertEquals("ZH-HANS", notices[0].shortText)
+    }
+
+    @Test
     fun `past endDate is filtered out`() {
         val notices = decode("notice_past_enddate.json", locale = "en", today = LocalDate.of(2026, 5, 12))
         assertTrue("past-endDate notice should be filtered", notices.isEmpty())

--- a/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepositoryTest.kt
+++ b/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepositoryTest.kt
@@ -16,6 +16,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.never
 import org.mockito.BDDMockito.times
@@ -120,6 +121,46 @@ class RealStakingNoticesRepositoryTest {
         repo.syncStakingNotices()
         val after = repo.observeStakingNotices().firstOrNull()
         assertEquals(initial, after)
+    }
+
+    @Test
+    fun `decode uses SharedPreferences language code, picks ru from locale map`() = runTest {
+        val localeMapJson = """
+            [
+              {
+                "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+                "severity": "info",
+                "shortText": { "en": "EN", "ru": "RU short" },
+                "longText":  { "en": "EN long", "ru": "RU long" }
+              }
+            ]
+        """.trimIndent()
+        given(sharedPreferences.getString(eq("lang"), Mockito.isNull())).willReturn("ru")
+        given(diskCache.read()).willReturn(localeMapJson)
+        val repo = newRepo()
+        advanceUntilIdle()
+        val map = repo.observeStakingNotices().firstOrNull()
+        assertEquals("RU short", map?.values?.first()?.shortText)
+    }
+
+    @Test
+    fun `Android pt language code is mapped to JSON pt-PT key`() = runTest {
+        val localeMapJson = """
+            [
+              {
+                "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+                "severity": "info",
+                "shortText": { "en": "EN", "pt-PT": "PT short" },
+                "longText":  { "en": "EN long", "pt-PT": "PT long" }
+              }
+            ]
+        """.trimIndent()
+        given(sharedPreferences.getString(eq("lang"), Mockito.isNull())).willReturn("pt")
+        given(diskCache.read()).willReturn(localeMapJson)
+        val repo = newRepo()
+        advanceUntilIdle()
+        val map = repo.observeStakingNotices().firstOrNull()
+        assertEquals("PT short", map?.values?.first()?.shortText)
     }
 
     @Test

--- a/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepositoryTest.kt
+++ b/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/data/notices/repository/RealStakingNoticesRepositoryTest.kt
@@ -1,0 +1,135 @@
+package io.novafoundation.nova.feature_staking_impl.data.notices.repository
+
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import io.novafoundation.nova.feature_staking_impl.data.notices.cache.StakingNoticesDiskCache
+import io.novafoundation.nova.feature_staking_impl.data.notices.network.StakingNoticesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.never
+import org.mockito.BDDMockito.times
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+
+// Debounce window is 5 minutes; pass a time well beyond it to allow the first sync through.
+private const val AFTER_DEBOUNCE = 5L * 60 * 1000 + 1   // 300_001 ms
+
+private const val SAMPLE_JSON = """
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+    "severity": "critical",
+    "shortText": "Short",
+    "longText":  "Long"
+  }
+]
+"""
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RealStakingNoticesRepositoryTest {
+
+    private lateinit var api: StakingNoticesApi
+    private lateinit var diskCache: StakingNoticesDiskCache
+    private lateinit var sharedPreferences: SharedPreferences
+    private val gson = Gson()
+
+    @Before
+    fun setUp() {
+        api = Mockito.mock(StakingNoticesApi::class.java)
+        diskCache = Mockito.mock(StakingNoticesDiskCache::class.java)
+        sharedPreferences = Mockito.mock(SharedPreferences::class.java)
+    }
+
+    private fun TestScope.newRepo(now: Long = 0L) = RealStakingNoticesRepository(
+        api = api,
+        diskCache = diskCache,
+        gson = gson,
+        sharedPreferences = sharedPreferences,
+        sharedPreferencesLanguageKey = "lang",
+        remoteUrl = "http://x",
+        timeProvider = { now },
+        externalScope = this,
+    )
+
+    @Test
+    fun `cold init with no disk cache emits empty map`() = runTest {
+        given(diskCache.read()).willReturn(null)
+        val repo = newRepo()
+        advanceUntilIdle()
+        val map = repo.observeStakingNotices().firstOrNull()
+        assertNotNull(map)
+        assertTrue(map!!.isEmpty())
+    }
+
+    @Test
+    fun `cold init with disk cache decodes and emits without network call`() = runTest {
+        given(diskCache.read()).willReturn(SAMPLE_JSON)
+        val repo = newRepo()
+        advanceUntilIdle()
+        val map = repo.observeStakingNotices().firstOrNull()
+        assertEquals(1, map?.size)
+        verify(api, never()).fetchStakingNotices(Mockito.anyString())
+    }
+
+    @Test
+    fun `syncStakingNotices fetches, writes disk, and emits new map`() = runTest {
+        given(diskCache.read()).willReturn(null)
+        given(api.fetchStakingNotices(Mockito.anyString())).willReturn(SAMPLE_JSON)
+        // timeProvider() must exceed DEBOUNCE_MILLIS so the first sync is not short-circuited
+        val repo = newRepo(now = AFTER_DEBOUNCE)
+        advanceUntilIdle()
+        // consume the initial empty emission
+        repo.observeStakingNotices().first()
+        repo.syncStakingNotices()
+        val map = repo.observeStakingNotices().first()
+        assertEquals(1, map.size)
+        verify(diskCache).write(SAMPLE_JSON)
+    }
+
+    @Test
+    fun `second sync within debounce window does not call api`() = runTest {
+        given(diskCache.read()).willReturn(null)
+        given(api.fetchStakingNotices(Mockito.anyString())).willReturn(SAMPLE_JSON)
+        // timeProvider() always returns AFTER_DEBOUNCE, so first sync proceeds;
+        // after first sync lastSuccessfulSyncAt = AFTER_DEBOUNCE, second sync: AFTER_DEBOUNCE - AFTER_DEBOUNCE = 0 < DEBOUNCE → blocked
+        val repo = newRepo(now = AFTER_DEBOUNCE)
+        advanceUntilIdle()
+        repo.syncStakingNotices()
+        repo.syncStakingNotices()
+        verify(api, times(1)).fetchStakingNotices(Mockito.anyString())
+    }
+
+    @Test
+    fun `api failure leaves state unchanged`() = runTest {
+        given(diskCache.read()).willReturn(SAMPLE_JSON)
+        given(api.fetchStakingNotices(Mockito.anyString())).willAnswer { throw RuntimeException("net fail") }
+        val repo = newRepo(now = AFTER_DEBOUNCE)
+        advanceUntilIdle()
+        val initial = repo.observeStakingNotices().firstOrNull()
+        repo.syncStakingNotices()
+        val after = repo.observeStakingNotices().firstOrNull()
+        assertEquals(initial, after)
+    }
+
+    @Test
+    fun `garbage json on disk yields no emission and does not crash`() = runTest {
+        given(diskCache.read()).willReturn("not valid json")
+        val repo = newRepo()
+        advanceUntilIdle()
+        // bad cache: decode() returns null so decodeFromDiskAndEmit() returns without emitting
+        // replayCache will be empty — confirm this via SharedFlow's replay cache
+        val sharedFlow = repo.observeStakingNotices() as SharedFlow<*>
+        assertTrue("no emission expected on garbage json", sharedFlow.replayCache.isEmpty())
+    }
+}

--- a/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/domain/dashboard/StakingDashboardDemotionTest.kt
+++ b/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/domain/dashboard/StakingDashboardDemotionTest.kt
@@ -1,0 +1,40 @@
+package io.novafoundation.nova.feature_staking_impl.domain.dashboard
+
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.tier.StakingDashboardTierConfig
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.KnownChainIds
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StakingDashboardDemotionTest {
+
+    @Test
+    fun `all 7 demoted chain ids are present in the demotion set`() {
+        val expected = setOf(
+            KnownChainIds.MANTA_ATLANTIC,
+            KnownChainIds.ALEPH_ZERO,
+            KnownChainIds.VARA,
+            KnownChainIds.ZEITGEIST,
+            KnownChainIds.MOONRIVER,
+            KnownChainIds.POLKADEX,
+            KnownChainIds.TERNOA,
+        )
+        assertEquals(expected, StakingDashboardTierConfig.demotedChainIds)
+    }
+
+    @Test
+    fun `manta atlantic chain id hex string is exactly the value from chains json`() {
+        assertEquals(
+            "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+            KnownChainIds.MANTA_ATLANTIC
+        )
+    }
+
+    @Test
+    fun `all 7 chain ids are 64 char hex strings`() {
+        StakingDashboardTierConfig.demotedChainIds.forEach { chainId ->
+            assertEquals("chainId $chainId should be 64 chars", 64, chainId.length)
+            assertTrue("chainId $chainId should be hex", chainId.matches(Regex("[0-9a-f]+")))
+        }
+    }
+}

--- a/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingCriticalNoticeInterceptTest.kt
+++ b/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingCriticalNoticeInterceptTest.kt
@@ -1,0 +1,38 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.staking.start.landing
+
+import io.novafoundation.nova.feature_staking_impl.data.notices.model.StakingNotice
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StartStakingCriticalNoticeInterceptTest {
+
+    /**
+     * Intercept decision: given the currently-resolved StakingNotice (or null), should the
+     * Start CTA show the critical sheet first, or proceed directly?
+     */
+    private fun shouldShowCriticalSheet(notice: StakingNotice?): Boolean =
+        notice?.severity == StakingNotice.Severity.CRITICAL
+
+    private fun fakeNotice(severity: StakingNotice.Severity) = StakingNotice(
+        chainId = "deadbeef",
+        severity = severity,
+        shortText = "x",
+        longText = "y",
+        endDate = null
+    )
+
+    @Test
+    fun `no notice does not show sheet`() {
+        assertEquals(false, shouldShowCriticalSheet(null))
+    }
+
+    @Test
+    fun `info notice does not show sheet`() {
+        assertEquals(false, shouldShowCriticalSheet(fakeNotice(StakingNotice.Severity.INFO)))
+    }
+
+    @Test
+    fun `critical notice shows sheet`() {
+        assertEquals(true, shouldShowCriticalSheet(fakeNotice(StakingNotice.Severity.CRITICAL)))
+    }
+}

--- a/feature-staking-impl/src/test/resources/notices/notice_future_enddate.json
+++ b/feature-staking-impl/src/test/resources/notices/notice_future_enddate.json
@@ -1,0 +1,9 @@
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+    "severity": "info",
+    "shortText": "Future notice",
+    "longText": "Should be kept",
+    "endDate": "2099-01-01"
+  }
+]

--- a/feature-staking-impl/src/test/resources/notices/notice_locale_map.json
+++ b/feature-staking-impl/src/test/resources/notices/notice_locale_map.json
@@ -1,0 +1,8 @@
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+    "severity": "info",
+    "shortText": { "en": "EN short", "ru": "RU short", "es": "ES short" },
+    "longText": { "en": "EN long", "ru": "RU long", "es": "ES long" }
+  }
+]

--- a/feature-staking-impl/src/test/resources/notices/notice_locale_map_with_intermediate.json
+++ b/feature-staking-impl/src/test/resources/notices/notice_locale_map_with_intermediate.json
@@ -1,0 +1,8 @@
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+    "severity": "info",
+    "shortText": { "en": "EN", "zh-Hans": "ZH-HANS" },
+    "longText":  { "en": "EN long", "zh-Hans": "ZH-HANS long" }
+  }
+]

--- a/feature-staking-impl/src/test/resources/notices/notice_missing_en.json
+++ b/feature-staking-impl/src/test/resources/notices/notice_missing_en.json
@@ -1,0 +1,8 @@
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+    "severity": "critical",
+    "shortText": { "ru": "RU only" },
+    "longText": { "ru": "RU only long" }
+  }
+]

--- a/feature-staking-impl/src/test/resources/notices/notice_no_enddate.json
+++ b/feature-staking-impl/src/test/resources/notices/notice_no_enddate.json
@@ -1,0 +1,8 @@
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+    "severity": "info",
+    "shortText": "No expiry",
+    "longText": "Kept indefinitely"
+  }
+]

--- a/feature-staking-impl/src/test/resources/notices/notice_past_enddate.json
+++ b/feature-staking-impl/src/test/resources/notices/notice_past_enddate.json
@@ -1,0 +1,9 @@
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+    "severity": "info",
+    "shortText": "Expired notice",
+    "longText": "Should be filtered",
+    "endDate": "2020-01-01"
+  }
+]

--- a/feature-staking-impl/src/test/resources/notices/notice_plain_string.json
+++ b/feature-staking-impl/src/test/resources/notices/notice_plain_string.json
@@ -1,0 +1,9 @@
+[
+  {
+    "chainId": "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb",
+    "severity": "critical",
+    "shortText": "Plain English short",
+    "longText": "Plain English long body",
+    "endDate": "2026-12-31"
+  }
+]

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/KnownChainIds.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/KnownChainIds.kt
@@ -1,0 +1,11 @@
+package io.novafoundation.nova.runtime.multiNetwork.chain.model
+
+object KnownChainIds {
+    const val MANTA_ATLANTIC = "f3c7ad88f6a80f366c4be216691411ef0622e8b809b1046ea297ef106058d4eb"
+    const val ALEPH_ZERO     = "70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e"
+    const val VARA           = "fe1b4c55fd4d668101126434206571a7838a8b6b93a6d1b95d607e78e6c53763"
+    const val ZEITGEIST      = "1bf2a2ecb4a868de66ea8610f2ce7c8c43706561b6476031315f6640fe38e060"
+    const val MOONRIVER      = "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b"
+    const val POLKADEX       = "3920bcb4960a1eef5580cd5367ff3f430eef052774f78468852f7b9cb39f8a3c"
+    const val TERNOA         = "6859c81ca95ef624c9dfe4dc6e3381c33e5d6509e35e147092bfbc780f777c4e"
+}


### PR DESCRIPTION
## Summary

Android counterpart of novasamatech/nova-wallet-ios#1830. Two coupled changes to the staking experience:

**1. Tier demotion** — 7 staking networks (Vara, Zeitgeist, Moonriver, Aleph Zero, Polkadex, Ternoa, Manta Atlantic) are moved from the dashboard's offer list to the "More Options" screen. Existing user stakes are unaffected and continue to render in the dashboard's active section — this is a discovery-tier change only. Demotion source is a hardcoded `Set<ChainId>` (intentional: tier changes are slow-changing structural decisions).

**2. Notice system** — a new per-chain notice mechanism served from `nova-utils/notices/staking_notices.json`. No app update is needed to publish, edit, or remove a notice. Notices render in four UI contexts:
- Dashboard active stake card → banner strip on top
- Stake details screen → expanded block above the summary
- More Options row + dashboard offer row → `Notice` chip next to the chain name
- StartStakingLanding screen → expanded block above the "Earn up to %" headline

Two severity tiers: `info` (yellow) and `critical` (red). Critical-severity notices also present a locked bottom-sheet modal when the user taps "Start staking" on the StartStakingLanding screen, mirroring the existing watch-only Scam Risk Warning pattern (10-second-gated Continue, Cancel returns to landing). The inline block persists behind the modal as a reminder.

## Architecture

- `RealStakingNoticesRepository` (Dagger `@FeatureScope`). Retrofit `@GET @Url` returning raw JSON, written to disk cache before decoding so locale changes can re-decode without a network call. `MutableSharedFlow(replay = 1)` matches the existing `RealDAppMetadataRepository` pattern. Sync is triggered from each consumer ViewModel's `init` and debounced 5 minutes between successful syncs.
- Locale resolution reads the user's selected language directly from `SharedPreferences` (the canonical source `PreferencesImpl` writes to), independent of `Locale.getDefault()` timing. Maps Android iso639-only codes to the JSON's BCP-47 keys (`pt → pt-PT`, `zh → zh-Hans`, `in → id`); other codes pass through. Iterative cascade `fr-FR → fr → en` matches iOS. The JSON schema accepts plain strings or locale-map objects (`{"en": "...", "ru": "..."}`) per entry.
- A `SharedPreferences.OnSharedPreferenceChangeListener` re-decodes from disk on language change — no network call needed, text updates without an app restart.
- Critical-notice bottom sheet is locked: `setCancelable(false)` blocks back-button + outside-tap, `BottomSheetBehavior.isHideable = false` blocks swipe-down (Material 1.1.0 doesn't expose `setDraggable`; `isHideable=false` achieves the same effect). Mirrors iOS `presenterShouldHide: false`.
- Notices past their `endDate` are filtered automatically at decode time.
- Companion JSON shipped in novasamatech/nova-utils#4334.

## Notes

- Demoted-chain set lives in `StakingDashboardTierConfig.kt` — promoting/demoting a chain is a deliberate app-release decision.
- 7 demoted chainIds are independently verified against `nova-utils/chains/v22/chains.json`.
- 26 unit tests across 4 test files: notice decoder (12), repository (8), demotion config (3), critical-notice CTA intercept (3).
- This PR is independent of the nova-utils PR and can merge in either order: if the JSON isn't live yet, the repository yields an empty map and nothing renders.