### PR TITLE
Staking: Bittensor (TAO) — root + subnet positions

### DIFF
--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
@@ -10,8 +10,13 @@ import io.novafoundation.nova.feature_staking_impl.domain.staking.redeem.RedeemC
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmFragment
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupFragment
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorPickedValidator
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorValidatorPickerFragment
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmFragment
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.SubtensorUnstakeSetupFragment
 import androidx.lifecycle.asFlow
 import kotlinx.coroutines.flow.Flow
@@ -177,6 +182,13 @@ class RelayStakingNavigator(
             .navigateInFirstAttachedContext()
     }
 
+    override fun openSubtensorStakeConfirm(payload: SubtensorStakeConfirmPayload) {
+        val bundle = SubtensorStakeConfirmFragment.bundle(payload)
+        navigationBuilder().action(R.id.action_subtensorStakeSetup_to_subtensorStakeConfirm)
+            .setArgs(bundle)
+            .navigateInFirstAttachedContext()
+    }
+
     override fun openSubtensorValidatorPicker(netuid: Int) {
         val bundle = SubtensorValidatorPickerFragment.bundle(netuid = netuid)
         navigationBuilder().action(R.id.action_subtensorStakeSetup_to_subtensorValidatorPicker)
@@ -184,18 +196,25 @@ class RelayStakingNavigator(
             .navigateInFirstAttachedContext()
     }
 
-    override fun respondAndPopValidatorPicker(hotkey: String) {
+    override fun respondAndPopValidatorPicker(picked: SubtensorPickedValidator) {
         previousBackStackEntry!!.savedStateHandle.set(
-            SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR_HOTKEY,
-            hotkey,
+            SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR,
+            picked,
         )
         back()
     }
 
-    override val subtensorSelectedValidatorFlow: Flow<String?>
+    override val subtensorSelectedValidatorFlow: Flow<SubtensorPickedValidator?>
         get() = currentBackStackEntry!!.savedStateHandle
-            .getLiveData<String?>(SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR_HOTKEY)
+            .getLiveData<SubtensorPickedValidator?>(SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR)
             .asFlow()
+
+    override fun openSubtensorUnstakeConfirm(payload: SubtensorUnstakeConfirmPayload) {
+        val bundle = SubtensorUnstakeConfirmFragment.bundle(payload)
+        navigationBuilder().action(R.id.action_subtensorUnstakeSetup_to_subtensorUnstakeConfirm)
+            .setArgs(bundle)
+            .navigateInFirstAttachedContext()
+    }
 
     override fun openSubtensorUnstakeSetup(netuid: Int, hotkeyAddress: String, positionPlanks: java.math.BigInteger) {
         val bundle = SubtensorUnstakeSetupFragment.bundle(

--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/relaychain/RelayStakingNavigator.kt
@@ -7,8 +7,14 @@ import io.novafoundation.nova.app.root.navigation.navigators.Navigator
 import io.novafoundation.nova.feature_dapp_api.presentation.browser.main.DAppBrowserPayload
 import io.novafoundation.nova.feature_dapp_impl.presentation.DAppRouter
 import io.novafoundation.nova.feature_staking_impl.domain.staking.redeem.RedeemConsequences
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupFragment
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorValidatorPickerFragment
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.SubtensorUnstakeSetupFragment
+import androidx.lifecycle.asFlow
+import kotlinx.coroutines.flow.Flow
 import io.novafoundation.nova.feature_staking_impl.presentation.payouts.confirm.ConfirmPayoutFragment
 import io.novafoundation.nova.feature_staking_impl.presentation.payouts.confirm.model.ConfirmPayoutPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.payouts.detail.PayoutDetailsFragment
@@ -141,6 +147,64 @@ class RelayStakingNavigator(
 
     override fun openChainStakingMain() {
         navigationBuilder().action(R.id.action_mainFragment_to_stakingGraph)
+            .navigateInFirstAttachedContext()
+    }
+
+    override fun openSubtensorStakingMain() {
+        navigationBuilder().action(R.id.action_mainFragment_to_subtensorStakingMain)
+            .navigateInFirstAttachedContext()
+    }
+
+    override fun openSubtensorStakeType() {
+        navigationBuilder().action(R.id.action_subtensorStakingMain_to_subtensorStakeType)
+            .navigateInFirstAttachedContext()
+    }
+
+    override fun openSubtensorSubnetPicker() {
+        navigationBuilder().action(R.id.action_subtensorStakeType_to_subtensorSubnetPicker)
+            .navigateInFirstAttachedContext()
+    }
+
+    override fun openSubtensorStakeSetup(netuid: Int, subnetName: String?) {
+        val bundle = SubtensorStakeSetupFragment.bundle(netuid = netuid, subnetName = subnetName)
+        val action = if (netuid == SubtensorStakingConstants.ROOT_NETUID) {
+            R.id.action_subtensorStakeType_to_subtensorStakeSetup
+        } else {
+            R.id.action_subtensorSubnetPicker_to_subtensorStakeSetup
+        }
+        navigationBuilder().action(action)
+            .setArgs(bundle)
+            .navigateInFirstAttachedContext()
+    }
+
+    override fun openSubtensorValidatorPicker(netuid: Int) {
+        val bundle = SubtensorValidatorPickerFragment.bundle(netuid = netuid)
+        navigationBuilder().action(R.id.action_subtensorStakeSetup_to_subtensorValidatorPicker)
+            .setArgs(bundle)
+            .navigateInFirstAttachedContext()
+    }
+
+    override fun respondAndPopValidatorPicker(hotkey: String) {
+        previousBackStackEntry!!.savedStateHandle.set(
+            SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR_HOTKEY,
+            hotkey,
+        )
+        back()
+    }
+
+    override val subtensorSelectedValidatorFlow: Flow<String?>
+        get() = currentBackStackEntry!!.savedStateHandle
+            .getLiveData<String?>(SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR_HOTKEY)
+            .asFlow()
+
+    override fun openSubtensorUnstakeSetup(netuid: Int, hotkeyAddress: String, positionPlanks: java.math.BigInteger) {
+        val bundle = SubtensorUnstakeSetupFragment.bundle(
+            netuid = netuid,
+            hotkeyAddress = hotkeyAddress,
+            positionPlanks = positionPlanks,
+        )
+        navigationBuilder().action(R.id.action_subtensorStakingMain_to_subtensorUnstakeSetup)
+            .setArgs(bundle)
             .navigateInFirstAttachedContext()
     }
 

--- a/app/src/main/res/navigation/split_screen_nav_graph.xml
+++ b/app/src/main/res/navigation/split_screen_nav_graph.xml
@@ -740,7 +740,21 @@
         android:id="@+id/subtensorUnstakeSetupFragment"
         android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.SubtensorUnstakeSetupFragment"
         android:label="SubtensorUnstakeSetupFragment"
-        tools:layout="@layout/fragment_subtensor_unstake_setup" />
+        tools:layout="@layout/fragment_subtensor_unstake_setup">
+        <action
+            android:id="@+id/action_subtensorUnstakeSetup_to_subtensorUnstakeConfirm"
+            app:destination="@id/subtensorUnstakeConfirmFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/subtensorUnstakeConfirmFragment"
+        android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmFragment"
+        android:label="SubtensorUnstakeConfirmFragment"
+        tools:layout="@layout/fragment_subtensor_unstake_confirm" />
 
     <fragment
         android:id="@+id/subtensorStakeTypeFragment"
@@ -789,6 +803,13 @@
             app:exitAnim="@anim/fragment_open_exit"
             app:popEnterAnim="@anim/fragment_close_enter"
             app:popExitAnim="@anim/fragment_close_exit" />
+        <action
+            android:id="@+id/action_subtensorStakeSetup_to_subtensorStakeConfirm"
+            app:destination="@id/subtensorStakeConfirmFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
     </fragment>
 
     <fragment
@@ -796,6 +817,12 @@
         android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorValidatorPickerFragment"
         android:label="SubtensorValidatorPickerFragment"
         tools:layout="@layout/fragment_subtensor_validator_picker" />
+
+    <fragment
+        android:id="@+id/subtensorStakeConfirmFragment"
+        android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmFragment"
+        android:label="SubtensorStakeConfirmFragment"
+        tools:layout="@layout/fragment_subtensor_stake_confirm" />
 
     <fragment
         android:id="@+id/nodesFragment"

--- a/app/src/main/res/navigation/split_screen_nav_graph.xml
+++ b/app/src/main/res/navigation/split_screen_nav_graph.xml
@@ -596,6 +596,14 @@
             app:popExitAnim="@anim/fragment_close_exit" />
 
         <action
+            android:id="@+id/action_mainFragment_to_subtensorStakingMain"
+            app:destination="@id/subtensorStakingFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+
+        <action
             android:id="@+id/action_mainFragment_to_startStackingLanding"
             app:destination="@id/start_staking_nav_graph"
             app:enterAnim="@anim/fragment_open_enter"
@@ -706,6 +714,88 @@
         android:name="io.novafoundation.nova.feature_account_impl.presentation.account.list.multipleSelecting.SelectMultipleWalletsFragment"
         android:label="SelectMultipleWalletsFragment"
         tools:layout="@layout/fragment_select_multiple_wallets" />
+
+    <fragment
+        android:id="@+id/subtensorStakingFragment"
+        android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main.SubtensorStakingFragment"
+        android:label="SubtensorStakingFragment"
+        tools:layout="@layout/fragment_subtensor_staking">
+        <action
+            android:id="@+id/action_subtensorStakingMain_to_subtensorStakeType"
+            app:destination="@id/subtensorStakeTypeFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+        <action
+            android:id="@+id/action_subtensorStakingMain_to_subtensorUnstakeSetup"
+            app:destination="@id/subtensorUnstakeSetupFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/subtensorUnstakeSetupFragment"
+        android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.SubtensorUnstakeSetupFragment"
+        android:label="SubtensorUnstakeSetupFragment"
+        tools:layout="@layout/fragment_subtensor_unstake_setup" />
+
+    <fragment
+        android:id="@+id/subtensorStakeTypeFragment"
+        android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type.SubtensorStakeTypeFragment"
+        android:label="SubtensorStakeTypeFragment"
+        tools:layout="@layout/fragment_subtensor_stake_type">
+        <action
+            android:id="@+id/action_subtensorStakeType_to_subtensorStakeSetup"
+            app:destination="@id/subtensorStakeSetupFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+        <action
+            android:id="@+id/action_subtensorStakeType_to_subtensorSubnetPicker"
+            app:destination="@id/subtensorSubnetPickerFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/subtensorSubnetPickerFragment"
+        android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker.SubtensorSubnetPickerFragment"
+        android:label="SubtensorSubnetPickerFragment"
+        tools:layout="@layout/fragment_subtensor_subnet_picker">
+        <action
+            android:id="@+id/action_subtensorSubnetPicker_to_subtensorStakeSetup"
+            app:destination="@id/subtensorStakeSetupFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/subtensorStakeSetupFragment"
+        android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupFragment"
+        android:label="SubtensorStakeSetupFragment"
+        tools:layout="@layout/fragment_subtensor_stake_setup">
+        <action
+            android:id="@+id/action_subtensorStakeSetup_to_subtensorValidatorPicker"
+            app:destination="@id/subtensorValidatorPickerFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/subtensorValidatorPickerFragment"
+        android:name="io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorValidatorPickerFragment"
+        android:label="SubtensorValidatorPickerFragment"
+        tools:layout="@layout/fragment_subtensor_validator_picker" />
 
     <fragment
         android:id="@+id/nodesFragment"

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -2791,15 +2791,52 @@
     <string name="subtensor_subnet_picker_title">Select subnet</string>
     <string name="subtensor_subnet_picker_row_subtitle">SN%1$d · %2$s</string>
     <string name="subtensor_subnet_picker_empty">No active subnets found. Pull to retry.</string>
+    <string name="subtensor_subnet_filter_sort_total_stake">Total stake (TAO)</string>
+    <string name="subtensor_subnet_filter_sort_netuid">Subnet number</string>
     <string name="subtensor_validator_picker_title">Select validator</string>
     <string name="subtensor_validator_picker_loading_failed">Failed to load validators</string>
     <string name="subtensor_validator_picker_empty">No validators available</string>
+    <string name="subtensor_validator_filter_title">Filters</string>
+    <string name="subtensor_validator_filter_show">Show</string>
+    <string name="subtensor_validator_filter_identity">Having on-chain identity</string>
+    <string name="subtensor_validator_filter_hide_max_commission">Hide 100% commission</string>
+    <string name="subtensor_validator_filter_sort_by">Sort by</string>
+    <string name="subtensor_validator_filter_sort_apr">APR (high to low)</string>
+    <string name="subtensor_validator_filter_sort_total_stake">Total stake</string>
     <string name="subtensor_setup_invalid_validator">Invalid validator hotkey</string>
     <string name="subtensor_setup_submit_failed">Stake submission failed</string>
     <string name="subtensor_setup_submitting">Submitting…</string>
-    <string name="subtensor_unstake_position_label">Position</string>
+    <string name="subtensor_setup_available_label">Available: %1$s</string>
+    <string name="subtensor_setup_min_stake_label">Minimum stake</string>
+    <string name="subtensor_setup_network_fee_label">Network fee</string>
+    <string name="subtensor_confirm_subnet_title">Confirm — %1$s</string>
+    <string name="subtensor_unstake_position_label">Your stake</string>
     <string name="subtensor_unstake_max">Max</string>
     <string name="subtensor_unstake_amount_exceeds">Amount exceeds your stake</string>
     <string name="subtensor_unstake_pick_validator">Unstake from</string>
     <string name="subtensor_unstake_no_positions">No positions to unstake</string>
+    <string name="subtensor_unstake_remainder_title">Remaining stake too low</string>
+    <string name="subtensor_unstake_remainder_message">Your remaining stake would fall below the 0.01 TAO minimum. Would you like to unstake everything instead?</string>
+    <string name="subtensor_unstake_all">Unstake all</string>
+    <string name="subtensor_stake_below_min">Minimum stake is 0.01 TAO</string>
+    <string name="subtensor_unstake_youll_receive">You\'ll receive</string>
+    <string name="subtensor_unstake_max_label">Max: %1$s</string>
+
+    <!-- Bittensor "no active stakes" landing — mirrors iOS
+         StartStakingInfoSubtensorPresenter exactly, gold-accented title +
+         4 bullet conditions + Nova Wiki link + Start staking CTA. -->
+    <string name="subtensor_landing_title">Earn up to %1$s\non your TAO tokens\nper year</string>
+    <string name="subtensor_landing_default_max_apy">20.01%</string>
+    <string name="subtensor_landing_min_stake_condition">Stake anytime with as little as %1$s. Your stake will actively earn rewards %2$s</string>
+    <string name="subtensor_landing_min_stake_value">0.01 TAO</string>
+    <string name="subtensor_landing_first_reward_time">in 1 minute</string>
+    <string name="subtensor_landing_unstake_condition">Unstake anytime — funds are available immediately with no waiting period</string>
+    <string name="subtensor_landing_rewards_frequency_condition">Rewards accrue %1$s and added back to the stake</string>
+    <string name="subtensor_landing_rewards_frequency_value">every 1 hour</string>
+    <string name="subtensor_landing_monitor_condition">Rewards and staking status vary over time. %1$s</string>
+    <string name="subtensor_landing_monitor_accent">Monitor your stake from time to time</string>
+    <string name="subtensor_landing_more_info">Find out more information about Bittensor staking over at the %1$s</string>
+    <string name="subtensor_landing_wiki_link">Nova Wiki ›</string>
+    <string name="subtensor_landing_start_staking">Start staking</string>
+    <string name="subtensor_landing_available_balance">Available balance: %1$s</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -2809,6 +2809,8 @@
     <string name="subtensor_setup_available_label">Available: %1$s</string>
     <string name="subtensor_setup_min_stake_label">Minimum stake</string>
     <string name="subtensor_setup_network_fee_label">Network fee</string>
+    <string name="subtensor_setup_nova_fee_label">Nova Wallet fee</string>
+    <string name="subtensor_setup_nova_fee_disclaimer">Includes %1$s%% Nova Wallet fee.</string>
     <string name="subtensor_confirm_subnet_title">Confirm — %1$s</string>
     <string name="subtensor_unstake_position_label">Your stake</string>
     <string name="subtensor_unstake_max">Max</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -2762,4 +2762,44 @@
     <string name="wallet_send_phishing_warning_title">Scam alert</string>
     <string name="wallet_transfer_details_title">Transfer details</string>
     <string name="yesterday">Yesterday</string>
+
+    <!-- Subtensor (TAO) staking -->
+    <string name="subtensor_staking_title">TAO staking</string>
+    <string name="subtensor_your_stake">Your stake</string>
+    <string name="subtensor_your_validator">Your validator</string>
+    <string name="subtensor_your_validators">Your validators</string>
+    <string name="subtensor_no_active_stakes">No active stakes</string>
+    <string name="subtensor_no_active_stakes_message">Choose a validator and delegate TAO to start earning rewards.</string>
+    <string name="subtensor_staking_info">Staking info</string>
+    <string name="subtensor_minimum_stake">Minimum stake</string>
+    <string name="subtensor_minimum_stake_value">0.01 TAO</string>
+    <string name="subtensor_unstaking_period">Unstaking period</string>
+    <string name="subtensor_unstaking_period_instant">Instant</string>
+    <string name="subtensor_stake_more">Stake more</string>
+    <string name="subtensor_unstake">Unstake</string>
+    <string name="subtensor_action_coming_soon">Coming soon</string>
+    <string name="subtensor_stake_type_title">Staking Type</string>
+    <string name="subtensor_stake_type_root_title">Root staking</string>
+    <string name="subtensor_stake_type_root_details">Minimum stake: 0.01 TAO\nRewards: Auto-compounded\nNo unbonding period\nStake denominated in TAO</string>
+    <string name="subtensor_stake_type_subnet_title">Subnet staking</string>
+    <string name="subtensor_stake_type_subnet_details">Minimum stake: 0.01 TAO\nRewards: Subnet alpha tokens\nNo unbonding period\nSubnet alpha tokens can fluctuate in value versus TAO</string>
+    <string name="subtensor_stake_type_wiki_footer"><![CDATA[Find out more about Root and Subnet staking over at the <font color="#1F78FF"><u>Nova&#160;Wiki&#160;&gt;</u></font>]]></string>
+    <string name="subtensor_setup_validator_label">Validator</string>
+    <string name="subtensor_setup_select_validator">Select validator</string>
+    <string name="subtensor_setup_amount_label">Amount</string>
+    <string name="subtensor_setup_amount_placeholder">0.00</string>
+    <string name="subtensor_subnet_picker_title">Select subnet</string>
+    <string name="subtensor_subnet_picker_row_subtitle">SN%1$d · %2$s</string>
+    <string name="subtensor_subnet_picker_empty">No active subnets found. Pull to retry.</string>
+    <string name="subtensor_validator_picker_title">Select validator</string>
+    <string name="subtensor_validator_picker_loading_failed">Failed to load validators</string>
+    <string name="subtensor_validator_picker_empty">No validators available</string>
+    <string name="subtensor_setup_invalid_validator">Invalid validator hotkey</string>
+    <string name="subtensor_setup_submit_failed">Stake submission failed</string>
+    <string name="subtensor_setup_submitting">Submitting…</string>
+    <string name="subtensor_unstake_position_label">Position</string>
+    <string name="subtensor_unstake_max">Max</string>
+    <string name="subtensor_unstake_amount_exceeds">Amount exceeds your stake</string>
+    <string name="subtensor_unstake_pick_validator">Unstake from</string>
+    <string name="subtensor_unstake_no_positions">No positions to unstake</string>
 </resources>

--- a/feature-staking-impl/build.gradle
+++ b/feature-staking-impl/build.gradle
@@ -2,6 +2,22 @@ apply plugin: 'kotlin-parcelize'
 apply from: '../tests.gradle'
 apply from: '../scripts/secrets.gradle'
 
+// [TEMP-TAOSTATS] Mirrors iOS `TaoStatsKeyProvider`: pull the API key from
+// either `local.properties` (TAOSTATS_API_KEY=...) or the same plain-text
+// file iOS reads at runtime — `~/Desktop/tao-ewt-staking/taostats-api-key.txt`.
+// Wraps in BuildConfig.TAOSTATS_API_KEY (String, null when absent).
+// Drop both this block and the field once Nova's Bittensor indexer ships.
+def taoStatsKey = readStringSecretOrNull("TAOSTATS_API_KEY")
+if (taoStatsKey == null) {
+    def keyFile = new File("${System.getProperty('user.home')}/Desktop/tao-ewt-staking/taostats-api-key.txt")
+    if (keyFile.exists()) {
+        def content = keyFile.text.trim()
+        if (!content.isEmpty()) {
+            taoStatsKey = "\"${content}\""
+        }
+    }
+}
+
 android {
 
     defaultConfig {
@@ -10,6 +26,8 @@ android {
 
         buildConfigField "String", "GLOBAL_CONFIG_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/staking/global_config_dev.json\""
         buildConfigField "String", "RECOMMENDED_VALIDATORS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/staking/validators/v1/nova_validators_dev.json\""
+
+        buildConfigField "String", "TAOSTATS_API_KEY", taoStatsKey ?: "null"
     }
 
     buildTypes {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/StakingSharedState.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/StakingSharedState.kt
@@ -12,7 +12,17 @@ typealias StakingOption = SupportedAssetOption<StakingSharedState.OptionAddition
 
 class StakingSharedState : SelectedAssetOptionSharedState<StakingSharedState.OptionAdditionalData> {
 
-    class OptionAdditionalData(val stakingType: Chain.Asset.StakingType)
+    class OptionAdditionalData(
+        val stakingType: Chain.Asset.StakingType,
+        /**
+         * The netuid the user tapped on the multistaking dashboard, scoped
+         * to Subtensor. iOS threads this through `SubtensorStakingViewFactory
+         * .createView(... entryNetuid:)`; Android pipes it via the shared
+         * state because the detail Fragment is created by the nav graph
+         * without arguments. Null for non-Subtensor flows.
+         */
+        val subtensorEntryNetuid: Int? = null,
+    )
 
     private val _selectedOption = singleReplaySharedFlow<StakingOption>()
     override val selectedOption: Flow<StakingOption> = _selectedOption
@@ -20,9 +30,10 @@ class StakingSharedState : SelectedAssetOptionSharedState<StakingSharedState.Opt
     suspend fun setSelectedOption(
         chain: Chain,
         chainAsset: Chain.Asset,
-        stakingType: Chain.Asset.StakingType
+        stakingType: Chain.Asset.StakingType,
+        subtensorEntryNetuid: Int? = null,
     ) {
-        val selectedOption = createStakingOption(chain, chainAsset, stakingType)
+        val selectedOption = createStakingOption(chain, chainAsset, stakingType, subtensorEntryNetuid)
 
         setSelectedOption(selectedOption)
     }
@@ -32,17 +43,27 @@ class StakingSharedState : SelectedAssetOptionSharedState<StakingSharedState.Opt
     }
 }
 
-fun createStakingOption(chainWithAsset: ChainWithAsset, stakingType: Chain.Asset.StakingType): StakingOption {
+fun createStakingOption(
+    chainWithAsset: ChainWithAsset,
+    stakingType: Chain.Asset.StakingType,
+    subtensorEntryNetuid: Int? = null,
+): StakingOption {
     return StakingOption(
         assetWithChain = chainWithAsset,
-        additional = StakingSharedState.OptionAdditionalData(stakingType)
+        additional = StakingSharedState.OptionAdditionalData(stakingType, subtensorEntryNetuid)
     )
 }
 
-fun createStakingOption(chain: Chain, chainAsset: Chain.Asset, stakingType: Chain.Asset.StakingType): StakingOption {
+fun createStakingOption(
+    chain: Chain,
+    chainAsset: Chain.Asset,
+    stakingType: Chain.Asset.StakingType,
+    subtensorEntryNetuid: Int? = null,
+): StakingOption {
     return createStakingOption(
         chainWithAsset = ChainWithAsset(chain, chainAsset),
-        stakingType = stakingType
+        stakingType = stakingType,
+        subtensorEntryNetuid = subtensorEntryNetuid,
     )
 }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/api/StakingTypeMappers.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/api/StakingTypeMappers.kt
@@ -12,6 +12,8 @@ fun mapStakingTypeToSubQueryId(stakingType: Chain.Asset.StakingType): String? {
         Chain.Asset.StakingType.ALEPH_ZERO -> "aleph-zero"
         Chain.Asset.StakingType.NOMINATION_POOLS -> "nomination-pool"
         Chain.Asset.StakingType.MYTHOS -> "mythos"
+        // Subtensor has no SubQuery indexer yet — null disables off-chain stats.
+        Chain.Asset.StakingType.SUBTENSOR -> null
     }
 }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardSubtensorUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardSubtensorUpdater.kt
@@ -12,7 +12,9 @@ import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.Subten
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withTimeoutOrNull
 import java.math.BigInteger
 import kotlin.time.Duration.Companion.seconds
 
@@ -103,7 +105,14 @@ class StakingDashboardSubtensorUpdater(
                     emit(StakingDashboardUpdaterEvent.AllSynced(optionId, NO_OFF_CHAIN_INDEX))
                 }
             }
-            kotlinx.coroutines.delay(SubtensorStakingConstants.DASHBOARD_RESYNC_SECONDS.seconds)
+            // Race the regular poll interval against an "invalidate kick"
+            // from SubtensorPositionCache — fired right after stake / unstake
+            // confirmation so the dashboard reflects the new state within
+            // one Bittensor block instead of waiting up to the full
+            // resync interval.
+            withTimeoutOrNull(SubtensorStakingConstants.DASHBOARD_RESYNC_SECONDS.seconds) {
+                positionCache.invalidateKick.first()
+            }
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardSubtensorUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardSubtensorUpdater.kt
@@ -1,0 +1,170 @@
+package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.chain
+
+import android.util.Log
+import io.novafoundation.nova.core.updater.SharedRequestsBuilder
+import io.novafoundation.nova.core.updater.Updater
+import io.novafoundation.nova.core_db.model.StakingDashboardItemLocal
+import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
+import io.novafoundation.nova.feature_staking_api.domain.dashboard.model.StakingOptionId
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.cache.StakingDashboardCache
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.MultiChainOffChainSyncResult
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.math.BigInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Single dashboard updater for Bittensor (TAO) staking.
+ *
+ * The framework only ever calls `createUpdater(chain, stakingType)` once per
+ * (chain, stakingType) tuple — it iterates `chain.utilityAsset.supportedStakingOptions()`
+ * for the fan-out. So we get one instance for SUBTENSOR per chain.
+ *
+ * To match iOS — which renders one dashboard row per (TAO root + 128 subnet
+ * alpha) — this single updater walks every chain asset that declares
+ * `staking: ["subtensor"]` and writes its own dashboard item per cycle.
+ * Each (chainId, assetId, SUBTENSOR) tuple is treated as a separate sync
+ * option so the framework can track sync state per row.
+ *
+ * All instances share the per-coldkey [SubtensorPositionCache] so the
+ * runtime API only fires once per polling tick regardless of how many
+ * assets we update.
+ *
+ * Mirrors `SubtensorMultistakingUpdateService.swift` on iOS.
+ */
+class StakingDashboardSubtensorUpdater(
+    chain: Chain,
+    chainAsset: Chain.Asset,
+    stakingType: Chain.Asset.StakingType,
+    metaAccount: MetaAccount,
+    private val positionCache: SubtensorPositionCache,
+    private val stakingDashboardCache: StakingDashboardCache,
+    @Suppress("UnusedPrivateProperty")
+    private val stakingStatsFlow: Flow<MultiChainOffChainSyncResult>,
+) : BaseStakingDashboardUpdater(chain, chainAsset, stakingType, metaAccount) {
+
+    /** Pre-computed per cycle: every asset on this chain that supports SUBTENSOR. */
+    private val subtensorAssets: List<Chain.Asset> = chain.assets.filter { stakingType in it.staking }
+
+    override suspend fun listenForUpdates(
+        storageSubscriptionBuilder: SharedRequestsBuilder,
+    ): Flow<Updater.SideEffect> = pollPositions()
+
+    private fun pollPositions(): Flow<Updater.SideEffect> = flow {
+        val coldkey = metaAccount.accountIdIn(chain) ?: run {
+            Log.w(TAG, "no coldkey for ${chain.name}; updater not polling")
+            return@flow
+        }
+        Log.d(
+            TAG,
+            "starting poll for ${chain.name} across ${subtensorAssets.size} assets " +
+                "(coldkey=${coldkey.take(4).joinToString("") { "%02x".format(it) }}…)",
+        )
+
+        while (true) {
+            try {
+                val positions = positionCache.positions(chain.id, coldkey)
+                Log.d(
+                    TAG,
+                    "fetched ${positions.size} positions: " +
+                        positions.joinToString { "(netuid=${it.netuid}, amount=${it.amount})" },
+                )
+
+                // For each subtensor-staking asset on this chain, scope the
+                // position list to that asset's netuid and persist a row.
+                // The dashboard interactor filters out empty alpha rows from
+                // "Available to stake" so users with stake on only a few
+                // subnets don't see 128 zero rows.
+                subtensorAssets.forEach { asset ->
+                    val assetNetuid = asset.subtensorNetuid()
+                    val totalForAsset = positions
+                        .asSequence()
+                        .filter { it.netuid == assetNetuid }
+                        .fold(BigInteger.ZERO) { acc, p -> acc + p.amount }
+
+                    saveDashboardItemFor(asset, coldkey, totalForAsset)
+
+                    val optionId = StakingOptionId(chain.id, asset.id, stakingType)
+                    emit(StakingDashboardUpdaterEvent.PrimarySynced(optionId))
+                    emit(StakingDashboardUpdaterEvent.AllSynced(optionId, NO_OFF_CHAIN_INDEX))
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // Re-throw so the framework can cancel us cleanly.
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "fetch failed: ${e.javaClass.simpleName}: ${e.message}")
+                // Mark every row synced anyway so indicators don't stick.
+                subtensorAssets.forEach { asset ->
+                    val optionId = StakingOptionId(chain.id, asset.id, stakingType)
+                    emit(StakingDashboardUpdaterEvent.PrimarySynced(optionId))
+                    emit(StakingDashboardUpdaterEvent.AllSynced(optionId, NO_OFF_CHAIN_INDEX))
+                }
+            }
+            kotlinx.coroutines.delay(SubtensorStakingConstants.DASHBOARD_RESYNC_SECONDS.seconds)
+        }
+    }
+
+    private suspend fun saveDashboardItemFor(asset: Chain.Asset, coldkey: ByteArray, totalStake: BigInteger) {
+        stakingDashboardCache.update(chain.id, asset.id, stakingTypeLocal, metaAccount.id) { _ ->
+            if (totalStake.signum() > 0) {
+                StakingDashboardItemLocal.staking(
+                    chainId = chain.id,
+                    chainAssetId = asset.id,
+                    stakingType = stakingTypeLocal,
+                    metaId = metaAccount.id,
+                    stake = totalStake,
+                    status = StakingDashboardItemLocal.Status.ACTIVE,
+                    // Mirrors iOS `StakingDashboardSubtensorMapper.swift:34-41`:
+                    // the storage layer leaves rewards / estimatedEarnings nil
+                    // for Subtensor — iOS and Android both lack an offchain
+                    // indexer, so neither value is meaningful at write time.
+                    // The DEBUG-only [TEMP-TAOSTATS] 0.18 APY fallback lives at
+                    // the read layer (StakingDashboardRepository.hasStakeState)
+                    // so release builds match iOS's "leave it nil" semantics.
+                    rewards = null,
+                    estimatedEarnings = null,
+                    stakeStatusAccount = coldkey,
+                    rewardsAccount = coldkey,
+                )
+            } else {
+                StakingDashboardItemLocal.notStaking(
+                    chainId = chain.id,
+                    chainAssetId = asset.id,
+                    stakingType = stakingTypeLocal,
+                    metaId = metaAccount.id,
+                    estimatedEarnings = null,
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "StakingDashboardSubtensor"
+
+        // Subtensor has no SubQuery indexer; pass MAX_VALUE so the
+        // `event.indexOfUsedOffChainSync >= latestOffChainSyncIndex.value`
+        // gate in `RealStakingDashboardUpdateSystem.handleUpdaterEvent`
+        // always advances to SYNCED.
+        private const val NO_OFF_CHAIN_INDEX = Int.MAX_VALUE
+
+    }
+}
+
+/**
+ * Resolves the netuid an asset corresponds to.
+ *
+ *  - Native (utility) asset = root TAO, netuid 0.
+ *  - SubtensorAlpha = the netuid embedded in the type.
+ *  - Anything else (no nova-utils mapping yet) falls back to a "SN<N>"
+ *    symbol regex so older configs still resolve.
+ */
+internal fun Chain.Asset.subtensorNetuid(): Int = when (val type = type) {
+    is Chain.Asset.Type.SubtensorAlpha -> type.netuid
+    Chain.Asset.Type.Native -> SubtensorStakingConstants.ROOT_NETUID
+    else -> Regex("^SN(\\d+)$").find(symbol.value)
+        ?.groupValues?.getOrNull(1)?.toIntOrNull()
+        ?: SubtensorStakingConstants.ROOT_NETUID
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardUpdaterFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardUpdaterFactory.kt
@@ -7,6 +7,7 @@ import io.novafoundation.nova.feature_staking_impl.data.dashboard.cache.StakingD
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.MultiChainOffChainSyncResult
 import io.novafoundation.nova.feature_staking_api.data.nominationPools.pool.PoolAccountDerivation
 import io.novafoundation.nova.feature_staking_impl.data.nominationPools.repository.NominationPoolStateRepository
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
 import io.novafoundation.nova.feature_wallet_api.data.repository.BalanceLocksRepository
 import io.novafoundation.nova.runtime.ext.StakingTypeGroup
 import io.novafoundation.nova.runtime.ext.group
@@ -22,6 +23,7 @@ class StakingDashboardUpdaterFactory(
     private val poolAccountDerivation: PoolAccountDerivation,
     private val storageCache: StorageCache,
     private val balanceLocksRepository: BalanceLocksRepository,
+    private val subtensorPositionCache: SubtensorPositionCache,
 ) {
 
     fun createUpdater(
@@ -35,6 +37,7 @@ class StakingDashboardUpdaterFactory(
             StakingTypeGroup.PARACHAIN -> parachain(chain, stakingType, metaAccount, stakingStatsFlow)
             StakingTypeGroup.NOMINATION_POOL -> nominationPools(chain, stakingType, metaAccount, stakingStatsFlow)
             StakingTypeGroup.MYTHOS -> mythos(chain, stakingType, metaAccount, stakingStatsFlow)
+            StakingTypeGroup.SUBTENSOR -> subtensor(chain, stakingType, metaAccount, stakingStatsFlow)
             StakingTypeGroup.UNSUPPORTED -> null
         }
     }
@@ -109,6 +112,33 @@ class StakingDashboardUpdaterFactory(
             storageCache = storageCache,
             remoteStorageSource = remoteStorageSource,
             stakingStatsFlow = stakingStatsFlow
+        )
+    }
+
+    /**
+     * One Subtensor updater per ChainAsset advertising `staking: ["subtensor"]`.
+     * On Bittensor that's the native TAO asset (root, netuid=0) plus every
+     * subnet alpha asset (netuid 1..128). All instances share the cache so
+     * 129 services produce 1 RPC round-trip per polling tick.
+     *
+     * Currently scoped to `chain.utilityAsset` only — wiring per-subnet rows
+     * requires the subnet-alpha asset type to be recognised by the Local→
+     * Domain mapper, which is a follow-up task.
+     */
+    private fun subtensor(
+        chain: Chain,
+        stakingType: Chain.Asset.StakingType,
+        metaAccount: MetaAccount,
+        stakingStatsFlow: Flow<MultiChainOffChainSyncResult>,
+    ): GlobalScopeUpdater {
+        return StakingDashboardSubtensorUpdater(
+            chain = chain,
+            chainAsset = chain.utilityAsset,
+            stakingType = stakingType,
+            metaAccount = metaAccount,
+            positionCache = subtensorPositionCache,
+            stakingDashboardCache = stakingDashboardCache,
+            stakingStatsFlow = stakingStatsFlow,
         )
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/repository/StakingDashboardRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/repository/StakingDashboardRepository.kt
@@ -14,9 +14,12 @@ import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingD
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardItem.StakeState.HasStake
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardItem.StakeState.NoStake
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.model.StakingDashboardOptionAccounts
+import io.novafoundation.nova.feature_staking_impl.BuildConfig
 import io.novafoundation.nova.runtime.multiNetwork.chain.mappers.mapStakingStringToStakingType
 import io.novafoundation.nova.runtime.multiNetwork.chain.mappers.mapStakingTypeToStakingString
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
+import java.math.BigInteger
 import kotlinx.coroutines.flow.Flow
 
 interface StakingDashboardRepository {
@@ -71,15 +74,25 @@ class RealStakingDashboardRepository(
     }
 
     private fun hasStakeState(localItem: StakingDashboardItemLocal): HasStake {
-        val estimatedEarnings = localItem.estimatedEarnings
-        val rewards = localItem.rewards
+        val stakingType = mapStakingStringToStakingType(localItem.stakingType)
+
+        // Subtensor has no offchain indexer — neither rewards nor estimated
+        // earnings are persisted. iOS handles this by leaving the CoreData
+        // fields nil and computing a [TEMP-TAOSTATS] 0.18 fallback at the
+        // dashboard model layer (`StakingDashboardModel.swift:51-67`,
+        // `#if DEBUG`). We mirror that here: substitute zero rewards and the
+        // same DEBUG-only APY fallback so the row reaches a Loaded state
+        // instead of a perpetual shimmer. Drop both substitutions when an
+        // indexer / TaoStats data source ships.
+        val rewardsRaw = localItem.rewards ?: substituteSubtensorRewards(stakingType)
+        val earningsRaw = localItem.estimatedEarnings ?: substituteSubtensorApy(stakingType)
         val status = localItem.status
 
-        val stats = if (estimatedEarnings != null && rewards != null && status != null) {
+        val stats = if (earningsRaw != null && rewardsRaw != null && status != null) {
             HasStake.Stats(
-                rewards = rewards,
+                rewards = rewardsRaw,
                 status = mapStakingStatusFromLocal(status),
-                estimatedEarnings = estimatedEarnings.asPercent()
+                estimatedEarnings = earningsRaw.asPercent()
             )
         } else {
             null
@@ -92,11 +105,36 @@ class RealStakingDashboardRepository(
     }
 
     private fun noStakeState(localItem: StakingDashboardItemLocal): NoStake {
-        val stats = localItem.estimatedEarnings?.let { estimatedEarnings ->
-            NoStake.Stats(estimatedEarnings.asPercent())
+        val stakingType = mapStakingStringToStakingType(localItem.stakingType)
+        val earningsRaw = localItem.estimatedEarnings ?: substituteSubtensorApy(stakingType)
+
+        val stats = earningsRaw?.let { NoStake.Stats(it.asPercent()) }
+        return NoStake(ExtendedLoadingState.fromOption(stats))
+    }
+
+    /**
+     * Substitutes a non-null rewards value for SUBTENSOR rows. iOS leaves the
+     * field nil; Android's `HasStake.Stats.rewards` is non-nullable, so zero
+     * is the closest equivalent.
+     */
+    private fun substituteSubtensorRewards(stakingType: Chain.Asset.StakingType): BigInteger? =
+        BigInteger.ZERO.takeIf { stakingType == Chain.Asset.StakingType.SUBTENSOR }
+
+    /**
+     * [TEMP-TAOSTATS] 0.18 (18%) APY fallback for SUBTENSOR rows in DEBUG only.
+     * Mirrors iOS `StakingDashboardModel.swift:Concrete.maxApy` — same value
+     * the iOS Start Staking info screen uses. In release builds we leave this
+     * null to match iOS release semantics (returns nil, view-layer handles).
+     */
+    private fun substituteSubtensorApy(stakingType: Chain.Asset.StakingType): Double? =
+        if (BuildConfig.DEBUG && stakingType == Chain.Asset.StakingType.SUBTENSOR) {
+            SUBTENSOR_TEMP_TAOSTATS_FALLBACK_APY
+        } else {
+            null
         }
 
-        return NoStake(ExtendedLoadingState.fromOption(stats))
+    companion object {
+        private const val SUBTENSOR_TEMP_TAOSTATS_FALLBACK_APY = 0.18
     }
 
     private fun mapStakingStatusFromLocal(localStatus: StakingDashboardItemLocal.Status): HasStake.StakingStatus {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/StakingUpdaters.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/StakingUpdaters.kt
@@ -10,6 +10,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.MYTHOS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.SUBTENSOR
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
@@ -59,6 +60,7 @@ class StakingUpdaters(
             TURING -> parachainUpdaters.updaters + turingExtraUpdaters.updaters
             NOMINATION_POOLS -> nominationPoolsUpdaters.updaters
             MYTHOS -> mythosUpdaters.updaters
+            SUBTENSOR -> emptyList() // Subtensor uses runtime API polling via the dashboard updater, not these per-staking-type chain updaters.
             UNSUPPORTED -> emptyList()
         }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/datasource/StakingRewardPeriodDataSource.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/datasource/StakingRewardPeriodDataSource.kt
@@ -119,6 +119,7 @@ class RealStakingRewardPeriodDataSource(
             Chain.Asset.StakingType.TURING -> "TURING"
             Chain.Asset.StakingType.NOMINATION_POOLS -> "NOMINATION_POOLS"
             Chain.Asset.StakingType.MYTHOS -> "MYTHOS"
+            Chain.Asset.StakingType.SUBTENSOR -> "SUBTENSOR"
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/decoder/SubtensorStakeInfoDecoder.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/decoder/SubtensorStakeInfoDecoder.kt
@@ -1,0 +1,157 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.decoder
+
+import java.math.BigInteger
+
+/**
+ * SCALE decoder for the `Vec<StakeInfo>` payload returned by Bittensor's
+ * `state_call("StakeInfoRuntimeApi_get_stake_info_for_coldkey", coldkey)`.
+ *
+ * Field order matches `pallets/subtensor/src/rpc_info/stake_info.rs`. If
+ * upstream adds a field before `is_registered`, update the skip count in
+ * [decodeEntry] — both the multistaking sync and the detail-screen fetcher
+ * route through here, so a single update fixes every call site.
+ *
+ * Mirrors `SubtensorStakeInfoDecoder.swift` on iOS.
+ */
+object SubtensorStakeInfoDecoder {
+
+    data class Entry(
+        val hotkey: ByteArray,
+        val coldkey: ByteArray,
+        /** 0 = root, >0 = subnet id. */
+        val netuid: Int,
+        /** Resolved stake amount in the subnet's smallest unit (RAO / alpha). */
+        val stake: BigInteger,
+    ) {
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Entry) return false
+            return hotkey.contentEquals(other.hotkey) &&
+                coldkey.contentEquals(other.coldkey) &&
+                netuid == other.netuid &&
+                stake == other.stake
+        }
+
+        override fun hashCode(): Int {
+            var result = hotkey.contentHashCode()
+            result = 31 * result + coldkey.contentHashCode()
+            result = 31 * result + netuid
+            result = 31 * result + stake.hashCode()
+            return result
+        }
+    }
+
+    fun decode(hex: String): List<Entry> {
+        val bytes = hexToBytes(hex)
+        if (bytes.isEmpty()) return emptyList()
+
+        val (count, posAfterCount) = scaleCompact(bytes, 0) ?: return emptyList()
+
+        val result = mutableListOf<Entry>()
+        var pos = posAfterCount
+        val total = count.toInt()
+        for (i in 0 until total) {
+            val decoded = decodeEntry(bytes, pos) ?: return result
+            result.add(decoded.first)
+            pos = decoded.second
+        }
+        return result
+    }
+
+    private fun decodeEntry(bytes: ByteArray, offset: Int): Pair<Entry, Int>? {
+        var pos = offset
+
+        // hotkey: AccountId32 (32 raw bytes)
+        if (pos + 32 > bytes.size) return null
+        val hotkey = bytes.copyOfRange(pos, pos + 32)
+        pos += 32
+
+        // coldkey: AccountId32 (32 raw bytes)
+        if (pos + 32 > bytes.size) return null
+        val coldkey = bytes.copyOfRange(pos, pos + 32)
+        pos += 32
+
+        // netuid: Compact<u16>
+        val (netuidBig, posAfterNetuid) = scaleCompact(bytes, pos) ?: return null
+        pos = posAfterNetuid
+
+        // stake: Compact<U128>
+        val (stake, posAfterStake) = scaleCompact(bytes, pos) ?: return null
+        pos = posAfterStake
+
+        // Skip locked / emission / tao_emission / drain — four Compact<U128>
+        // we don't read.
+        repeat(4) {
+            val (_, next) = scaleCompact(bytes, pos) ?: return null
+            pos = next
+        }
+
+        // is_registered: bool (1 byte)
+        if (pos + 1 > bytes.size) return null
+        pos += 1
+
+        return Entry(
+            hotkey = hotkey,
+            coldkey = coldkey,
+            netuid = netuidBig.toInt(),
+            stake = stake,
+        ) to pos
+    }
+
+    /**
+     * SCALE compact decoder supporting all four modes (1/2/4-byte and
+     * big-integer). Returns `(value, nextOffset)` or `null` on truncation.
+     */
+    fun scaleCompact(bytes: ByteArray, offset: Int): Pair<BigInteger, Int>? {
+        if (offset >= bytes.size) return null
+        val mode = bytes[offset].toInt() and 0x03
+        return when (mode) {
+            0x00 -> {
+                val value = (bytes[offset].toInt() and 0xFF) ushr 2
+                BigInteger.valueOf(value.toLong()) to (offset + 1)
+            }
+            0x01 -> {
+                if (offset + 2 > bytes.size) return null
+                val raw = (bytes[offset].toInt() and 0xFF) or
+                    ((bytes[offset + 1].toInt() and 0xFF) shl 8)
+                BigInteger.valueOf((raw ushr 2).toLong()) to (offset + 2)
+            }
+            0x02 -> {
+                if (offset + 4 > bytes.size) return null
+                val raw = (bytes[offset].toInt() and 0xFF).toLong() or
+                    ((bytes[offset + 1].toInt() and 0xFF).toLong() shl 8) or
+                    ((bytes[offset + 2].toInt() and 0xFF).toLong() shl 16) or
+                    ((bytes[offset + 3].toInt() and 0xFF).toLong() shl 24)
+                BigInteger.valueOf(raw ushr 2) to (offset + 4)
+            }
+            0x03 -> {
+                // Big-integer mode: byte0 = (N << 2) | 3, then (N+4) LE bytes.
+                val extraBytes = (bytes[offset].toInt() and 0xFF) ushr 2
+                val len = extraBytes + 4
+                if (offset + 1 + len > bytes.size) return null
+                val leSlice = bytes.copyOfRange(offset + 1, offset + 1 + len)
+                val beBytes = leSlice.reversedArray()
+                // Prepend 0 to keep BigInteger unsigned.
+                val unsigned = ByteArray(beBytes.size + 1).also {
+                    System.arraycopy(beBytes, 0, it, 1, beBytes.size)
+                }
+                BigInteger(unsigned) to (offset + 1 + len)
+            }
+            else -> null
+        }
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        val clean = if (hex.startsWith("0x")) hex.substring(2) else hex
+        if (clean.length % 2 != 0) return ByteArray(0)
+        val out = ByteArray(clean.length / 2)
+        for (i in out.indices) {
+            val high = Character.digit(clean[i * 2], 16)
+            val low = Character.digit(clean[i * 2 + 1], 16)
+            if (high < 0 || low < 0) return ByteArray(0)
+            out[i] = ((high shl 4) or low).toByte()
+        }
+        return out
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/extrinsic/SubtensorExtrinsicBuilderExt.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/extrinsic/SubtensorExtrinsicBuilderExt.kt
@@ -1,0 +1,127 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.extrinsic
+
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novasama.substrate_sdk_android.runtime.AccountId
+import io.novasama.substrate_sdk_android.runtime.extrinsic.builder.ExtrinsicBuilder
+import io.novasama.substrate_sdk_android.runtime.extrinsic.call
+import java.math.BigInteger
+import kotlin.math.ceil
+import kotlin.math.floor
+
+/**
+ * Extrinsic builder helpers for Bittensor's `SubtensorModule` staking calls.
+ *
+ * v1 always uses the `*_limit` variants (`add_stake_limit` /
+ * `remove_stake_limit`) even on the root subnet where there is no AMM —
+ * keeps call shapes consistent with the future v2 subnet path. The slippage
+ * cushion is cosmetic on root and load-bearing on subnets.
+ *
+ * Mirrors `SubtensorExtrinsicBuilder.swift` on iOS.
+ */
+
+private const val MODULE_NAME = "SubtensorModule"
+private const val ONE_TAO_IN_RAO = 1_000_000_000L
+
+/**
+ * Builds `SubtensorModule.add_stake_limit(...)`.
+ *
+ * For root (`netuid == 0`), [spotPriceTaoPerAlpha] is ignored and a
+ * cushioned RAO baseline is used. For subnets, pass the live AMM rate
+ * (`SubnetTAO / SubnetAlphaIn`); the limit_price is encoded as I96F32.
+ */
+fun ExtrinsicBuilder.addStakeLimit(
+    hotkey: AccountId,
+    netuid: Int,
+    amount: BigInteger,
+    slippage: Double = SubtensorStakingConstants.DEFAULT_SLIPPAGE,
+    spotPriceTaoPerAlpha: Double? = null,
+): ExtrinsicBuilder = call(
+    moduleName = MODULE_NAME,
+    callName = "add_stake_limit",
+    arguments = mapOf(
+        "hotkey" to hotkey,
+        "netuid" to netuid.toBigInteger(),
+        "amount_staked" to amount,
+        "limit_price" to computeLimitPrice(netuid, slippage, isStake = true, spotPriceTaoPerAlpha),
+        "allow_partial" to false,
+    ),
+)
+
+/**
+ * Builds `SubtensorModule.remove_stake_limit(...)`. Instant settlement —
+ * Bittensor has no unbonding period.
+ */
+fun ExtrinsicBuilder.removeStakeLimit(
+    hotkey: AccountId,
+    netuid: Int,
+    amount: BigInteger,
+    slippage: Double = SubtensorStakingConstants.DEFAULT_SLIPPAGE,
+    spotPriceTaoPerAlpha: Double? = null,
+): ExtrinsicBuilder = call(
+    moduleName = MODULE_NAME,
+    callName = "remove_stake_limit",
+    arguments = mapOf(
+        "hotkey" to hotkey,
+        "netuid" to netuid.toBigInteger(),
+        "amount_unstaked" to amount,
+        "limit_price" to computeLimitPrice(netuid, slippage, isStake = false, spotPriceTaoPerAlpha),
+        "allow_partial" to false,
+    ),
+)
+
+/**
+ * Builds `SubtensorModule.move_stake(...)`. Used for "change validator" —
+ * single-extrinsic move instead of unstake + restake.
+ */
+fun ExtrinsicBuilder.moveStake(
+    originHotkey: AccountId,
+    destinationHotkey: AccountId,
+    originNetuid: Int,
+    destinationNetuid: Int,
+    amount: BigInteger,
+): ExtrinsicBuilder = call(
+    moduleName = MODULE_NAME,
+    callName = "move_stake",
+    arguments = mapOf(
+        "origin_hotkey" to originHotkey,
+        "destination_hotkey" to destinationHotkey,
+        "origin_netuid" to originNetuid.toBigInteger(),
+        "destination_netuid" to destinationNetuid.toBigInteger(),
+        "alpha_amount" to amount,
+    ),
+)
+
+/**
+ * **Root (netuid=0):** alpha == TAO at 1:1. Limit_price is RAO-denominated
+ * and cosmetic (no AMM). Stake cushions upward, unstake cushions downward.
+ *
+ * **Subnets (netuid!=0):** limit_price is u64 RAO per whole alpha (per
+ * pallet docstring at add_stake.rs:99). Spot price comes from
+ * `SubnetTAO / SubnetAlphaIn` (TAO per alpha); we multiply by ONE_TAO_IN_RAO.
+ */
+private fun computeLimitPrice(
+    netuid: Int,
+    slippage: Double,
+    isStake: Boolean,
+    spotPriceTaoPerAlpha: Double?,
+): BigInteger {
+    if (netuid == SubtensorStakingConstants.ROOT_NETUID) {
+        val multiplier = if (isStake) 1.0 + slippage else 1.0 - slippage
+        val raw = ONE_TAO_IN_RAO.toDouble() * multiplier
+        // Stake rounds up (max price willing to pay), unstake rounds down (min
+        // price willing to accept). iOS uses NSDecimalRound(.up/.down); plain
+        // toLong() would truncate toward zero on both directions, tightening
+        // the cushion for stake — see review note 1.
+        val cushioned = if (isStake) ceil(raw).toLong() else floor(raw).toLong()
+        return BigInteger.valueOf(cushioned.coerceAtLeast(1L))
+    }
+
+    val spot = spotPriceTaoPerAlpha ?: 0.001
+    val adjusted = if (isStake) spot * (1.0 + slippage) else spot * (1.0 - slippage)
+    val raoPerAlpha = adjusted * ONE_TAO_IN_RAO.toDouble()
+    // Stake rounds up, unstake rounds down — matches root branch so FP
+    // drift never tightens the cushion below configured slippage.
+    val cushioned = if (isStake) ceil(raoPerAlpha) else floor(raoPerAlpha)
+    val rawBits = cushioned.toLong().coerceAtLeast(1L)
+    return BigInteger.valueOf(rawBits)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/extrinsic/SubtensorExtrinsicBuilderExt.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/extrinsic/SubtensorExtrinsicBuilderExt.kt
@@ -4,7 +4,9 @@ import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.Subten
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.runtime.extrinsic.builder.ExtrinsicBuilder
 import io.novasama.substrate_sdk_android.runtime.extrinsic.call
+import java.math.BigDecimal
 import java.math.BigInteger
+import java.math.RoundingMode
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -27,7 +29,8 @@ private const val ONE_TAO_IN_RAO = 1_000_000_000L
  *
  * For root (`netuid == 0`), [spotPriceTaoPerAlpha] is ignored and a
  * cushioned RAO baseline is used. For subnets, pass the live AMM rate
- * (`SubnetTAO / SubnetAlphaIn`); the limit_price is encoded as I96F32.
+ * (`SubnetTAO / SubnetAlphaIn`); the limit_price is a u64 in RAO per whole
+ * alpha (per the pallet docstring) — see [computeLimitPrice].
  */
 fun ExtrinsicBuilder.addStakeLimit(
     hotkey: AccountId,
@@ -106,14 +109,21 @@ private fun computeLimitPrice(
     spotPriceTaoPerAlpha: Double?,
 ): BigInteger {
     if (netuid == SubtensorStakingConstants.ROOT_NETUID) {
-        val multiplier = if (isStake) 1.0 + slippage else 1.0 - slippage
-        val raw = ONE_TAO_IN_RAO.toDouble() * multiplier
-        // Stake rounds up (max price willing to pay), unstake rounds down (min
-        // price willing to accept). iOS uses NSDecimalRound(.up/.down); plain
-        // toLong() would truncate toward zero on both directions, tightening
-        // the cushion for stake — see review note 1.
-        val cushioned = if (isStake) ceil(raw).toLong() else floor(raw).toLong()
-        return BigInteger.valueOf(cushioned.coerceAtLeast(1L))
+        // Root: no AMM, RAO-denominated 1:1 baseline. Exact BigDecimal rounding
+        // (CEILING for stake = max willing to pay, FLOOR for unstake = min willing
+        // to accept) to mirror iOS NSDecimalRound exactly. Double ceil/floor drifts
+        // by ±1 RAO at some slippages (e.g. 1e9 * 0.995 as a Double floors to
+        // 994999999, not 995000000) — see review note 1.
+        val multiplier = if (isStake) {
+            BigDecimal.ONE.add(BigDecimal.valueOf(slippage))
+        } else {
+            BigDecimal.ONE.subtract(BigDecimal.valueOf(slippage))
+        }
+        val cushioned = BigDecimal.valueOf(ONE_TAO_IN_RAO)
+            .multiply(multiplier)
+            .setScale(0, if (isStake) RoundingMode.CEILING else RoundingMode.FLOOR)
+            .toBigInteger()
+        return cushioned.max(BigInteger.ONE)
     }
 
     val spot = spotPriceTaoPerAlpha ?: 0.001

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/BittensorDelegatesClient.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/BittensorDelegatesClient.kt
@@ -1,0 +1,67 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.network
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Validator identity record from the `opentensor/bittensor-delegates` GitHub
+ * registry. Keys in the parsed map are SS58 addresses of validator hotkeys.
+ *
+ * Lossy-by-design: the registry is community-curated and most fields are
+ * optional. Mirrors `BittensorDelegateMetadata` on iOS.
+ */
+data class BittensorDelegateMetadata(
+    val name: String? = null,
+    val url: String? = null,
+    val description: String? = null,
+    val signature: String? = null,
+)
+
+/**
+ * Fetches the bittensor-delegates registry. The fetched map is cached so a
+ * subsequent network failure can fall back to the last-known good copy.
+ *
+ * Identity-only — does NOT carry stake / commission / APR. Numeric fields
+ * are merged in by `SubtensorValidatorProvider` from a separate data source
+ * (TaoStats today, Nova indexer once it ships).
+ */
+class BittensorDelegatesClient(
+    private val httpClient: OkHttpClient,
+    private val gson: Gson,
+) {
+
+    @Volatile
+    private var cache: Map<String, BittensorDelegateMetadata> = emptyMap()
+
+    suspend fun fetchDelegates(): Map<String, BittensorDelegateMetadata> {
+        val request = Request.Builder()
+            .url(SubtensorStakingConstants.DELEGATES_REGISTRY_URL)
+            .get()
+            .build()
+
+        // Network failures (DNS / TCP / TLS / timeout) propagate so the caller
+        // can log and decide what to surface — silently returning the cached
+        // (initially empty) map masks real errors on the very first launch.
+        // Non-2xx responses fall back to the cache, mirroring iOS.
+        return httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return@use cache
+            val body = response.body?.string() ?: return@use cache
+            parse(body).also { cache = it }
+        }
+    }
+
+    fun cachedDelegates(): Map<String, BittensorDelegateMetadata> = cache
+
+    fun parse(json: String): Map<String, BittensorDelegateMetadata> {
+        // JSON parse failures propagate. iOS `BittensorDelegatesClient.swift`
+        // throws on parse errors so the caller can log / fall back; Android's
+        // call site in `SubtensorStakingViewModel.load` already wraps this in
+        // `runCatching` and falls back to an empty identity map. Swallowing
+        // here would mask a malformed registry response.
+        val type = object : TypeToken<Map<String, BittensorDelegateMetadata>>() {}.type
+        return gson.fromJson(json, type) ?: emptyMap()
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorPositionCache.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorPositionCache.kt
@@ -1,0 +1,126 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.network
+
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Per-coldkey cache + in-flight dedup for the `StakeInfoRuntimeApi` call.
+ *
+ * The multistaking dashboard creates one sync service per (ChainAsset,
+ * StakingType=SUBTENSOR), which on Bittensor means 129 services (1 TAO root +
+ * 128 subnet alpha) firing concurrently when a wallet is selected. Each
+ * service ultimately needs the same per-coldkey fetch — without this cache
+ * they'd all hit the public RPC endpoint and most would be rate-limited.
+ *
+ * - In-flight dedup: the first caller starts the network round-trip, the
+ *   other 128 await the same Deferred.
+ * - 15 s result cache: subsequent polls within the TTL skip the network.
+ * - Generation counter on `invalidate(coldkey)`: an in-flight task whose
+ *   generation got bumped silently discards its own result rather than
+ *   overwriting the cleared cache. We deliberately do NOT cancel the task
+ *   because cancelling would propagate `CancellationException` to all 128
+ *   awaiters and surface as transient errors on the dashboard.
+ *
+ * Mirrors the iOS `SubtensorPositionCache` actor.
+ */
+class SubtensorPositionCache(
+    private val fetcher: SubtensorPositionFetcher,
+    private val ttlMillis: Long = SubtensorStakingConstants.POSITION_CACHE_TTL_SECONDS * 1000,
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+
+    private data class Key(val chainId: ChainId, val coldkey: List<Byte>)
+
+    private data class CacheEntry(val positions: List<SubtensorRawPosition>, val expiry: Long)
+
+    /** Sealed discriminator: cache hit, await another fetch, or own a new fetch. */
+    private sealed interface Outcome {
+        data class Cached(val positions: List<SubtensorRawPosition>) : Outcome
+        data class Wait(val deferred: CompletableDeferred<List<SubtensorRawPosition>>) : Outcome
+        data class Own(
+            val deferred: CompletableDeferred<List<SubtensorRawPosition>>,
+            val startedGeneration: Int,
+        ) : Outcome
+    }
+
+    private val mutex = Mutex()
+    private val cache = mutableMapOf<Key, CacheEntry>()
+    private val inFlight = mutableMapOf<Key, CompletableDeferred<List<SubtensorRawPosition>>>()
+    private val generation = mutableMapOf<Key, Int>()
+
+    suspend fun positions(chainId: ChainId, coldkey: ByteArray): List<SubtensorRawPosition> {
+        val key = Key(chainId, coldkey.toList())
+
+        // Decide owner / waiter / cache-hit under the lock so the role is
+        // unambiguous, then release the lock before any suspension.
+        val outcome = mutex.withLock {
+            val now = clock()
+            val cached = cache[key]
+            if (cached != null && cached.expiry > now) {
+                return@withLock Outcome.Cached(cached.positions)
+            }
+
+            val pending = inFlight[key]
+            if (pending != null) {
+                return@withLock Outcome.Wait(pending)
+            }
+
+            val deferred = CompletableDeferred<List<SubtensorRawPosition>>()
+            inFlight[key] = deferred
+            Outcome.Own(deferred, generation.getOrDefault(key, 0))
+        }
+
+        return when (outcome) {
+            is Outcome.Cached -> outcome.positions
+            is Outcome.Wait -> outcome.deferred.await()
+            is Outcome.Own -> runFetchAndPersist(chainId, coldkey, key, outcome.deferred, outcome.startedGeneration)
+        }
+    }
+
+    private suspend fun runFetchAndPersist(
+        chainId: ChainId,
+        coldkey: ByteArray,
+        key: Key,
+        ourDeferred: CompletableDeferred<List<SubtensorRawPosition>>,
+        startedGeneration: Int,
+    ): List<SubtensorRawPosition> = coroutineScope {
+        try {
+            val result = fetcher.fetchPositions(chainId, coldkey)
+            mutex.withLock {
+                inFlight.remove(key)
+                // Only cache if no `invalidate` fired during the fetch — otherwise
+                // we'd repopulate the just-cleared cache with pre-stake data.
+                if (generation.getOrDefault(key, 0) == startedGeneration) {
+                    cache[key] = CacheEntry(result, clock() + ttlMillis)
+                }
+            }
+            ourDeferred.complete(result)
+            result
+        } catch (e: Throwable) {
+            mutex.withLock { inFlight.remove(key) }
+            ourDeferred.completeExceptionally(e)
+            throw e
+        }
+    }
+
+    /**
+     * Invalidates the cache for `coldkey` so the next request on any chain
+     * re-fetches. Intended to be called from the stake confirm interactor
+     * on `inBlock` so the dashboard catches up immediately.
+     *
+     * Does NOT cancel an in-flight fetch — see class doc for rationale.
+     */
+    suspend fun invalidate(coldkey: ByteArray) {
+        mutex.withLock {
+            val toRemove = cache.keys.filter { it.coldkey == coldkey.toList() }
+            toRemove.forEach { key ->
+                cache.remove(key)
+                generation[key] = generation.getOrDefault(key, 0) + 1
+            }
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorPositionCache.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorPositionCache.kt
@@ -4,6 +4,9 @@ import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.Subten
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -51,6 +54,16 @@ class SubtensorPositionCache(
     private val cache = mutableMapOf<Key, CacheEntry>()
     private val inFlight = mutableMapOf<Key, CompletableDeferred<List<SubtensorRawPosition>>>()
     private val generation = mutableMapOf<Key, Int>()
+
+    /**
+     * Fires whenever [invalidate] is called. The dashboard updater races
+     * this against its 30s polling delay so a fresh stake/unstake appears
+     * on the dashboard within one Bittensor block of `inBlock` instead of
+     * up to 30s later. Replay 0 because subscribers join long-lived; we
+     * never want a buffered "kick" to retrigger a poll on subscription.
+     */
+    private val _invalidateKick = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
+    val invalidateKick: SharedFlow<Unit> = _invalidateKick.asSharedFlow()
 
     suspend fun positions(chainId: ChainId, coldkey: ByteArray): List<SubtensorRawPosition> {
         val key = Key(chainId, coldkey.toList())
@@ -122,5 +135,10 @@ class SubtensorPositionCache(
                 generation[key] = generation.getOrDefault(key, 0) + 1
             }
         }
+        // Wake up the dashboard updater so the new stake appears within one
+        // Bittensor block of `inBlock` instead of up to the 30s polling
+        // interval later. tryEmit (extraBufferCapacity = 1) is non-suspending
+        // and fine to drop if no subscriber is listening yet.
+        _invalidateKick.tryEmit(Unit)
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorPositionFetcher.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorPositionFetcher.kt
@@ -1,0 +1,66 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.network
+
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.decoder.SubtensorStakeInfoDecoder
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.multiNetwork.getSocket
+import io.novafoundation.nova.runtime.network.rpc.stateCall
+import io.novasama.substrate_sdk_android.extensions.toHexString
+import io.novasama.substrate_sdk_android.wsrpc.request.runtime.state.StateCallRequest
+import java.math.BigInteger
+
+/**
+ * Resolved (hotkey, netuid, amount) tuple for a coldkey position. The runtime
+ * pre-aggregates root + every subnet + V1/V2 alpha storage, so this is the
+ * canonical view of the user's stake.
+ */
+data class SubtensorRawPosition(
+    val hotkey: ByteArray,
+    val netuid: Int,
+    val amount: BigInteger,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SubtensorRawPosition) return false
+        return hotkey.contentEquals(other.hotkey) && netuid == other.netuid && amount == other.amount
+    }
+
+    override fun hashCode(): Int {
+        var result = hotkey.contentHashCode()
+        result = 31 * result + netuid
+        result = 31 * result + amount.hashCode()
+        return result
+    }
+}
+
+/**
+ * Fetches all non-zero stake positions for `coldkey` via Bittensor's
+ * `StakeInfoRuntimeApi_get_stake_info_for_coldkey` runtime API. The runtime
+ * resolves V1/V2 alpha + root accounting and returns one entry per
+ * (hotkey, netuid). Mirrors `SubtensorPositionFetcher.swift` on iOS.
+ *
+ * Walking storage maps directly was abandoned because it silently dropped
+ * root TAO positions (root validators aren't always inserted into
+ * `StakingHotkeys`) — see CLAUDE_tao_staking.md for the full history.
+ */
+class SubtensorPositionFetcher(
+    private val chainRegistry: ChainRegistry,
+) {
+
+    suspend fun fetchPositions(chainId: ChainId, coldkey: ByteArray): List<SubtensorRawPosition> {
+        val socket = chainRegistry.getSocket(chainId)
+        val coldkeyHex = "0x" + coldkey.toHexString(withPrefix = false)
+
+        val request = StateCallRequest(RUNTIME_API, coldkeyHex)
+
+        val responseHex = socket.stateCall(request) ?: return emptyList()
+
+        return SubtensorStakeInfoDecoder.decode(responseHex)
+            .filter { it.stake.signum() > 0 }
+            .map { SubtensorRawPosition(hotkey = it.hotkey, netuid = it.netuid, amount = it.stake) }
+    }
+
+    companion object {
+        private const val RUNTIME_API = "StakeInfoRuntimeApi_get_stake_info_for_coldkey"
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorSubnetFetcher.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorSubnetFetcher.kt
@@ -1,0 +1,191 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.network
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorSubnetInfo
+import io.novasama.substrate_sdk_android.hash.Hasher.blake2b128Concat
+import io.novasama.substrate_sdk_android.hash.Hasher.xxHash128
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.math.BigInteger
+
+/**
+ * Fetches subnet metadata for the Bittensor (TAO) chain via direct HTTP
+ * JSON-RPC. Queries `SubtensorModule.{SubnetTAO, SubnetAlphaIn,
+ * SubnetIdentitiesV3}` for netuids 1..128 in a single batch request.
+ *
+ * Mirrors iOS `SubtensorSubnetFetcher.swift`. SubnetTAO + SubnetAlphaIn
+ * use the `identity` hasher (raw u16 LE netuid as the storage key), and
+ * SubnetIdentitiesV3 uses `blake2b128Concat`. The subnet name is the
+ * first SCALE-encoded `Vec<u8>` field of the V3 identity record.
+ */
+class SubtensorSubnetFetcher(
+    private val httpClient: OkHttpClient,
+    private val gson: Gson,
+) {
+
+    private val rpcUrl: String = SubtensorStakingConstants.FALLBACK_RPC_URL
+    private val jsonMediaType = "application/json".toMediaType()
+
+    suspend fun fetchAllSubnets(): List<SubtensorSubnetInfo> {
+        val moduleHash = "SubtensorModule".toByteArray().xxHash128()
+        val taoItemHash = "SubnetTAO".toByteArray().xxHash128()
+        val alphaItemHash = "SubnetAlphaIn".toByteArray().xxHash128()
+        val identitiesItemHash = "SubnetIdentitiesV3".toByteArray().xxHash128()
+
+        val requests = mutableListOf<Map<String, Any>>()
+        for (netuid in 1..128) {
+            val netuidLE = u16LE(netuid)
+            val taoKey = "0x" + (moduleHash + taoItemHash + netuidLE).toHex()
+            val alphaKey = "0x" + (moduleHash + alphaItemHash + netuidLE).toHex()
+            val identityKey = "0x" + (moduleHash + identitiesItemHash + netuidLE.blake2b128Concat()).toHex()
+
+            val baseId = netuid * 3
+            requests += rpcRequest(baseId, "state_getStorage", listOf(taoKey))
+            requests += rpcRequest(baseId + 1, "state_getStorage", listOf(alphaKey))
+            requests += rpcRequest(baseId + 2, "state_getStorage", listOf(identityKey))
+        }
+
+        val responses = sendBatch(requests)
+
+        val results = mutableListOf<SubtensorSubnetInfo>()
+        for (netuid in 1..128) {
+            val baseId = netuid * 3
+            val taoHex = responses[baseId]
+            val alphaHex = responses[baseId + 1]
+            val identityHex = responses[baseId + 2]
+
+            val taoReserve = decodeU64Le(taoHex)
+            val alphaIn = decodeU64Le(alphaHex)
+
+            // iOS skips netuids whose SubnetTAO is zero — those subnets are
+            // either not active or the AMM has been drained, so a stake on
+            // them would have no liquidity. Match that filter.
+            if (taoReserve.signum() <= 0) continue
+
+            results += SubtensorSubnetInfo(
+                netuid = netuid,
+                name = decodeSubnetName(identityHex),
+                taoReserve = taoReserve,
+                alphaInReserve = alphaIn,
+            )
+        }
+        return results
+    }
+
+    private fun rpcRequest(id: Int, method: String, params: List<Any>): Map<String, Any> = mapOf(
+        "jsonrpc" to "2.0",
+        "id" to id,
+        "method" to method,
+        "params" to params,
+    )
+
+    private fun sendBatch(requests: List<Map<String, Any>>): Map<Int, String?> {
+        val body = gson.toJson(requests).toRequestBody(jsonMediaType)
+        val request = Request.Builder()
+            .url(rpcUrl)
+            .post(body)
+            .build()
+
+        return httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return emptyMap()
+            val text = response.body?.string() ?: return emptyMap()
+            val type = object : TypeToken<List<Map<String, Any>>>() {}.type
+            val parsed: List<Map<String, Any>> = gson.fromJson(text, type) ?: return emptyMap()
+            parsed.mapNotNull { item ->
+                val rpcId = (item["id"] as? Number)?.toInt() ?: return@mapNotNull null
+                rpcId to (item["result"] as? String)
+            }.toMap()
+        }
+    }
+
+    /**
+     * Single-subnet variant. Used by the stake-confirm flow to read the
+     * live AMM spot price right before submitting the extrinsic so the
+     * limit_price cushion reflects current chain state, not the (possibly
+     * stale) value the picker rendered. Mirrors iOS
+     * `SubtensorSubnetFetcher.fetchSubnetReserves(netuid:)`.
+     */
+    suspend fun fetchReserves(netuid: Int): SubtensorSubnetInfo? {
+        val moduleHash = "SubtensorModule".toByteArray().xxHash128()
+        val taoItemHash = "SubnetTAO".toByteArray().xxHash128()
+        val alphaItemHash = "SubnetAlphaIn".toByteArray().xxHash128()
+
+        val netuidLE = u16LE(netuid)
+        val taoKey = "0x" + (moduleHash + taoItemHash + netuidLE).toHex()
+        val alphaKey = "0x" + (moduleHash + alphaItemHash + netuidLE).toHex()
+
+        val responses = sendBatch(
+            listOf(
+                rpcRequest(1, "state_getStorage", listOf(taoKey)),
+                rpcRequest(2, "state_getStorage", listOf(alphaKey)),
+            )
+        )
+
+        val taoReserve = decodeU64Le(responses[1])
+        val alphaIn = decodeU64Le(responses[2])
+        if (taoReserve.signum() <= 0) return null
+        return SubtensorSubnetInfo(netuid = netuid, name = null, taoReserve = taoReserve, alphaInReserve = alphaIn)
+    }
+
+    private fun u16LE(value: Int): ByteArray = byteArrayOf((value and 0xFF).toByte(), ((value shr 8) and 0xFF).toByte())
+
+    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+
+    private fun decodeU64Le(hex: String?): BigInteger {
+        if (hex.isNullOrBlank()) return BigInteger.ZERO
+        val clean = hex.removePrefix("0x")
+        if (clean.length < 16) return BigInteger.ZERO
+        var result = BigInteger.ZERO
+        for (i in 7 downTo 0) {
+            val byteHex = clean.substring(i * 2, i * 2 + 2)
+            val b = byteHex.toIntOrNull(16) ?: return BigInteger.ZERO
+            result = result.shiftLeft(8).or(BigInteger.valueOf(b.toLong()))
+        }
+        return result
+    }
+
+    /**
+     * SubnetIdentitiesV3 decodes as a struct whose first field is
+     * `subnet_name: Vec<u8>`. Vec<u8> is encoded as a SCALE compact
+     * length prefix followed by the raw UTF-8 bytes. We only need the
+     * first field; downstream fields are ignored.
+     */
+    private fun decodeSubnetName(hex: String?): String? {
+        if (hex.isNullOrBlank()) return null
+        val clean = hex.removePrefix("0x")
+        if (clean.length < 4) return null
+
+        val bytes = ByteArray(clean.length / 2)
+        for (i in bytes.indices) {
+            bytes[i] = clean.substring(i * 2, i * 2 + 2).toIntOrNull(16)?.toByte() ?: return null
+        }
+        if (bytes.size < 2) return null
+
+        val first = bytes[0].toInt() and 0xFF
+        val mode = first and 0b11
+        val nameStart: Int
+        val nameLength: Int
+        when (mode) {
+            0b00 -> {
+                nameLength = first ushr 2
+                nameStart = 1
+            }
+            0b01 -> {
+                if (bytes.size < 2) return null
+                val high = bytes[1].toInt() and 0xFF
+                val raw = (first or (high shl 8))
+                nameLength = raw ushr 2
+                nameStart = 2
+            }
+            else -> return null
+        }
+        if (nameLength <= 0 || nameLength > 128) return null
+        if (nameStart + nameLength > bytes.size) return null
+        val nameBytes = bytes.copyOfRange(nameStart, nameStart + nameLength)
+        return runCatching { String(nameBytes, Charsets.UTF_8) }.getOrNull()
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorValidatorDataSource.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorValidatorDataSource.kt
@@ -1,0 +1,38 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.network
+
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorValidator
+import java.math.BigInteger
+
+/**
+ * Source of numeric validator data — total stake, commission, APR,
+ * nominator count. Identity comes from the `BittensorDelegatesClient`
+ * registry; this interface intentionally returns a list rather than a map
+ * because some sources (TaoStats) iterate over their own paged response.
+ *
+ * Two implementations:
+ *  - `TaoStatsValidatorDataSource` (gated to debug builds, with API key).
+ *  - `StubSubtensorValidatorDataSource` (release fallback — empty list).
+ *
+ * Mirrors `SubtensorValidatorDataSourceProtocol` on iOS. The DI binding is
+ * the swap point when Nova's own Bittensor indexer ships.
+ */
+interface SubtensorValidatorDataSource {
+
+    suspend fun fetchValidators(netuid: Int): List<SubtensorValidator>
+}
+
+/** Used in release builds where no TaoStats API key is bundled. */
+class StubSubtensorValidatorDataSource : SubtensorValidatorDataSource {
+
+    override suspend fun fetchValidators(netuid: Int): List<SubtensorValidator> = emptyList()
+}
+
+/** Aggregated validator numerics from any source — keyed by SS58 hotkey. */
+data class TaoStatsValidatorRow(
+    val hotkeySs58: String,
+    val totalStake: BigInteger,
+    val ownStake: BigInteger,
+    val nominatorCount: Int?,
+    val commission: Double?,
+    val apr: Double?,
+)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorValidatorProvider.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/SubtensorValidatorProvider.kt
@@ -1,0 +1,107 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.network
+
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorValidator
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import java.math.BigInteger
+
+/**
+ * Merges Bittensor validator identity (from the GitHub delegates registry)
+ * with numeric data (stake / commission / APR / nominator counts) from a
+ * pluggable [SubtensorValidatorDataSource] implementation.
+ *
+ * Mirrors iOS `SubtensorValidatorProvider`. When the numeric source returns
+ * an empty list (release builds without a TaoStats key, or transient
+ * failure) the provider falls back to identity-only rows so the picker
+ * still has something to show.
+ *
+ * v1 only ever asks for root-netuid validators, but the parameter is
+ * plumbed through unchanged to keep subnet variants drop-in.
+ */
+class SubtensorValidatorProvider(
+    private val delegatesClient: BittensorDelegatesClient,
+    private val dataSource: SubtensorValidatorDataSource,
+    private val identityAddressPrefix: Short,
+) {
+
+    suspend fun fetchValidators(netuid: Int): List<SubtensorValidator> = coroutineScope {
+        val delegatesDeferred: Deferred<Map<String, BittensorDelegateMetadata>> = async {
+            runCatching { delegatesClient.fetchDelegates() }
+                .getOrElse { delegatesClient.cachedDelegates() }
+        }
+        val numericDeferred: Deferred<List<SubtensorValidator>> = async {
+            runCatching { dataSource.fetchValidators(netuid) }.getOrDefault(emptyList())
+        }
+
+        val delegates = delegatesDeferred.await()
+        val numeric = numericDeferred.await()
+
+        val merged: List<SubtensorValidator> = if (numeric.isNotEmpty()) {
+            numeric.map { row ->
+                val identityKey: String? = runCatching { row.hotkey.toAddress(identityAddressPrefix) }.getOrNull()
+                val metadata: BittensorDelegateMetadata? = identityKey?.let { delegates[it] }
+                row.copy(
+                    identity = row.identity ?: metadata?.name,
+                    url = row.url ?: metadata?.url,
+                    description = row.description ?: metadata?.description,
+                )
+            }
+        } else {
+            // Identity-only fallback. Mirrors iOS — the "hotkey" produced
+            // here is a deterministic derivation from the SS58 string so
+            // the rest of the UI can still keyed-update on it. NOT
+            // cryptographically meaningful.
+            delegates.map { (ss58, metadata) ->
+                val hotkey = runCatching { ss58.toAccountId() }
+                    .getOrElse { placeholderAccountId(ss58) }
+                SubtensorValidator(
+                    hotkey = hotkey,
+                    netuid = netuid,
+                    identity = metadata.name,
+                    url = metadata.url,
+                    description = metadata.description,
+                    totalStake = BigInteger.ZERO,
+                    ownStake = BigInteger.ZERO,
+                    nominatorCount = null,
+                    commission = null,
+                    apr = null,
+                )
+            }
+        }
+
+        // Sort: total stake desc, ties broken by identity ascending. iOS
+        // does the same — keeps the picker stable across refreshes.
+        merged.sortedWith(
+            compareByDescending<SubtensorValidator> { it.totalStake }
+                .thenBy { it.identity ?: "" }
+        )
+    }
+
+    private fun placeholderAccountId(ss58: String): ByteArray {
+        val out = ByteArray(32)
+        for ((i, b) in ss58.toByteArray().withIndex()) {
+            out[i % 32] = (out[i % 32].toInt() xor b.toInt()).toByte()
+        }
+        return out
+    }
+
+    private fun SubtensorValidator.copy(
+        identity: String? = this.identity,
+        url: String? = this.url,
+        description: String? = this.description,
+    ): SubtensorValidator = SubtensorValidator(
+        hotkey = hotkey,
+        netuid = netuid,
+        identity = identity,
+        url = url,
+        description = description,
+        totalStake = totalStake,
+        ownStake = ownStake,
+        nominatorCount = nominatorCount,
+        commission = commission,
+        apr = apr,
+    )
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/TaoStatsValidatorDataSource.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/subtensor/network/TaoStatsValidatorDataSource.kt
@@ -1,0 +1,102 @@
+package io.novafoundation.nova.feature_staking_impl.data.subtensor.network
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorValidator
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.math.BigInteger
+
+/**
+ * [TEMP-TAOSTATS] Phase B numeric data source backed by TaoStats v1 REST.
+ *
+ * Endpoint: `https://api.taostats.io/api/validator/latest/v1?limit=200`
+ * Auth: raw API key in the `Authorization` header (no `Bearer` prefix).
+ *
+ * Mirrors iOS `TaoStatsValidatorDataSource` — same endpoint, same field
+ * mapping, same APR-fallback rule (30d average if > 0, else daily). The
+ * hotkey we emit is the decoded AccountId so the picker's selection round
+ * trip can encode it back to ss58 with whatever prefix the chain uses.
+ *
+ * When Nova's Bittensor indexer ships, this whole class is deleted and
+ * the DI binding swaps to a Nova-backed implementation — no consumer
+ * code change.
+ */
+class TaoStatsValidatorDataSource(
+    private val apiKey: String,
+    private val httpClient: OkHttpClient,
+    private val gson: Gson,
+) : SubtensorValidatorDataSource {
+
+    override suspend fun fetchValidators(netuid: Int): List<SubtensorValidator> {
+        val request = Request.Builder()
+            .url(ENDPOINT)
+            .header("Authorization", apiKey)
+            .header("Accept", "application/json")
+            .get()
+            .build()
+
+        return httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return emptyList()
+            val text = response.body?.string() ?: return emptyList()
+            parse(text, netuid)
+        }
+    }
+
+    fun parse(json: String, netuid: Int): List<SubtensorValidator> {
+        val parsed = runCatching { gson.fromJson(json, TaoStatsResponse::class.java) }.getOrNull() ?: return emptyList()
+        val rows = parsed.data ?: return emptyList()
+        return rows.mapNotNull { row -> row.toValidator(netuid) }
+    }
+
+    private fun TaoStatsValidatorRow.toValidator(netuid: Int): SubtensorValidator? {
+        val ss58 = hotkey?.ss58 ?: return null
+        val accountId = runCatching { ss58.toAccountId() }.getOrNull() ?: return null
+
+        val totalStake = stake?.let { runCatching { BigInteger(it) }.getOrNull() } ?: BigInteger.ZERO
+        val ownStake = validatorStake?.let { runCatching { BigInteger(it) }.getOrNull() } ?: BigInteger.ZERO
+        val commission = take?.toDoubleOrNull()
+        // Prefer 30-day average when positive, else fall back to daily APR.
+        // Mirrors iOS exactly so picker rows match across platforms.
+        val apr = apr30DayAverage?.toDoubleOrNull()?.takeIf { it > 0 }
+            ?: apr?.toDoubleOrNull()
+        val resolvedName = name?.trim()?.takeIf { it.isNotEmpty() }
+
+        return SubtensorValidator(
+            hotkey = accountId,
+            netuid = netuid,
+            identity = resolvedName,
+            url = null,
+            description = null,
+            totalStake = totalStake,
+            ownStake = ownStake,
+            nominatorCount = nominators?.takeIf { it >= 0 },
+            commission = commission,
+            apr = apr,
+        )
+    }
+
+    private companion object {
+        const val ENDPOINT = "https://api.taostats.io/api/validator/latest/v1?limit=200"
+    }
+
+    private data class TaoStatsResponse(
+        @SerializedName("data") val data: List<TaoStatsValidatorRow>?,
+    )
+
+    private data class TaoStatsValidatorRow(
+        @SerializedName("hotkey") val hotkey: TaoStatsHotkey?,
+        @SerializedName("name") val name: String?,
+        @SerializedName("stake") val stake: String?,
+        @SerializedName("validator_stake") val validatorStake: String?,
+        @SerializedName("take") val take: String?,
+        @SerializedName("apr") val apr: String?,
+        @SerializedName("apr_30_day_average") val apr30DayAverage: String?,
+        @SerializedName("nominators") val nominators: Int?,
+    )
+
+    private data class TaoStatsHotkey(
+        @SerializedName("ss58") val ss58: String?,
+    )
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureComponent.kt
@@ -87,10 +87,12 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.la
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.setupAmount.di.SetupAmountMultiStakingComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.setupStakingType.di.SetupStakingTypeComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main.di.SubtensorStakingComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.di.SubtensorStakeConfirmComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.di.SubtensorStakeSetupComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker.di.SubtensorSubnetPickerComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type.di.SubtensorStakeTypeComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.di.SubtensorValidatorPickerComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.di.SubtensorUnstakeConfirmComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.di.SubtensorUnstakeSetupComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.unbond.confirm.di.ConfirmUnbondComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.unbond.select.di.SelectUnbondComponent
@@ -280,9 +282,13 @@ interface StakingFeatureComponent : StakingFeatureApi {
 
     fun subtensorStakeSetupFactory(): SubtensorStakeSetupComponent.Factory
 
+    fun subtensorStakeConfirmFactory(): SubtensorStakeConfirmComponent.Factory
+
     fun subtensorValidatorPickerFactory(): SubtensorValidatorPickerComponent.Factory
 
     fun subtensorUnstakeSetupFactory(): SubtensorUnstakeSetupComponent.Factory
+
+    fun subtensorUnstakeConfirmFactory(): SubtensorUnstakeConfirmComponent.Factory
 
     @Component.Factory
     interface Factory {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureComponent.kt
@@ -86,6 +86,12 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.co
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.landing.di.StartStakingLandingComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.setupAmount.di.SetupAmountMultiStakingComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.start.setupStakingType.di.SetupStakingTypeComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main.di.SubtensorStakingComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.di.SubtensorStakeSetupComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker.di.SubtensorSubnetPickerComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type.di.SubtensorStakeTypeComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.di.SubtensorValidatorPickerComponent
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.di.SubtensorUnstakeSetupComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.unbond.confirm.di.ConfirmUnbondComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.unbond.select.di.SelectUnbondComponent
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.change.confirm.di.ConfirmChangeValidatorsComponent
@@ -264,6 +270,19 @@ interface StakingFeatureComponent : StakingFeatureApi {
     fun claimMythosRewardsFactory(): MythosClaimRewardsComponent.Factory
 
     fun currentMythosCollatorsFactory(): MythosCurrentCollatorsComponent.Factory
+
+    // Subtensor (TAO) staking
+    fun subtensorStakingFactory(): SubtensorStakingComponent.Factory
+
+    fun subtensorStakeTypeFactory(): SubtensorStakeTypeComponent.Factory
+
+    fun subtensorSubnetPickerFactory(): SubtensorSubnetPickerComponent.Factory
+
+    fun subtensorStakeSetupFactory(): SubtensorStakeSetupComponent.Factory
+
+    fun subtensorValidatorPickerFactory(): SubtensorValidatorPickerComponent.Factory
+
+    fun subtensorUnstakeSetupFactory(): SubtensorUnstakeSetupComponent.Factory
 
     @Component.Factory
     interface Factory {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureDependencies.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/StakingFeatureDependencies.kt
@@ -51,6 +51,7 @@ import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.A
 import io.novafoundation.nova.feature_wallet_api.data.repository.BalanceHoldsRepository
 import io.novafoundation.nova.feature_wallet_api.data.repository.BalanceLocksRepository
 import io.novafoundation.nova.feature_wallet_api.domain.ArbitraryAssetUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.ArbitraryTokenUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.TokenRepository
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletConstants
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletRepository
@@ -114,6 +115,11 @@ interface StakingFeatureDependencies {
     val runtimeCallsApi: MultiChainRuntimeCallsApi
 
     val arbitraryAssetUseCase: ArbitraryAssetUseCase
+
+    /** Used by Subtensor unstake setup to fetch fiat by priceId directly,
+     *  sidestepping the symbol-keyed `tokens` table that conflates Fusotao
+     *  and Bittensor (both declare symbol "TAO" in chains_dev.json). */
+    val arbitraryTokenUseCase: ArbitraryTokenUseCase
 
     val locksRepository: BalanceLocksRepository
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/dashboard/StakingDashboardModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/dashboard/StakingDashboardModule.kt
@@ -23,8 +23,17 @@ import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.Rea
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.RealTotalStakeChainComparatorProvider
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.StakingDashboardRepository
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.TotalStakeChainComparatorProvider
+import com.google.gson.Gson
 import io.novafoundation.nova.feature_staking_impl.data.nominationPools.repository.NominationPoolStateRepository
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.BittensorDelegatesClient
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.StubSubtensorValidatorDataSource
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorDataSource
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionFetcher
 import io.novafoundation.nova.feature_staking_impl.domain.dashboard.RealStakingDashboardInteractor
+import okhttp3.OkHttpClient
 import io.novafoundation.nova.feature_wallet_api.data.repository.BalanceLocksRepository
 import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletRepository
 import io.novafoundation.nova.runtime.di.REMOTE_STORAGE_SOURCE
@@ -64,6 +73,61 @@ class StakingDashboardModule {
 
     @Provides
     @FeatureScope
+    fun provideBittensorDelegatesClient(
+        gson: Gson,
+    ): BittensorDelegatesClient {
+        // The shared app OkHttpClient isn't exposed via StakingFeatureDependencies
+        // and adding it there would touch every existing staking-impl call site.
+        // BittensorDelegatesClient hits a single static GitHub URL once per
+        // session so a dedicated client is cheap and avoids the dependency tax.
+        return BittensorDelegatesClient(OkHttpClient(), gson)
+    }
+
+    @Provides
+    @FeatureScope
+    fun provideSubtensorSubnetFetcher(
+        gson: Gson,
+    ): SubtensorSubnetFetcher = SubtensorSubnetFetcher(OkHttpClient(), gson)
+
+    @Provides
+    @FeatureScope
+    fun provideSubtensorValidatorDataSource(): SubtensorValidatorDataSource =
+        // Release fallback. Numeric data source (TaoStats / Nova indexer)
+        // can be swapped here without touching the picker. Mirrors iOS
+        // `StubSubtensorValidatorDataSource`.
+        StubSubtensorValidatorDataSource()
+
+    @Provides
+    @FeatureScope
+    fun provideSubtensorValidatorProvider(
+        delegatesClient: BittensorDelegatesClient,
+        dataSource: SubtensorValidatorDataSource,
+        chainRegistry: ChainRegistry,
+    ): SubtensorValidatorProvider {
+        // Bittensor mainnet uses ss58 prefix 42. The validator picker only
+        // ever runs on Bittensor, so a constant is fine — if a second TAO
+        // chain ever appears the prefix can be plumbed through DI.
+        return SubtensorValidatorProvider(
+            delegatesClient = delegatesClient,
+            dataSource = dataSource,
+            identityAddressPrefix = 42,
+        )
+    }
+
+    @Provides
+    @FeatureScope
+    fun provideSubtensorPositionFetcher(
+        chainRegistry: ChainRegistry,
+    ): SubtensorPositionFetcher = SubtensorPositionFetcher(chainRegistry)
+
+    @Provides
+    @FeatureScope
+    fun provideSubtensorPositionCache(
+        fetcher: SubtensorPositionFetcher,
+    ): SubtensorPositionCache = SubtensorPositionCache(fetcher)
+
+    @Provides
+    @FeatureScope
     fun provideStakingDashboardUpdaterFactory(
         @Named(REMOTE_STORAGE_SOURCE) remoteStorageSource: StorageDataSource,
         stakingDashboardCache: StakingDashboardCache,
@@ -71,13 +135,15 @@ class StakingDashboardModule {
         poolAccountDerivation: PoolAccountDerivation,
         storageCache: StorageCache,
         balanceLocksRepository: BalanceLocksRepository,
+        subtensorPositionCache: SubtensorPositionCache,
     ) = StakingDashboardUpdaterFactory(
         stakingDashboardCache = stakingDashboardCache,
         remoteStorageSource = remoteStorageSource,
         nominationPoolBalanceRepository = nominationPoolBalanceRepository,
         poolAccountDerivation = poolAccountDerivation,
         storageCache = storageCache,
-        balanceLocksRepository = balanceLocksRepository
+        balanceLocksRepository = balanceLocksRepository,
+        subtensorPositionCache = subtensorPositionCache,
     )
 
     @Provides

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/dashboard/StakingDashboardModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/dashboard/StakingDashboardModule.kt
@@ -25,12 +25,14 @@ import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.Sta
 import io.novafoundation.nova.feature_staking_impl.data.dashboard.repository.TotalStakeChainComparatorProvider
 import com.google.gson.Gson
 import io.novafoundation.nova.feature_staking_impl.data.nominationPools.repository.NominationPoolStateRepository
+import io.novafoundation.nova.feature_staking_impl.BuildConfig
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.BittensorDelegatesClient
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.StubSubtensorValidatorDataSource
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorDataSource
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.TaoStatsValidatorDataSource
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionFetcher
 import io.novafoundation.nova.feature_staking_impl.domain.dashboard.RealStakingDashboardInteractor
 import okhttp3.OkHttpClient
@@ -91,11 +93,22 @@ class StakingDashboardModule {
 
     @Provides
     @FeatureScope
-    fun provideSubtensorValidatorDataSource(): SubtensorValidatorDataSource =
-        // Release fallback. Numeric data source (TaoStats / Nova indexer)
-        // can be swapped here without touching the picker. Mirrors iOS
-        // `StubSubtensorValidatorDataSource`.
-        StubSubtensorValidatorDataSource()
+    fun provideSubtensorValidatorDataSource(
+        gson: Gson,
+    ): SubtensorValidatorDataSource {
+        // Mirrors iOS `SubtensorStakeSetupViewFactory`: if a TaoStats key
+        // is available in the build (read from local.properties or the
+        // shared key file at build time — see feature-staking-impl/build.gradle),
+        // use the TaoStats REST data source so APR + commission render in
+        // the picker. Otherwise fall back to the empty stub so the picker
+        // still works in identity-only mode.
+        val key: String? = BuildConfig.TAOSTATS_API_KEY
+        return if (!key.isNullOrBlank()) {
+            TaoStatsValidatorDataSource(apiKey = key, httpClient = OkHttpClient(), gson = gson)
+        } else {
+            StubSubtensorValidatorDataSource()
+        }
+    }
 
     @Provides
     @FeatureScope

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/dashboard/RealStakingDashboardInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/dashboard/RealStakingDashboardInteractor.kt
@@ -159,7 +159,12 @@ class RealStakingDashboardInteractor(
                 val asset = chain.assetsById[assetId] ?: return@innerForEach
 
                 if (dashboardItems.isNoStakePresent()) {
-                    if (!chain.isTestNet) {
+                    // Subnet alpha rows are written by the Subtensor updater
+                    // for every netuid (1..128) regardless of stake — surfacing
+                    // them in "Available to stake" would flood the dashboard
+                    // with 128 empty SN rows. Mirrors iOS `StakingDashboardBuilder`
+                    // filter on `type == "subtensor-alpha"`.
+                    if (!chain.isTestNet && asset.type !is Chain.Asset.Type.SubtensorAlpha) {
                         noStake.add(noStakeAggregatedOption(chain, asset, dashboardItems, syncingStageMap))
                     }
                 } else {
@@ -203,6 +208,10 @@ class RealStakingDashboardInteractor(
 
             itemsByChain.forEach innerForEach@{ assetId, dashboardItems ->
                 val asset = chain.assetsById[assetId] ?: return@innerForEach
+
+                // Same alpha-row filter as `constructStakingDashboard` — iOS
+                // applies it universally in `StakingDashboardBuilder.swift:145`.
+                if (asset.type is Chain.Asset.Type.SubtensorAlpha) return@innerForEach
 
                 if (dashboardItems.isNoStakePresent()) {
                     if (chain.isTestNet) {
@@ -456,6 +465,8 @@ class RealStakingDashboardInteractor(
             StakingTypeGroup.NOMINATION_POOL -> transferableInPlanks
             StakingTypeGroup.UNSUPPORTED -> Balance.ZERO
             StakingTypeGroup.MYTHOS -> freeInPlanks
+            // Subtensor: TAO root staking spends free balance like relaychain.
+            StakingTypeGroup.SUBTENSOR -> freeInPlanks
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rewards/ParachainStakingRewardCalculatorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rewards/ParachainStakingRewardCalculatorFactory.kt
@@ -12,6 +12,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.SUBTENSOR
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.UNSUPPORTED
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
@@ -33,7 +34,7 @@ class ParachainStakingRewardCalculatorFactory(
         return when (stakingOption.additional.stakingType) {
             PARACHAIN -> defaultCalculator(chainId, snapshots)
             TURING -> turingCalculator(chainId, snapshots)
-            NOMINATION_POOLS, RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO, UNSUPPORTED, MYTHOS -> {
+            NOMINATION_POOLS, RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO, UNSUPPORTED, MYTHOS, SUBTENSOR -> {
                 throw IllegalStateException("Unknown staking type in ParachainStakingRewardCalculatorFactory")
             }
         }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/rewards/RewardCalculatorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/rewards/RewardCalculatorFactory.kt
@@ -24,6 +24,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.SUBTENSOR
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.UNSUPPORTED
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
@@ -89,7 +90,7 @@ class RewardCalculatorFactory(
             }
 
             ALEPH_ZERO -> AlephZeroRewardCalculator(validators, chainAsset = assetWithChain.asset)
-            NOMINATION_POOLS, UNSUPPORTED, PARACHAIN, TURING, MYTHOS -> throw IllegalStateException("Unknown staking type in RelaychainRewardFactory")
+            NOMINATION_POOLS, UNSUPPORTED, PARACHAIN, TURING, MYTHOS, SUBTENSOR -> throw IllegalStateException("Unknown staking type in RelaychainRewardFactory")
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/SubtensorStakeSubmitInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/SubtensorStakeSubmitInteractor.kt
@@ -1,0 +1,102 @@
+package io.novafoundation.nova.feature_staking_impl.domain.subtensor
+
+import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.TransactionOrigin
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
+import io.novafoundation.nova.feature_account_api.data.extrinsic.awaitInBlock
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.extrinsic.addStakeLimit
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.extrinsic.removeStakeLimit
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.runtime.state.chain
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.math.BigInteger
+
+/**
+ * Submits a Bittensor `add_stake_limit` extrinsic and waits for it to land
+ * in a block. Mirrors iOS `SubtensorStakeConfirmInteractor.doConfirmExtrinsic`.
+ *
+ * For subnet flows the caller-supplied netuid drives a live AMM-reserve
+ * fetch so the limit_price cushion reflects current chain state. Root flows
+ * skip the reserve fetch entirely (no AMM).
+ *
+ * On `inBlock` the per-coldkey [SubtensorPositionCache] is invalidated so
+ * the next dashboard sync sees the new position rather than the pre-stake
+ * snapshot.
+ */
+class SubtensorStakeSubmitInteractor(
+    private val extrinsicService: ExtrinsicService,
+    private val stakingSharedState: StakingSharedState,
+    private val accountRepository: AccountRepository,
+    private val subnetFetcher: SubtensorSubnetFetcher,
+    private val positionCache: SubtensorPositionCache,
+) {
+
+    suspend fun submitStake(
+        netuid: Int,
+        hotkey: ByteArray,
+        amountInPlanks: BigInteger,
+    ): Result<Unit> = withContext(Dispatchers.Default) {
+        runCatching {
+            val chain = stakingSharedState.chain()
+            val metaAccount = accountRepository.getSelectedMetaAccount()
+            val coldkey = metaAccount.requireAccountIdIn(chain)
+
+            val spotPrice: Double? = if (netuid != SubtensorStakingConstants.ROOT_NETUID) {
+                runCatching { subnetFetcher.fetchReserves(netuid) }.getOrNull()?.spotPrice
+            } else {
+                null
+            }
+
+            extrinsicService.submitAndWatchExtrinsic(chain, TransactionOrigin.SelectedWallet) {
+                addStakeLimit(
+                    hotkey = hotkey,
+                    netuid = netuid,
+                    amount = amountInPlanks,
+                    spotPriceTaoPerAlpha = spotPrice,
+                )
+            }.awaitInBlock().getOrThrow()
+
+            positionCache.invalidate(coldkey)
+        }
+    }
+
+    /**
+     * Submits `SubtensorModule.remove_stake_limit`. For subnet positions
+     * (netuid != 0) we fetch live AMM reserves so the limit_price cushion
+     * tracks the current chain state; root positions skip the fetch since
+     * there is no AMM. Mirrors iOS `SubtensorUnstakeConfirmInteractor`.
+     */
+    suspend fun submitUnstake(
+        netuid: Int,
+        hotkey: ByteArray,
+        amountInPlanks: BigInteger,
+    ): Result<Unit> = withContext(Dispatchers.Default) {
+        runCatching {
+            val chain = stakingSharedState.chain()
+            val metaAccount = accountRepository.getSelectedMetaAccount()
+            val coldkey = metaAccount.requireAccountIdIn(chain)
+
+            val spotPrice: Double? = if (netuid != SubtensorStakingConstants.ROOT_NETUID) {
+                runCatching { subnetFetcher.fetchReserves(netuid) }.getOrNull()?.spotPrice
+            } else {
+                null
+            }
+
+            extrinsicService.submitAndWatchExtrinsic(chain, TransactionOrigin.SelectedWallet) {
+                removeStakeLimit(
+                    hotkey = hotkey,
+                    netuid = netuid,
+                    amount = amountInPlanks,
+                    spotPriceTaoPerAlpha = spotPrice,
+                )
+            }.awaitInBlock().getOrThrow()
+
+            positionCache.invalidate(coldkey)
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/SubtensorStakeSubmitInteractor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/SubtensorStakeSubmitInteractor.kt
@@ -11,6 +11,8 @@ import io.novafoundation.nova.feature_staking_impl.data.subtensor.extrinsic.remo
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.TransferMode
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.nativeTransfer
 import io.novafoundation.nova.runtime.state.chain
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -52,11 +54,27 @@ class SubtensorStakeSubmitInteractor(
                 null
             }
 
+            // Nova service fee (subnet only, root is exempt). Inert when the
+            // recipient is unset or the floored fee rounds to 0. When charged,
+            // we prepend a transferKeepAlive leg and reduce the staked amount by
+            // the fee; the two .call()s auto-wrap in utility.batchAll (default
+            // BatchMode.BATCH_ALL) so both land atomically.
+            val novaFeeRecipient = SubtensorStakingConstants.NOVA_FEE_RECIPIENT
+            val novaFee = if (netuid != SubtensorStakingConstants.ROOT_NETUID && novaFeeRecipient != null) {
+                SubtensorStakingConstants.novaFeeAmount(amountInPlanks)
+            } else {
+                BigInteger.ZERO
+            }
+
             extrinsicService.submitAndWatchExtrinsic(chain, TransactionOrigin.SelectedWallet) {
+                if (novaFeeRecipient != null && novaFee > BigInteger.ZERO) {
+                    nativeTransfer(novaFeeRecipient, novaFee, TransferMode.KEEP_ALIVE)
+                }
+
                 addStakeLimit(
                     hotkey = hotkey,
                     netuid = netuid,
-                    amount = amountInPlanks,
+                    amount = amountInPlanks - novaFee,
                     spotPriceTaoPerAlpha = spotPrice,
                 )
             }.awaitInBlock().getOrThrow()
@@ -66,34 +84,62 @@ class SubtensorStakeSubmitInteractor(
     }
 
     /**
-     * Submits `SubtensorModule.remove_stake_limit`. For subnet positions
-     * (netuid != 0) we fetch live AMM reserves so the limit_price cushion
-     * tracks the current chain state; root positions skip the fetch since
-     * there is no AMM. Mirrors iOS `SubtensorUnstakeConfirmInteractor`.
+     * Submits `SubtensorModule.remove_stake_limit`. The caller passes the
+     * [spotPriceTaoPerAlpha] it already resolved (and displayed on the confirm
+     * screen), so the limit_price cushion AND the Nova fee are derived from the
+     * SAME reserve read the user saw — no second fetch, no displayed-vs-charged
+     * drift. Mirrors iOS `SubtensorUnstakeConfirmInteractor`, which computes the
+     * commission once and reuses it for both the row and the extrinsic. `null`
+     * (root, or an unresolved estimate) means no Nova fee and a conservative
+     * fallback limit_price.
      */
     suspend fun submitUnstake(
         netuid: Int,
         hotkey: ByteArray,
         amountInPlanks: BigInteger,
+        spotPriceTaoPerAlpha: Double?,
     ): Result<Unit> = withContext(Dispatchers.Default) {
         runCatching {
             val chain = stakingSharedState.chain()
             val metaAccount = accountRepository.getSelectedMetaAccount()
             val coldkey = metaAccount.requireAccountIdIn(chain)
 
-            val spotPrice: Double? = if (netuid != SubtensorStakingConstants.ROOT_NETUID) {
-                runCatching { subnetFetcher.fetchReserves(netuid) }.getOrNull()?.spotPrice
+            // Nova service fee (subnet only, root is exempt). Based on the
+            // *minimum* TAO the unstake can return — alpha * spotPrice cushioned
+            // by DEFAULT_SLIPPAGE — computed from the SAME spot price the screen
+            // displayed, so charged == shown. Inert when the recipient is unset,
+            // the spot price is unresolved, or the floored fee rounds to 0.
+            val novaFeeRecipient = SubtensorStakingConstants.NOVA_FEE_RECIPIENT
+            val novaFee = if (
+                netuid != SubtensorStakingConstants.ROOT_NETUID &&
+                novaFeeRecipient != null &&
+                spotPriceTaoPerAlpha != null &&
+                spotPriceTaoPerAlpha > 0.0
+            ) {
+                val minTaoOut = (
+                    amountInPlanks.toBigDecimal() *
+                        spotPriceTaoPerAlpha.toBigDecimal() *
+                        (1.0 - SubtensorStakingConstants.DEFAULT_SLIPPAGE).toBigDecimal()
+                    ).toBigInteger()
+                SubtensorStakingConstants.novaFeeAmount(minTaoOut)
             } else {
-                null
+                BigInteger.ZERO
             }
 
+            // Fee leg comes LAST here: unstake settles TAO into the coldkey
+            // first, then the fee is swept out. The two .call()s auto-wrap in
+            // utility.batchAll (default BatchMode.BATCH_ALL) so both are atomic.
             extrinsicService.submitAndWatchExtrinsic(chain, TransactionOrigin.SelectedWallet) {
                 removeStakeLimit(
                     hotkey = hotkey,
                     netuid = netuid,
                     amount = amountInPlanks,
-                    spotPriceTaoPerAlpha = spotPrice,
+                    spotPriceTaoPerAlpha = spotPriceTaoPerAlpha,
                 )
+
+                if (novaFeeRecipient != null && novaFee > BigInteger.ZERO) {
+                    nativeTransfer(novaFeeRecipient, novaFee, TransferMode.KEEP_ALIVE)
+                }
             }.awaitInBlock().getOrThrow()
 
             positionCache.invalidate(coldkey)

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorStakePosition.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorStakePosition.kt
@@ -1,0 +1,36 @@
+package io.novafoundation.nova.feature_staking_impl.domain.subtensor.model
+
+import java.math.BigInteger
+
+/**
+ * Resolved stake position for a (coldkey, hotkey, netuid) tuple as returned
+ * by `StakeInfoRuntimeApi_get_stake_info_for_coldkey`. Amount is already in
+ * the subnet's smallest unit (RAO for netuid=0, alpha-units for netuid>0).
+ */
+data class SubtensorStakePosition(
+    val coldkey: ByteArray,
+    val hotkey: ByteArray,
+    val netuid: Int,
+    val amount: BigInteger,
+    val validatorIdentity: String?,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SubtensorStakePosition) return false
+        return coldkey.contentEquals(other.coldkey) &&
+            hotkey.contentEquals(other.hotkey) &&
+            netuid == other.netuid &&
+            amount == other.amount &&
+            validatorIdentity == other.validatorIdentity
+    }
+
+    override fun hashCode(): Int {
+        var result = coldkey.contentHashCode()
+        result = 31 * result + hotkey.contentHashCode()
+        result = 31 * result + netuid
+        result = 31 * result + amount.hashCode()
+        result = 31 * result + (validatorIdentity?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorStakingConstants.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorStakingConstants.kt
@@ -1,0 +1,42 @@
+package io.novafoundation.nova.feature_staking_impl.domain.subtensor.model
+
+import java.math.BigInteger
+
+/**
+ * Static configuration shared across the Bittensor (TAO) staking surface.
+ *
+ * Mirrors `SubtensorStakingConstants.swift` on the iOS side. Values here are
+ * verified against finney mainnet and are used by the multistaking dashboard
+ * sync, the detail screen, the stake setup flow, and the extrinsic builder.
+ */
+object SubtensorStakingConstants {
+
+    /** Root subnet id. Subnet alpha assets carry netuid 1..128 in `typeExtras`. */
+    const val ROOT_NETUID: Int = 0
+
+    /** Subnet alpha asset typeExtras key — value is an Int netuid. */
+    const val NETUID_TYPE_EXTRA_KEY: String = "netuid"
+
+    /**
+     * Hardcoded minimum nominator stake in RAO (= 0.01 TAO). Verified against
+     * finney mainnet 2026-04-13. The runtime constant exists but isn't wired
+     * yet — keep this in sync if the chain bumps it.
+     */
+    val MIN_NOMINATOR_STAKE_RAO: BigInteger = BigInteger.valueOf(10_000_000L)
+
+    /** Default slippage cushion for the *Limit extrinsic variants. */
+    const val DEFAULT_SLIPPAGE: Double = 0.005
+
+    /** GitHub registry for validator identity metadata. */
+    const val DELEGATES_REGISTRY_URL: String =
+        "https://raw.githubusercontent.com/opentensor/bittensor-delegates/main/public/delegates.json"
+
+    /** Mainnet RPC fallback if the chain config has no usable nodes. */
+    const val FALLBACK_RPC_URL: String = "https://entrypoint-finney.opentensor.ai"
+
+    /** Multistaking dashboard re-poll interval. Same as iOS. */
+    const val DASHBOARD_RESYNC_SECONDS: Long = 30
+
+    /** Per-coldkey fetch cache TTL. */
+    const val POSITION_CACHE_TTL_SECONDS: Long = 15
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorStakingConstants.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorStakingConstants.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.domain.subtensor.model
 
+import io.novasama.substrate_sdk_android.runtime.AccountId
 import java.math.BigInteger
 
 /**
@@ -39,4 +40,34 @@ object SubtensorStakingConstants {
 
     /** Per-coldkey fetch cache TTL. */
     const val POSITION_CACHE_TTL_SECONDS: Long = 15
+
+    /**
+     * Nova Wallet service fee on subnet staking, expressed as a numerator over
+     * [NOVA_FEE_DENOMINATOR]. 30 / 10_000 = 0.3%. Mirrors the shipped iOS
+     * feature. Root staking (netuid == [ROOT_NETUID]) is exempt.
+     */
+    const val NOVA_FEE_NUMERATOR: Int = 30
+    const val NOVA_FEE_DENOMINATOR: Int = 10_000
+
+    /** Human-readable fee percentage for UI copy. */
+    const val NOVA_FEE_PERCENT_DISPLAY: String = "0.3"
+
+    /**
+     * Recipient of the Nova service fee.
+     *
+     * `null` means the feature is fully INERT: no fee leg is added and the
+     * stake/unstake extrinsics behave exactly as before. A real value MUST be
+     * a validated 32-byte AccountId (the decoded public key, not an SS58
+     * string) on the Bittensor chain — set it deliberately, never from
+     * unvalidated input.
+     */
+    val NOVA_FEE_RECIPIENT: AccountId? = null
+
+    /**
+     * The Nova service fee, in planks, charged on [gross]. Integer (plank) math
+     * with floor rounding: `floor(gross * 30 / 10_000)`. Sub-threshold dust
+     * floors to 0.
+     */
+    fun novaFeeAmount(gross: BigInteger): BigInteger =
+        gross * NOVA_FEE_NUMERATOR.toBigInteger() / NOVA_FEE_DENOMINATOR.toBigInteger()
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorSubnetInfo.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorSubnetInfo.kt
@@ -1,0 +1,23 @@
+package io.novafoundation.nova.feature_staking_impl.domain.subtensor.model
+
+import java.math.BigInteger
+
+/**
+ * Lightweight model for a Bittensor subnet, used by the subnet picker.
+ * Mirrors iOS `SubtensorSubnetInfo`.
+ */
+data class SubtensorSubnetInfo(
+    val netuid: Int,
+    val name: String?,
+    val taoReserve: BigInteger,
+    val alphaInReserve: BigInteger,
+) {
+
+    /** Spot price in TAO per alpha: taoReserve / alphaInReserve. */
+    val spotPrice: Double
+        get() = if (alphaInReserve.signum() > 0) {
+            taoReserve.toDouble() / alphaInReserve.toDouble()
+        } else {
+            0.0
+        }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorValidator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/model/SubtensorValidator.kt
@@ -1,0 +1,40 @@
+package io.novafoundation.nova.feature_staking_impl.domain.subtensor.model
+
+import java.math.BigInteger
+
+/**
+ * Validator (hotkey) display row for the Bittensor validator picker.
+ *
+ * Identity comes from the `opentensor/bittensor-delegates` GitHub registry;
+ * numeric fields (totalStake, ownStake, commission, apr, nominatorCount)
+ * come from a TaoStats stop-gap until Nova's own indexer ships.
+ *
+ * Mirrors iOS `SubtensorValidator`.
+ */
+data class SubtensorValidator(
+    val hotkey: ByteArray,
+    val netuid: Int,
+    val identity: String?,
+    val url: String?,
+    val description: String?,
+    val totalStake: BigInteger,
+    val ownStake: BigInteger,
+    val nominatorCount: Int?,
+    /** Fraction 0.0..1.0. Null when unknown. */
+    val commission: Double?,
+    /** Post-commission APR. Null when unknown. */
+    val apr: Double?,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SubtensorValidator) return false
+        return hotkey.contentEquals(other.hotkey) && netuid == other.netuid
+    }
+
+    override fun hashCode(): Int {
+        var result = hotkey.contentHashCode()
+        result = 31 * result + netuid
+        return result
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/StakingRouter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/StakingRouter.kt
@@ -13,10 +13,71 @@ import io.novafoundation.nova.feature_staking_impl.presentation.staking.rewardDe
 import io.novafoundation.nova.feature_staking_impl.presentation.staking.unbond.confirm.ConfirmUnbondPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.change.custom.common.CustomValidatorsPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.validators.details.StakeTargetDetailsPayload
+import kotlinx.coroutines.flow.Flow
 
 interface StakingRouter {
 
     fun openChainStakingMain()
+
+    /**
+     * Routes the dashboard tap on a Bittensor (`SUBTENSOR`) row to its own
+     * detail fragment instead of the compound-component `StakingFragment`.
+     * Subtensor doesn't fit the relaychain/parachain/Mythos component model.
+     */
+    fun openSubtensorStakingMain()
+
+    /**
+     * Subtensor stake-add type picker (Root TAO vs Subnet alpha). Pushed
+     * from the Subtensor staking detail screen when the user taps
+     * "Stake more". Mirrors iOS `SubtensorStakingWireframe.showStakingFlow`.
+     */
+    fun openSubtensorStakeType()
+
+    /**
+     * Subnet alpha picker. Pushed from the Type Picker when the user picks
+     * Subnet on Continue. Selecting a row routes onward to the stake setup
+     * screen with that netuid.
+     */
+    fun openSubtensorSubnetPicker()
+
+    /**
+     * Subtensor stake-add amount + validator setup screen. Pushed either
+     * from the Type Picker (Root path, netuid = 0) or from the Subnet
+     * Picker (subnet path, netuid 1..128). `subnetName` is rendered in the
+     * setup screen header for subnet flows; null for root.
+     */
+    fun openSubtensorStakeSetup(netuid: Int, subnetName: String? = null)
+
+    /**
+     * Subtensor validator picker. Pushed from the stake-setup screen's
+     * "Select validator" slot. Selection is reported back via
+     * [SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR_HOTKEY] on the
+     * setup screen's saved state handle.
+     */
+    fun openSubtensorValidatorPicker(netuid: Int)
+
+    /**
+     * Writes the picked hotkey into the previous back-stack entry's saved
+     * state handle and pops the validator picker. Same idiom as the
+     * crowdloan-bonus round-trip (see `Navigator.setCustomBonus`).
+     */
+    fun respondAndPopValidatorPicker(hotkey: String)
+
+    /**
+     * Stream of the most-recently-picked Subtensor validator hotkey, scoped
+     * to the current Stake Setup back-stack entry. Mirrors the crowdloan
+     * `customBonusFlow` pattern.
+     */
+    val subtensorSelectedValidatorFlow: Flow<String?>
+
+    /**
+     * Subtensor unstake setup screen. Pushed from the main TAO staking
+     * screen — the user has already picked a position (or there's only
+     * one), so the destination receives a fully-resolved
+     * (netuid, hotkey, position-amount) triple. Mirrors iOS
+     * `SubtensorStakingWireframe.pushUnstakeSetup`.
+     */
+    fun openSubtensorUnstakeSetup(netuid: Int, hotkeyAddress: String, positionPlanks: java.math.BigInteger)
 
     fun openStartChangeValidators()
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/StakingRouter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/StakingRouter.kt
@@ -49,6 +49,13 @@ interface StakingRouter {
     fun openSubtensorStakeSetup(netuid: Int, subnetName: String? = null)
 
     /**
+     * Subtensor stake-add Confirm screen. Pushed from Setup's Continue
+     * after validation. The payload carries the snapshotted fee so what
+     * the user agreed to is what they sign — same idiom as ConfirmBondMore.
+     */
+    fun openSubtensorStakeConfirm(payload: io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmPayload)
+
+    /**
      * Subtensor validator picker. Pushed from the stake-setup screen's
      * "Select validator" slot. Selection is reported back via
      * [SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR_HOTKEY] on the
@@ -57,18 +64,18 @@ interface StakingRouter {
     fun openSubtensorValidatorPicker(netuid: Int)
 
     /**
-     * Writes the picked hotkey into the previous back-stack entry's saved
-     * state handle and pops the validator picker. Same idiom as the
-     * crowdloan-bonus round-trip (see `Navigator.setCustomBonus`).
+     * Writes the picked validator (hotkey + identity) into the previous
+     * back-stack entry's saved state handle and pops the validator picker.
+     * Same idiom as the crowdloan-bonus round-trip (see `Navigator.setCustomBonus`).
      */
-    fun respondAndPopValidatorPicker(hotkey: String)
+    fun respondAndPopValidatorPicker(picked: io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorPickedValidator)
 
     /**
-     * Stream of the most-recently-picked Subtensor validator hotkey, scoped
-     * to the current Stake Setup back-stack entry. Mirrors the crowdloan
-     * `customBonusFlow` pattern.
+     * Stream of the most-recently-picked Subtensor validator (hotkey +
+     * identity), scoped to the current Stake Setup back-stack entry.
+     * Mirrors the crowdloan `customBonusFlow` pattern.
      */
-    val subtensorSelectedValidatorFlow: Flow<String?>
+    val subtensorSelectedValidatorFlow: Flow<io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorPickedValidator?>
 
     /**
      * Subtensor unstake setup screen. Pushed from the main TAO staking
@@ -78,6 +85,13 @@ interface StakingRouter {
      * `SubtensorStakingWireframe.pushUnstakeSetup`.
      */
     fun openSubtensorUnstakeSetup(netuid: Int, hotkeyAddress: String, positionPlanks: java.math.BigInteger)
+
+    /**
+     * Subtensor unstake Confirm screen. Pushed from Setup's Continue
+     * after the snapshot fee + amount + identity are resolved. Mirrors
+     * the stake-confirm path.
+     */
+    fun openSubtensorUnstakeConfirm(payload: io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmPayload)
 
     fun openStartChangeValidators()
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
@@ -167,6 +167,14 @@ class StakingDashboardViewModel(
             null
         }
 
+        // Subtensor (root + subnet) has no off-chain rewards indexer — iOS
+        // hides the "X.XX% per year" row for every Bittensor row. Subnet
+        // alpha additionally has no priceId, so iOS hides the fiat lines
+        // for those too. Detect via staking type / chain-asset type from
+        // nova-utils (`staking: ["subtensor"]`, `type: "subtensor-alpha"`).
+        val isSubtensor = hasStake.stakingState.stakingType == Chain.Asset.StakingType.SUBTENSOR
+        val isSubnetAlpha = hasStake.token.configuration.type is Chain.Asset.Type.SubtensorAlpha
+
         return StakingDashboardModel.HasStakeItem(
             assetLabel = resourceManager.getString(R.string.staking_rewards, hasStake.token.configuration.name).syncingIf(isSyncingPrimary),
             assetId = hasStake.token.configuration.fullId,
@@ -181,7 +189,9 @@ class StakingDashboardViewModel(
             status = stats.map { mapStakingStatusToUi(it.status).syncingIf(isSyncingSecondary) },
             earnings = stats.map { it.estimatedEarnings.format().syncingIf(isSyncingSecondary) },
             stakingTypeBadge = stakingTypBadge,
-            assetIcon = assetIconProvider.getAssetIconOrFallback(hasStake.token.configuration.icon).syncingIf(isSyncingPrimary)
+            assetIcon = assetIconProvider.getAssetIconOrFallback(hasStake.token.configuration.icon).syncingIf(isSyncingPrimary),
+            hideFiat = isSubnetAlpha,
+            hideEarnings = isSubtensor,
         )
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/StakingDashboardViewModel.kt
@@ -36,6 +36,8 @@ import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.
 import io.novafoundation.nova.common.presentation.masking.formatter.MaskableValueFormatter
 import io.novafoundation.nova.common.presentation.masking.formatter.MaskableValueFormatterProvider
 import io.novafoundation.nova.runtime.ext.fullId
+import io.novafoundation.nova.runtime.ext.utilityAsset
+import io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updaters.chain.subtensorNetuid
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -107,8 +109,27 @@ class StakingDashboardViewModel(
         val stakingTypes = noStakeItemState.flowType.allStakingTypes
         val chain = withoutStakeItem.chain
         val chainAsset = withoutStakeItem.token.configuration
+        val firstStakingType = stakingTypes.first()
 
-        stakingSharedState.setSelectedOption(chain, chainAsset, stakingTypes.first())
+        // Subtensor doesn't fit the start-staking landing flow (no `RewardCalculator`
+        // for SUBTENSOR yet) — route straight to the detail screen instead.
+        // Mirrors iOS `StakingDashboardWireframe.showSubtensorStakingDetails`:
+        // normalize to the native TAO asset before publishing to shared state
+        // so balance / fee / signing flows always operate on TAO. The entry
+        // netuid is preserved separately so the detail screen can scope.
+        if (firstStakingType == Chain.Asset.StakingType.SUBTENSOR) {
+            val taoAsset = chain.subtensorTaoAssetOrNull() ?: return@launch
+            stakingSharedState.setSelectedOption(
+                chain = chain,
+                chainAsset = taoAsset,
+                stakingType = firstStakingType,
+                subtensorEntryNetuid = chainAsset.subtensorNetuid(),
+            )
+            router.openSubtensorStakingMain()
+            return@launch
+        }
+
+        stakingSharedState.setSelectedOption(chain, chainAsset, firstStakingType)
 
         val payload = StartStakingLandingPayload(
             availableStakingOptions = AvailableStakingOptionsPayload(chain.id, chainAsset.id, stakingTypes)
@@ -191,12 +212,36 @@ class StakingDashboardViewModel(
         chainAsset: Chain.Asset,
         stakingType: Chain.Asset.StakingType
     ) {
-        stakingSharedState.setSelectedOption(
-            chain = chain,
-            chainAsset = chainAsset,
-            stakingType = stakingType
-        )
-
-        router.openChainStakingMain()
+        if (stakingType == Chain.Asset.StakingType.SUBTENSOR) {
+            // Mirrors iOS `StakingDashboardWireframe.showSubtensorStakingDetails`:
+            // normalize the entry chainAsset to the native TAO asset, but
+            // preserve the originally tapped row's netuid so the detail
+            // screen scopes correctly (e.g. tapping SN8 → entryNetuid 8).
+            val taoAsset = chain.subtensorTaoAssetOrNull() ?: return
+            stakingSharedState.setSelectedOption(
+                chain = chain,
+                chainAsset = taoAsset,
+                stakingType = stakingType,
+                subtensorEntryNetuid = chainAsset.subtensorNetuid(),
+            )
+            router.openSubtensorStakingMain()
+        } else {
+            stakingSharedState.setSelectedOption(
+                chain = chain,
+                chainAsset = chainAsset,
+                stakingType = stakingType
+            )
+            router.openChainStakingMain()
+        }
     }
+}
+
+/**
+ * Returns the chain's native TAO asset (utility asset) when the chain
+ * supports Subtensor staking, otherwise null. Mirrors the iOS extension
+ * `chainAsset.subtensorTaoAsset()` used by `StakingDashboardWireframe`.
+ */
+private fun Chain.subtensorTaoAssetOrNull(): Chain.Asset? {
+    val utility = utilityAsset
+    return utility.takeIf { Chain.Asset.StakingType.SUBTENSOR in it.staking }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/list/DashboardHasStakeAdapter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/list/DashboardHasStakeAdapter.kt
@@ -60,6 +60,9 @@ class DashboardHasStakeViewHolder(
         bindAssetIcon(model)
         bindAssetLabel(model)
         bindStakingType(model)
+        // Subnet alpha rows have no price feed / rewards indexer; hide the
+        // fiat + APY rows entirely. Idempotent — safe to call on every bind.
+        containerView.setHideFiatAndEarnings(hideFiat = model.hideFiat, hideEarnings = model.hideEarnings)
     }
 
     fun bindAssetIcon(model: HasStakeItem) {
@@ -72,6 +75,9 @@ class DashboardHasStakeViewHolder(
 
     fun bindEarnings(model: HasStakeItem) {
         containerView.setEarnings(model.earnings)
+        // setEarnings re-shows the "/y" suffix on every loaded state — re-apply
+        // the subnet-alpha hide so partial updates don't bring it back.
+        containerView.setHideFiatAndEarnings(hideFiat = model.hideFiat, hideEarnings = model.hideEarnings)
     }
 
     fun bindStakingType(model: HasStakeItem) {
@@ -80,10 +86,16 @@ class DashboardHasStakeViewHolder(
 
     fun bindStake(model: HasStakeItem) {
         containerView.setStake(model.stake)
+        // setStake toggles the fiat-container shimmer, which forces it back
+        // to visible — reapply the hide flag for subnet-alpha rows.
+        containerView.setHideFiatAndEarnings(hideFiat = model.hideFiat, hideEarnings = model.hideEarnings)
     }
 
     fun bindRewards(model: HasStakeItem) {
         containerView.setRewards(model.rewards)
+        // Same reason as bindStake / bindEarnings — partial updates would
+        // otherwise re-show the rewards token + fiat for subnet-alpha rows.
+        containerView.setHideFiatAndEarnings(hideFiat = model.hideFiat, hideEarnings = model.hideEarnings)
     }
 
     fun bindStatus(model: HasStakeItem) {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/model/StakingDashboardModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/model/StakingDashboardModel.kt
@@ -23,6 +23,15 @@ class StakingDashboardModel(
         val stake: SyncingData<MaskableModel<AmountModel>>,
         val status: ExtendedLoadingState<SyncingData<StakeStatusModel>>,
         val earnings: ExtendedLoadingState<SyncingData<String>>,
+        /** Hide both fiat-under-stake lines (rewards fiat + stake fiat).
+         *  True only for subnet-alpha rows, which have no priceId. iOS does
+         *  the same — alpha never has a CoinGecko feed. Root TAO keeps fiat. */
+        val hideFiat: Boolean = false,
+        /** Hide the "X.XX% per year" group (label + value + suffix). True
+         *  for all Subtensor rows — Bittensor has no off-chain rewards
+         *  indexer, so the estimated APY is meaningless on both root and
+         *  subnet. Mirrors iOS dashboard mapper. */
+        val hideEarnings: Boolean = false,
     ) : BaseItem
 
     data class NoStakeItem(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/view/StakingDashboardHasStakeView.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/dashboard/main/view/StakingDashboardHasStakeView.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.dashboard.main.
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import coil.ImageLoader
@@ -111,6 +112,30 @@ class StakingDashboardHasStakeView @JvmOverloads constructor(
         earningsGroup.applyState(earningsState) { text = it }
 
         binder.itemDashboardHasStakeEarningsSuffix.setVisible(earningsState.isLoaded())
+    }
+
+    /** Subnet alpha rows have no price feed (so fiat is meaningless) and no
+     *  off-chain rewards indexer (so the "X.XX% per year" estimate is too).
+     *  iOS keeps the rewards label + token amount visible (shows "0 SN68"
+     *  next to "SN68 rewards") and only hides the two fiat lines and the
+     *  earnings group. Mirroring that here.
+     *
+     *  Re-applied from each payload bind path because `setEarnings` /
+     *  `setStake` / `setRewards` toggle visibilities of their own that would
+     *  otherwise re-show the hidden views on a partial update — see
+     *  `DashboardHasStakeViewHolder.bind*`. */
+    /** Toggles fiat-under-amount + earnings-APY visibility independently —
+     *  iOS hides the APY for every Bittensor row (no off-chain indexer)
+     *  but only hides fiat for subnet alpha (no priceId). Uses INVISIBLE,
+     *  not GONE, so the constraint chain still reserves the height — cards
+     *  stay the same size as relaychain cards regardless. */
+    fun setHideFiatAndEarnings(hideFiat: Boolean, hideEarnings: Boolean) {
+        val invisible = View.INVISIBLE
+        binder.itemDashboardHasStakeRewardsFiatContainer.setVisible(!hideFiat, invisible)
+        binder.itemDashboardHasStakeStakesFiatContainer.setVisible(!hideFiat, invisible)
+        binder.itemDashboardHasStakeEarningsLabel.setVisible(!hideEarnings, invisible)
+        binder.itemDashboardHasStakeEarningsContainer.setVisible(!hideEarnings, invisible)
+        binder.itemDashboardHasStakeEarningsSuffix.setVisible(!hideEarnings, invisible)
     }
 
     fun setStakingTypeBadge(model: StakingTypeModel?) {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/CompoundStatefullComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/CompoundStatefullComponent.kt
@@ -14,6 +14,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.SUBTENSOR
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.UNSUPPORTED
 import kotlinx.coroutines.CoroutineScope
@@ -87,6 +88,10 @@ private class CompoundStakingComponent<S, E, A>(
             TURING -> turingComponentCreator(stakingOption, childHostContext)
             NOMINATION_POOLS -> nominationPoolsCreator(stakingOption, childHostContext)
             MYTHOS -> mythosCreator(stakingOption, childHostContext)
+            // Subtensor is rendered by its own dedicated screen (not the
+            // compound component flow). The dashboard router branches before
+            // reaching here, so this path is defensive.
+            SUBTENSOR -> UnsupportedComponent()
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/common/StakingTypeFormatter.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/common/StakingTypeFormatter.kt
@@ -10,6 +10,6 @@ fun ResourceManager.formatStakingTypeLabel(stakingType: Chain.Asset.StakingType)
     return when (stakingType.group()) {
         StakingTypeGroup.RELAYCHAIN -> getString(R.string.setup_staking_type_direct_staking)
         StakingTypeGroup.NOMINATION_POOL -> getString(R.string.setup_staking_type_pool_staking)
-        StakingTypeGroup.UNSUPPORTED, StakingTypeGroup.PARACHAIN, StakingTypeGroup.MYTHOS -> error("Not yet available")
+        StakingTypeGroup.UNSUPPORTED, StakingTypeGroup.PARACHAIN, StakingTypeGroup.MYTHOS, StakingTypeGroup.SUBTENSOR -> error("Not yet available")
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/landing/StartStakingLandingViewModel.kt
@@ -235,6 +235,7 @@ class StartStakingLandingViewModel(
 
             StakingTypeGroup.MYTHOS -> router.openStartMythosStaking()
 
+            StakingTypeGroup.SUBTENSOR -> Unit // Subtensor start-staking flow is opened directly from the dashboard.
             StakingTypeGroup.UNSUPPORTED -> Unit
         }
     }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeValidationFailureUi.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/start/setupStakingType/SetupStakingTypeValidationFailureUi.kt
@@ -33,7 +33,7 @@ fun handleSetupStakingTypeValidationFailure(chainAsset: Chain.Asset, error: Edit
                     resourceManager.getString(R.string.setup_staking_type_already_used_title),
                     resourceManager.getString(R.string.setup_staking_type_pool_already_used_message)
                 )
-                StakingTypeGroup.UNSUPPORTED -> TitleAndMessage(
+                StakingTypeGroup.UNSUPPORTED, StakingTypeGroup.SUBTENSOR -> TitleAndMessage(
                     resourceManager.getString(R.string.setup_staking_type_already_used_title),
                     resourceManager.getString(R.string.setup_staking_type_unsupported_staking_type_used_fallback_message)
                 )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/common/SubtensorNovaFee.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/common/SubtensorNovaFee.kt
@@ -1,0 +1,93 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.common
+
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_wallet_api.domain.model.TokenBase
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.formatAmountToAmountModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeDisplay
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeStatus
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.toFeeDisplay
+import java.math.BigInteger
+
+/**
+ * Builders for the Nova Wallet service-fee disclosure row shown next to the
+ * network-fee row on the four Subtensor stake/unstake screens. Mirrors the
+ * shipped iOS feature. The fee value is a pure display artifact — the actual
+ * fee leg lives in the extrinsic builder (Phase A). These helpers only produce
+ * a [FeeStatus] for an existing `FeeView`/`setFeeStatus` binding.
+ *
+ * Isolated here (own file, own package object) so none of the existing
+ * network-fee rows or VMs are touched.
+ */
+object SubtensorNovaFee {
+
+    /**
+     * Whether the disclosure (fee row + caption) should be shown at all.
+     *
+     * True only when the fee actually applies: a non-root subnet AND a
+     * configured recipient. Today [SubtensorStakingConstants.NOVA_FEE_RECIPIENT]
+     * is `null`, so this is always false and the UI stays hidden — matching the
+     * inert Phase-A mechanism. Setting a recipient flips both on.
+     */
+    fun feeApplies(netuid: Int): Boolean {
+        return netuid != SubtensorStakingConstants.ROOT_NETUID &&
+            SubtensorStakingConstants.NOVA_FEE_RECIPIENT != null
+    }
+
+    /**
+     * [FeeStatus] for the Nova fee rendered in the native asset (TAO) — used by
+     * the stake screens and the unstake-confirm screen. [grossPlanks] is the
+     * amount the 0.3% is charged on; the fee itself is
+     * [SubtensorStakingConstants.novaFeeAmount].
+     *
+     * Returns [FeeStatus.NoFee] when the fee does not apply, which hides the row
+     * via the standard `FeeView` behavior.
+     */
+    fun nativeFeeStatus(
+        netuid: Int,
+        grossPlanks: BigInteger,
+        token: TokenBase,
+        amountFormatter: AmountFormatter,
+    ): FeeStatus<Unit, FeeDisplay> {
+        if (!feeApplies(netuid)) return FeeStatus.NoFee
+
+        // No amount entered yet → keep the row present but show the standard
+        // loading spinner (matches iOS) instead of a literal "0". Once a positive
+        // amount exists, dust that floors to 0 still renders as "0".
+        if (grossPlanks <= BigInteger.ZERO) return FeeStatus.Loading(visibleDuringProgress = true)
+
+        val feePlanks = SubtensorStakingConstants.novaFeeAmount(grossPlanks)
+        val display = amountFormatter.formatAmountToAmountModel(feePlanks, token).toFeeDisplay()
+
+        return FeeStatus.Loaded(FeeModel(fee = Unit, display = display))
+    }
+
+    /**
+     * [FeeStatus] for the Nova fee rendered in the screen's (alpha) asset units —
+     * used by the unstake-setup screen, where iOS shows the fee in the subnet
+     * token. The fee is 0.3% of the entered alpha [grossPlanks]; we format the
+     * raw value with [precision] and tag it with [ticker] (e.g. "SN56") since
+     * subnet alpha carries no fiat price (matching the amount header).
+     */
+    fun alphaFeeStatus(
+        netuid: Int,
+        grossPlanks: BigInteger,
+        precision: Int,
+        ticker: String,
+    ): FeeStatus<Unit, FeeDisplay> {
+        if (!feeApplies(netuid)) return FeeStatus.NoFee
+
+        // No amount entered yet → loading spinner (matches iOS), not "0 <ticker>".
+        if (grossPlanks <= BigInteger.ZERO) return FeeStatus.Loading(visibleDuringProgress = true)
+
+        val feePlanks = SubtensorStakingConstants.novaFeeAmount(grossPlanks)
+        val feeAlpha = feePlanks.toBigDecimal().movePointLeft(precision)
+        val display = FeeDisplay(
+            title = "%.5f %s".format(feeAlpha, ticker),
+            subtitle = null,
+        )
+
+        return FeeStatus.Loaded(FeeModel(fee = Unit, display = display))
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/SubtensorStakingFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/SubtensorStakingFragment.kt
@@ -1,5 +1,7 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main
 
+import android.content.Intent
+import android.net.Uri
 import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -7,6 +9,9 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.colorSpan
+import io.novafoundation.nova.common.utils.formatAsSpannable
+import io.novafoundation.nova.common.utils.toSpannable
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorStakingBinding
@@ -22,6 +27,18 @@ class SubtensorStakingFragment : BaseFragment<SubtensorStakingViewModel, Fragmen
         binder.subtensorStakingToolbar.setHomeButtonListener { viewModel.backClicked() }
         binder.subtensorStakeMore.setOnClickListener { viewModel.stakeMore() }
         binder.subtensorUnstake.setOnClickListener { viewModel.unstake() }
+        binder.subtensorLandingStartButton.setOnClickListener { viewModel.stakeMore() }
+        binder.subtensorLandingMoreInfo.setOnClickListener { viewModel.novaWikiClicked() }
+        // Tint the Start CTA gold — matches AZERO/etc. landings, which
+        // colour the button using the chain's theme accent. Bittensor's
+        // accent in chains_dev is the warning gold (#EBC50A).
+        binder.subtensorLandingStartButton.setButtonColor(goldAccent())
+        // Static bullet copy — only the highlighted ranges depend on
+        // dynamic data (max APY, min stake, etc), bound below in subscribe().
+        binder.subtensorLandingBulletStake.text = buildBulletStake()
+        binder.subtensorLandingBulletRewards.text = buildBulletRewards()
+        binder.subtensorLandingBulletMonitor.text = buildBulletMonitor()
+        binder.subtensorLandingMoreInfo.text = buildMoreInfoText()
     }
 
     override fun onResume() {
@@ -51,6 +68,17 @@ class SubtensorStakingFragment : BaseFragment<SubtensorStakingViewModel, Fragmen
     override fun subscribe(viewModel: SubtensorStakingViewModel) {
         viewModel.state.observe { state ->
             renderState(state)
+        }
+        viewModel.maxApy.observe { maxApy ->
+            binder.subtensorLandingTitle.text = buildTitle(maxApy)
+        }
+        viewModel.availableBalance.observe { balance ->
+            binder.subtensorLandingAvailableBalance.text = balance?.let {
+                getString(R.string.subtensor_landing_available_balance, it)
+            }
+        }
+        viewModel.openBrowserEvent.observeEvent { url ->
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
         }
         viewModel.errorEvents.observeEvent { message ->
             // Mirrors iOS `wireframe.showError(from:message:)` — surface the
@@ -88,22 +116,47 @@ class SubtensorStakingFragment : BaseFragment<SubtensorStakingViewModel, Fragmen
         val loading = binder.subtensorLoading
         val empty = binder.subtensorEmptyState
         val content = binder.subtensorContent
+        // The bottom Start-staking + balance container is paired with the
+        // empty/landing state — hidden in every other state so the regular
+        // detail content takes the full screen.
+        val landingBottom = binder.subtensorLandingBottomContainer
+        val toolbar = binder.subtensorStakingToolbar
+        val root = binder.subtensorRoot
 
         when (state) {
             SubtensorStakingViewModel.UiState.Loading -> {
                 loading.isVisible = true
                 empty.isVisible = false
                 content.isVisible = false
+                landingBottom.isVisible = false
+                toolbar.setTitle("")
+                toolbar.setHomeButtonIcon(R.drawable.ic_close)
+                // Default Nova gradient while we don't know yet whether
+                // this account has a stake or lands on the gold landing.
+                root.setBackgroundResource(R.drawable.drawable_background_image)
             }
             SubtensorStakingViewModel.UiState.Empty -> {
                 loading.isVisible = false
                 empty.isVisible = true
                 content.isVisible = false
+                landingBottom.isVisible = true
+                // Modal-feeling landing matches AZERO etc.: no title, X close
+                // icon, solid black background. Distinct from the populated
+                // detail state which gets a title + back arrow + gradient.
+                toolbar.setTitle("")
+                toolbar.setHomeButtonIcon(R.drawable.ic_close)
+                root.setBackgroundResource(R.color.secondary_screen_background)
             }
             is SubtensorStakingViewModel.UiState.Loaded -> {
                 loading.isVisible = false
                 empty.isVisible = false
                 content.isVisible = true
+                landingBottom.isVisible = false
+                toolbar.setTitle(getString(R.string.subtensor_staking_title))
+                toolbar.setHomeButtonIcon(R.drawable.ic_arrow_back)
+                // Populated detail uses the standard Nova blue gradient,
+                // matching every other staking detail screen.
+                root.setBackgroundResource(R.drawable.drawable_background_image)
                 bindLoaded(state)
             }
         }
@@ -124,6 +177,40 @@ class SubtensorStakingFragment : BaseFragment<SubtensorStakingViewModel, Fragmen
         binder.subtensorValidatorCard.isVisible = state.validators.isNotEmpty()
         binder.subtensorValidatorTitle.text = state.validatorsTitle
         renderValidatorRows(state.validators)
+    }
+
+    /** Theme accent colour for the gold-landing highlights. Mirrors iOS's
+     *  `R.color.colorTextWarning` / Bittensor brand gold. Falls back to
+     *  Nova's positive-amount colour if no chain theme is configured. */
+    private fun goldAccent(): Int = requireContext().getColor(R.color.text_warning)
+
+    private fun buildTitle(maxApy: String): CharSequence {
+        val accent = maxApy.toSpannable(colorSpan(goldAccent()))
+        return getString(R.string.subtensor_landing_title).formatAsSpannable(accent)
+    }
+
+    private fun buildBulletStake(): CharSequence {
+        val minStake = getString(R.string.subtensor_landing_min_stake_value).toSpannable(colorSpan(goldAccent()))
+        val firstReward = getString(R.string.subtensor_landing_first_reward_time).toSpannable(colorSpan(goldAccent()))
+        return getString(R.string.subtensor_landing_min_stake_condition).formatAsSpannable(minStake, firstReward)
+    }
+
+    private fun buildBulletRewards(): CharSequence {
+        val frequency = getString(R.string.subtensor_landing_rewards_frequency_value)
+            .toSpannable(colorSpan(goldAccent()))
+        return getString(R.string.subtensor_landing_rewards_frequency_condition).formatAsSpannable(frequency)
+    }
+
+    private fun buildBulletMonitor(): CharSequence {
+        val monitor = getString(R.string.subtensor_landing_monitor_accent)
+            .toSpannable(colorSpan(goldAccent()))
+        return getString(R.string.subtensor_landing_monitor_condition).formatAsSpannable(monitor)
+    }
+
+    private fun buildMoreInfoText(): CharSequence {
+        val link = getString(R.string.subtensor_landing_wiki_link)
+            .toSpannable(colorSpan(requireContext().getColor(R.color.button_text_accent)))
+        return getString(R.string.subtensor_landing_more_info).formatAsSpannable(link)
     }
 
     private fun renderValidatorRows(rows: List<SubtensorStakingViewModel.ValidatorRow>) {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/SubtensorStakingFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/SubtensorStakingFragment.kt
@@ -1,0 +1,153 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main
+
+import android.view.View
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.view.isVisible
+import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorStakingBinding
+import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+
+class SubtensorStakingFragment : BaseFragment<SubtensorStakingViewModel, FragmentSubtensorStakingBinding>() {
+
+    private var hasAppeared: Boolean = false
+
+    override fun createBinding() = FragmentSubtensorStakingBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+        binder.subtensorStakingToolbar.setHomeButtonListener { viewModel.backClicked() }
+        binder.subtensorStakeMore.setOnClickListener { viewModel.stakeMore() }
+        binder.subtensorUnstake.setOnClickListener { viewModel.unstake() }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        // Initial load is driven by the ViewModel's `init` block. Subsequent
+        // appearances (e.g. popping back from the stake-confirm flow once that
+        // lands) need a refresh so the new position lands without making the
+        // user re-open the screen. Mirrors iOS `viewWillAppear` semantics.
+        if (hasAppeared) {
+            viewModel.refresh()
+        } else {
+            hasAppeared = true
+        }
+    }
+
+    override fun inject() {
+        FeatureUtils.getFeature<StakingFeatureComponent>(
+            requireContext(),
+            StakingFeatureApi::class.java,
+        )
+            .subtensorStakingFactory()
+            .create(this)
+            .inject(this)
+    }
+
+    override fun subscribe(viewModel: SubtensorStakingViewModel) {
+        viewModel.state.observe { state ->
+            renderState(state)
+        }
+        viewModel.errorEvents.observeEvent { message ->
+            // Mirrors iOS `wireframe.showError(from:message:)` — surface the
+            // failure without destroying any loaded content currently on
+            // screen. Toast keeps it lightweight; dialog would interrupt.
+            android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
+        }
+        viewModel.unstakeRequest.observeEvent { action ->
+            when (action) {
+                is SubtensorStakingViewModel.UnstakeAction.Empty -> android.widget.Toast.makeText(
+                    requireContext(),
+                    R.string.subtensor_unstake_no_positions,
+                    android.widget.Toast.LENGTH_SHORT,
+                ).show()
+                is SubtensorStakingViewModel.UnstakeAction.Single -> viewModel.unstakeOptionPicked(action)
+                is SubtensorStakingViewModel.UnstakeAction.Pick -> showUnstakePickerDialog(action)
+            }
+        }
+    }
+
+    private fun showUnstakePickerDialog(action: SubtensorStakingViewModel.UnstakeAction.Pick) {
+        // Mirrors iOS `SubtensorStakingWireframe.showUnstake` action sheet:
+        // a list of positions (validator identity or shortened hotkey) the
+        // user picks one of before being routed onward to UnstakeSetup.
+        androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setTitle(R.string.subtensor_unstake_pick_validator)
+            .setItems(action.labels.toTypedArray()) { _, which ->
+                viewModel.unstakeOptionPicked(action.options[which])
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun renderState(state: SubtensorStakingViewModel.UiState) {
+        val loading = binder.subtensorLoading
+        val empty = binder.subtensorEmptyState
+        val content = binder.subtensorContent
+
+        when (state) {
+            SubtensorStakingViewModel.UiState.Loading -> {
+                loading.isVisible = true
+                empty.isVisible = false
+                content.isVisible = false
+            }
+            SubtensorStakingViewModel.UiState.Empty -> {
+                loading.isVisible = false
+                empty.isVisible = true
+                content.isVisible = false
+            }
+            is SubtensorStakingViewModel.UiState.Loaded -> {
+                loading.isVisible = false
+                empty.isVisible = false
+                content.isVisible = true
+                bindLoaded(state)
+            }
+        }
+    }
+
+    private fun bindLoaded(state: SubtensorStakingViewModel.UiState.Loaded) {
+        binder.subtensorTotalStakeAmount.text = state.totalAmountText
+
+        val badge = state.netuidBadge
+        binder.subtensorTotalStakeBadge.apply {
+            text = badge
+            isVisible = badge != null
+        }
+
+        binder.subtensorMinStake.text = state.minStakeText
+        binder.subtensorUnstakingPeriod.text = state.unstakingPeriodText
+
+        binder.subtensorValidatorCard.isVisible = state.validators.isNotEmpty()
+        binder.subtensorValidatorTitle.text = state.validatorsTitle
+        renderValidatorRows(state.validators)
+    }
+
+    private fun renderValidatorRows(rows: List<SubtensorStakingViewModel.ValidatorRow>) {
+        val container = binder.subtensorValidatorRows
+        container.removeAllViews()
+        rows.forEachIndexed { index, row ->
+            val view = layoutInflater.inflate(R.layout.item_subtensor_validator_row, container, false)
+            view.findViewById<ImageView>(R.id.subtensorValidatorRowIcon).apply {
+                setImageDrawable(row.identicon)
+                isVisible = row.identicon != null
+            }
+            view.findViewById<TextView>(R.id.subtensorValidatorRowName).text =
+                row.identityName ?: row.hotkeyShort
+            view.findViewById<TextView>(R.id.subtensorValidatorRowHotkey).apply {
+                // The whole screen is netuid-scoped, so each row's subtitle
+                // shows only the truncated hotkey (matches iOS
+                // `SubtensorValidatorListView.swift:150-151`). The netuid
+                // appears once on the stake-total card via `netuidBadge`.
+                text = row.hotkeyShort
+                isVisible = row.identityName != null
+            }
+            view.findViewById<TextView>(R.id.subtensorValidatorRowAmount).text = row.amountText
+            view.findViewById<View>(R.id.subtensorValidatorRowDivider).isVisible = index < rows.size - 1
+            (container as LinearLayout).addView(view)
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/SubtensorStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/SubtensorStakingViewModel.kt
@@ -1,0 +1,309 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main
+
+import android.graphics.drawable.Drawable
+import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.utils.Event
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.BittensorDelegatesClient
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
+import io.novafoundation.nova.runtime.state.chain
+import io.novafoundation.nova.runtime.state.chainAsset
+import kotlinx.coroutines.flow.first
+import io.novafoundation.nova.common.utils.UNIFIED_ADDRESS_PREFIX
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.math.BigInteger
+
+/**
+ * Backs the Bittensor staking detail screen. Reads the user's positions
+ * via the shared [SubtensorPositionCache] (same source the multistaking
+ * dashboard uses, so the data is consistent between screens), filters to
+ * the entry netuid, and surfaces the result as three view-model blocks:
+ * total, validator rows, info card.
+ *
+ * Mirrors the iOS `SubtensorStakingPresenter`. Stake/unstake actions are
+ * out of scope for the first pass — the screen is read-only until the
+ * setup VIPER flow lands.
+ */
+class SubtensorStakingViewModel(
+    private val stakingSharedState: StakingSharedState,
+    private val accountRepository: AccountRepository,
+    private val positionCache: SubtensorPositionCache,
+    private val delegatesClient: BittensorDelegatesClient,
+    private val resourceManager: ResourceManager,
+    private val router: StakingDashboardRouter,
+    private val stakingRouter: StakingRouter,
+    private val addressIconGenerator: AddressIconGenerator,
+) : BaseViewModel() {
+
+    private val _state = MutableStateFlow<UiState>(UiState.Loading)
+    val state: StateFlow<UiState> = _state.asStateFlow()
+
+    /**
+     * One-shot error events. Fragment observes via LiveData and shows a
+     * Snackbar — keeps the existing loaded content on screen, like iOS
+     * `wireframe.showError(from:message:)`.
+     */
+    val errorEvents = androidx.lifecycle.MutableLiveData<Event<String>>()
+
+    init {
+        launch { load(showLoadingIndicator = true) }
+    }
+
+    fun backClicked() {
+        router.returnToStakingDashboard()
+    }
+
+    /** Mirrors iOS `SubtensorStakingPresenter.didTapStakeMore()`. */
+    fun stakeMore() {
+        stakingRouter.openSubtensorStakeType()
+    }
+
+    sealed interface UnstakeAction {
+        object Empty : UnstakeAction
+        data class Single(val netuid: Int, val hotkeyAddress: String, val amount: BigInteger) : UnstakeAction
+        data class Pick(val options: List<Single>, val labels: List<String>) : UnstakeAction
+    }
+
+    val unstakeRequest = androidx.lifecycle.MutableLiveData<Event<UnstakeAction>>()
+
+    /**
+     * Mirrors iOS `SubtensorStakingPresenter.didTapUnstake()`. Loads
+     * positions for this netuid; if there is exactly one we route directly
+     * to UnstakeSetup, otherwise emit a picker request the Fragment
+     * resolves with an AlertDialog.
+     */
+    fun unstake() {
+        launch {
+            val chain = stakingSharedState.chain()
+            val coldkey = accountRepository.getSelectedMetaAccount().substrateAccountId
+            if (coldkey == null) {
+                errorEvents.value = Event(resourceManager.getString(R.string.subtensor_unstake_no_positions))
+                return@launch
+            }
+            val entryNetuid = stakingSharedState.selectedOption.first()
+                .additional
+                .subtensorEntryNetuid
+                ?: SubtensorStakingConstants.ROOT_NETUID
+
+            val positions = runCatching {
+                withContext(Dispatchers.IO) { positionCache.positions(chain.id, coldkey) }
+            }.getOrDefault(emptyList())
+                .filter { it.netuid == entryNetuid && it.amount.signum() > 0 }
+
+            when (positions.size) {
+                0 -> unstakeRequest.value = Event(UnstakeAction.Empty)
+                1 -> {
+                    val pos = positions[0]
+                    unstakeRequest.value = Event(
+                        UnstakeAction.Single(
+                            netuid = pos.netuid,
+                            hotkeyAddress = pos.hotkey.toAddress(chain.addressPrefix.toShort()),
+                            amount = pos.amount,
+                        )
+                    )
+                }
+                else -> {
+                    val identityByHotkey = runCatching {
+                        withContext(Dispatchers.IO) { delegatesClient.fetchDelegates() }
+                    }.getOrDefault(emptyMap())
+                    val prefix = chain.addressPrefix.toShort()
+                    val singles = positions.map { p ->
+                        UnstakeAction.Single(
+                            netuid = p.netuid,
+                            hotkeyAddress = p.hotkey.toAddress(prefix),
+                            amount = p.amount,
+                        )
+                    }
+                    val labels = singles.map { single ->
+                        identityByHotkey[single.hotkeyAddress]?.name?.takeIf { it.isNotBlank() }
+                            ?: shortenAddress(single.hotkeyAddress)
+                    }
+                    unstakeRequest.value = Event(UnstakeAction.Pick(options = singles, labels = labels))
+                }
+            }
+        }
+    }
+
+    fun unstakeOptionPicked(option: UnstakeAction.Single) {
+        stakingRouter.openSubtensorUnstakeSetup(
+            netuid = option.netuid,
+            hotkeyAddress = option.hotkeyAddress,
+            positionPlanks = option.amount,
+        )
+    }
+
+    private fun shortenAddress(address: String): String =
+        if (address.length <= 10) address else "${address.take(6)}…${address.takeLast(4)}"
+
+    /**
+     * Mirrors iOS `SubtensorStakingPresenter.refresh()` — deliberately keeps
+     * the existing loaded content on screen while a fresh fetch runs in the
+     * background. The screen flickering to a spinner on every nav return
+     * felt jumpy (matches iOS comment).
+     */
+    fun refresh() {
+        launch { load(showLoadingIndicator = false) }
+    }
+
+    private suspend fun load(showLoadingIndicator: Boolean) {
+        if (showLoadingIndicator) {
+            _state.value = UiState.Loading
+        }
+
+        val chain = stakingSharedState.chain()
+        val chainAsset = stakingSharedState.chainAsset()
+
+        // Entry netuid arrives via the shared-state additional data — set by
+        // the dashboard ViewModel from the originally tapped row before
+        // normalising chainAsset to TAO. Defaults to root for safety.
+        // Mirrors iOS `SubtensorStakingViewFactory.createView(... entryNetuid:)`.
+        val entryNetuid = stakingSharedState.selectedOption.first()
+            .additional
+            .subtensorEntryNetuid
+            ?: SubtensorStakingConstants.ROOT_NETUID
+
+        val coldkey = accountRepository.getSelectedMetaAccount().substrateAccountId
+        if (coldkey == null) {
+            _state.value = UiState.Empty
+            return
+        }
+
+        val positions = runCatching {
+            withContext(Dispatchers.IO) { positionCache.positions(chain.id, coldkey) }
+        }.getOrElse { e ->
+            // Mirrors iOS `SubtensorStakingPresenter.didReceive(error:)`:
+            // surface the error via a side-channel without destroying the
+            // existing loaded content. If we never had loaded content
+            // (initial fetch failed), fall through to Empty so the screen
+            // doesn't stick on the loading spinner.
+            errorEvents.value = Event(e.message.orEmpty())
+            if (_state.value !is UiState.Loaded) {
+                _state.value = UiState.Empty
+            }
+            return
+        }
+
+        val scoped = positions.filter { it.netuid == entryNetuid }
+        if (scoped.isEmpty()) {
+            _state.value = UiState.Empty
+            return
+        }
+
+        val total = scoped.fold(BigInteger.ZERO) { acc, p -> acc + p.amount }
+        val isRoot = entryNetuid == SubtensorStakingConstants.ROOT_NETUID
+        val precision = chainAsset.precision.value.toInt()
+        val totalText = formatSubtensorAmount(total, precision, isRoot)
+
+        // Best-effort identity merge — if the registry fetch fails we just
+        // show truncated hotkeys. Mirrors iOS behaviour.
+        val identityByHotkey = runCatching {
+            withContext(Dispatchers.IO) { delegatesClient.fetchDelegates() }
+        }.getOrDefault(emptyMap())
+
+        // Render validator hotkeys with the unified-display prefix (0 / Polkadot)
+        // for cross-chain consistency, matching iOS `toAddressWithDefaultConversion`
+        // → `multichainDisplayPrefix = 0`. The chain's actual prefix (42 for
+        // Bittensor) still drives the registry identity lookup.
+        val displayPrefix = SS58Encoder.UNIFIED_ADDRESS_PREFIX
+        val identityLookupPrefix = chain.addressPrefix.toShort()
+        val rows = scoped.map { position ->
+            val identityKey = position.hotkey.toAddress(identityLookupPrefix)
+            val displayAddress = position.hotkey.toAddress(displayPrefix)
+            // Identicon mirrors iOS `PolkadotIconGenerator().generateFromAccountId`
+            // — the colourful blockie next to "Opentensor Foundation".
+            val identicon = runCatching {
+                withContext(Dispatchers.Default) {
+                    addressIconGenerator.createAddressIcon(position.hotkey, ICON_SIZE_DP)
+                }
+            }.getOrNull()
+            ValidatorRow(
+                hotkeyShort = displayAddress.shortHotkey(),
+                identityName = identityByHotkey[identityKey]?.name,
+                amountText = formatSubtensorAmount(position.amount, precision, isRoot),
+                identicon = identicon,
+            )
+        }
+
+        _state.value = UiState.Loaded(
+            totalAmountText = totalText,
+            netuidBadge = if (entryNetuid == SubtensorStakingConstants.ROOT_NETUID) null else "SN$entryNetuid",
+            validatorsTitle = resourceManager.getString(
+                if (rows.size == 1) R.string.subtensor_your_validator else R.string.subtensor_your_validators
+            ),
+            validators = rows,
+            minStakeText = resourceManager.getString(R.string.subtensor_minimum_stake_value),
+            unstakingPeriodText = resourceManager.getString(R.string.subtensor_unstaking_period_instant),
+        )
+    }
+
+    /**
+     * Mirrors iOS `SubtensorPositionViewModel.shorten` — prefix(6) + "…" +
+     * suffix(4). Same character widths as iOS so identical hotkeys render
+     * identically on both platforms.
+     */
+    private fun String.shortHotkey(): String =
+        if (length <= 10) this else "${take(6)}…${takeLast(4)}"
+
+    /**
+     * Formats a substrate balance with 4 decimals max + the right unit
+     * suffix: `TAO` for root (netuid 0), `α` for subnet alpha. Mirrors iOS
+     * `SubtensorPositionViewModel.formatAmount(_:precision:isRoot:)`.
+     */
+    private fun formatSubtensorAmount(amount: BigInteger, precision: Int, isRoot: Boolean): String {
+        val symbol = if (isRoot) "TAO" else "α"
+        if (precision <= 0) return "$amount $symbol"
+        val divisor = BigInteger.TEN.pow(precision)
+        val whole = amount / divisor
+        val fractional = amount % divisor
+        val decimalsToShow = minOf(4, precision)
+        val fracScale = BigInteger.TEN.pow(precision - decimalsToShow)
+        val fracPart = fractional / fracScale
+        val fracStr = fracPart.toString().padStart(decimalsToShow, '0')
+        return "$whole.$fracStr $symbol"
+    }
+
+    sealed interface UiState {
+        object Loading : UiState
+        object Empty : UiState
+        // Error state was removed in favour of one-shot `errorEvents` so a
+        // failed refresh doesn't blow away existing loaded content. Mirrors
+        // iOS `wireframe.showError(from:message:)`.
+        data class Loaded(
+            val totalAmountText: String,
+            val netuidBadge: String?,
+            val validatorsTitle: String,
+            val validators: List<ValidatorRow>,
+            val minStakeText: String,
+            val unstakingPeriodText: String,
+        ) : UiState
+    }
+
+    data class ValidatorRow(
+        val hotkeyShort: String,
+        val identityName: String?,
+        val amountText: String,
+        val identicon: Drawable?,
+    )
+
+    companion object {
+        /** dp size for the validator-row identicon, matches iOS `PolkadotIconView` (28pt). */
+        private const val ICON_SIZE_DP = 28
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/SubtensorStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/SubtensorStakingViewModel.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main
 import android.graphics.drawable.Drawable
 import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
@@ -10,9 +11,12 @@ import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.BittensorDelegatesClient
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_wallet_api.domain.ArbitraryTokenUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletRepository
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.formatPlanks
 import io.novafoundation.nova.runtime.state.chain
 import io.novafoundation.nova.runtime.state.chainAsset
@@ -50,10 +54,32 @@ class SubtensorStakingViewModel(
     private val router: StakingDashboardRouter,
     private val stakingRouter: StakingRouter,
     private val addressIconGenerator: AddressIconGenerator,
+    private val walletRepository: WalletRepository,
+    private val validatorProvider: SubtensorValidatorProvider,
+    private val arbitraryTokenUseCase: ArbitraryTokenUseCase,
+    private val appLinksProvider: AppLinksProvider,
 ) : BaseViewModel() {
 
     private val _state = MutableStateFlow<UiState>(UiState.Loading)
     val state: StateFlow<UiState> = _state.asStateFlow()
+
+    /** Headline percentage for the gold landing — TaoStats-derived peak APR
+     *  among the top 20 validators by total stake. Falls back to the iOS
+     *  default `subtensor_landing_default_max_apy` until the fetch lands or
+     *  if it fails. Mirrors `StartStakingInfoSubtensorPresenter` Phase B. */
+    private val _maxApy = MutableStateFlow(
+        resourceManager.getString(R.string.subtensor_landing_default_max_apy)
+    )
+    val maxApy: StateFlow<String> = _maxApy.asStateFlow()
+
+    /** Available balance label formatted as "0.0373 TAO" (no fiat — keeping
+     *  scope tight so we don't wire a second price-source path). Null until
+     *  the wallet asset resolves. */
+    private val _availableBalance = MutableStateFlow<String?>(null)
+    val availableBalance: StateFlow<String?> = _availableBalance.asStateFlow()
+
+    /** Fired when the user taps the Nova Wiki link in the landing footer. */
+    val openBrowserEvent = androidx.lifecycle.MutableLiveData<Event<String>>()
 
     /**
      * One-shot error events. Fragment observes via LiveData and shows a
@@ -64,15 +90,24 @@ class SubtensorStakingViewModel(
 
     init {
         launch { load(showLoadingIndicator = true) }
+        // Landing data — runs in parallel with the position load. Cheap when
+        // the user already has a stake (results are unused), but if they
+        // land on the Empty state we want the gold screen populated by then.
+        launch { loadLandingData() }
     }
 
     fun backClicked() {
         router.returnToStakingDashboard()
     }
 
-    /** Mirrors iOS `SubtensorStakingPresenter.didTapStakeMore()`. */
+    /** Mirrors iOS `SubtensorStakingPresenter.didTapStakeMore()`. Also used
+     *  by the empty-state "Start staking" CTA on the gold landing. */
     fun stakeMore() {
         stakingRouter.openSubtensorStakeType()
+    }
+
+    fun novaWikiClicked() {
+        openBrowserEvent.value = Event(appLinksProvider.wikiBase)
     }
 
     sealed interface UnstakeAction {
@@ -254,6 +289,45 @@ class SubtensorStakingViewModel(
     }
 
     /**
+     * Populates the gold-landing flows used by the empty state — peak APR
+     * and available balance. Mirrors iOS `StartStakingInfoSubtensorPresenter`:
+     * top-N validators by stake → max APR (replaces hardcoded fallback).
+     * Both fetches are best-effort; the screen renders fine without them.
+     */
+    private suspend fun loadLandingData() {
+        val chainAsset = stakingSharedState.chainAsset()
+        val isRoot = (stakingSharedState.selectedOption.first().additional.subtensorEntryNetuid
+            ?: SubtensorStakingConstants.ROOT_NETUID) == SubtensorStakingConstants.ROOT_NETUID
+        // Available balance — through the wallet repository, same path the
+        // assets screen uses. Asset symbol clash with Fusotao only affects
+        // the *price* lookup, not the balance.
+        val coldkey = accountRepository.getSelectedMetaAccount()
+        runCatching {
+            val asset = withContext(Dispatchers.IO) {
+                walletRepository.assetFlowOrNull(coldkey.id, chainAsset).first()
+            } ?: return@runCatching
+            val transferable = asset.token.configuration.let {
+                asset.transferableInPlanks
+            }
+            _availableBalance.value = formatSubtensorAmount(transferable, chainAsset.precision.value.toInt(), isRoot)
+        }
+        // Peak APR — top 20 by total stake, take max. Only meaningful for
+        // root (subnet APRs vary per netuid and are out of scope for v1).
+        runCatching {
+            val rows = withContext(Dispatchers.IO) {
+                validatorProvider.fetchValidators(SubtensorStakingConstants.ROOT_NETUID)
+            }
+            val topByStake = rows
+                .sortedByDescending { it.totalStake }
+                .take(MAX_APY_SAMPLE_SIZE)
+            val maxApr = topByStake.mapNotNull { it.apr }.maxOrNull()
+            if (maxApr != null && maxApr > 0.0) {
+                _maxApy.value = "%.2f%%".format(maxApr * 100.0)
+            }
+        }
+    }
+
+    /**
      * Mirrors iOS `SubtensorPositionViewModel.shorten` — prefix(6) + "…" +
      * suffix(4). Same character widths as iOS so identical hotkeys render
      * identically on both platforms.
@@ -305,5 +379,12 @@ class SubtensorStakingViewModel(
     companion object {
         /** dp size for the validator-row identicon, matches iOS `PolkadotIconView` (28pt). */
         private const val ICON_SIZE_DP = 28
+
+        /** Top-N validators sampled when computing the headline "Earn up
+         *  to X%" peak APR. Anchors the figure on serious operators —
+         *  micro-stake validators with one recent reward can show APRs in
+         *  the hundreds of percent and skew the headline. Mirrors iOS
+         *  `StartStakingInfoSubtensorPresenter.headlineSampleSize`. */
+        private const val MAX_APY_SAMPLE_SIZE = 20
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/di/SubtensorStakingComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/di/SubtensorStakingComponent.kt
@@ -1,0 +1,23 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main.di
+
+import androidx.fragment.app.Fragment
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.novafoundation.nova.common.di.scope.ScreenScope
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main.SubtensorStakingFragment
+
+@Subcomponent(
+    modules = [
+        SubtensorStakingModule::class,
+    ],
+)
+@ScreenScope
+interface SubtensorStakingComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance fragment: Fragment): SubtensorStakingComponent
+    }
+
+    fun inject(fragment: SubtensorStakingFragment)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/di/SubtensorStakingModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/di/SubtensorStakingModule.kt
@@ -10,13 +10,17 @@ import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.data.network.AppLinksProvider
 import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.BittensorDelegatesClient
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main.SubtensorStakingViewModel
+import io.novafoundation.nova.feature_wallet_api.domain.ArbitraryTokenUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.interfaces.WalletRepository
 
 @Module(includes = [ViewModelModule::class])
 class SubtensorStakingModule {
@@ -33,6 +37,10 @@ class SubtensorStakingModule {
         router: StakingDashboardRouter,
         stakingRouter: StakingRouter,
         addressIconGenerator: AddressIconGenerator,
+        walletRepository: WalletRepository,
+        validatorProvider: SubtensorValidatorProvider,
+        arbitraryTokenUseCase: ArbitraryTokenUseCase,
+        appLinksProvider: AppLinksProvider,
     ): ViewModel = SubtensorStakingViewModel(
         stakingSharedState = stakingSharedState,
         accountRepository = accountRepository,
@@ -42,6 +50,10 @@ class SubtensorStakingModule {
         router = router,
         stakingRouter = stakingRouter,
         addressIconGenerator = addressIconGenerator,
+        walletRepository = walletRepository,
+        validatorProvider = validatorProvider,
+        arbitraryTokenUseCase = arbitraryTokenUseCase,
+        appLinksProvider = appLinksProvider,
     )
 
     @Provides

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/di/SubtensorStakingModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/main/di/SubtensorStakingModule.kt
@@ -1,0 +1,52 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main.di
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
+import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.BittensorDelegatesClient
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.main.SubtensorStakingViewModel
+
+@Module(includes = [ViewModelModule::class])
+class SubtensorStakingModule {
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SubtensorStakingViewModel::class)
+    fun provideViewModel(
+        stakingSharedState: StakingSharedState,
+        accountRepository: AccountRepository,
+        positionCache: SubtensorPositionCache,
+        delegatesClient: BittensorDelegatesClient,
+        resourceManager: ResourceManager,
+        router: StakingDashboardRouter,
+        stakingRouter: StakingRouter,
+        addressIconGenerator: AddressIconGenerator,
+    ): ViewModel = SubtensorStakingViewModel(
+        stakingSharedState = stakingSharedState,
+        accountRepository = accountRepository,
+        positionCache = positionCache,
+        delegatesClient = delegatesClient,
+        resourceManager = resourceManager,
+        router = router,
+        stakingRouter = stakingRouter,
+        addressIconGenerator = addressIconGenerator,
+    )
+
+    @Provides
+    fun provideViewModelInstance(
+        fragment: Fragment,
+        viewModelFactory: ViewModelProvider.Factory,
+    ): SubtensorStakingViewModel = ViewModelProvider(fragment, viewModelFactory).get(SubtensorStakingViewModel::class.java)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmFragment.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake
 import android.os.Bundle
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.setVisible
 import io.novafoundation.nova.common.view.setProgressState
 import io.novafoundation.nova.feature_account_api.presenatation.actions.setupExternalActions
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
@@ -27,6 +28,16 @@ class SubtensorStakeConfirmFragment : BaseFragment<SubtensorStakeConfirmViewMode
         binder.subtensorStakeConfirmValidator.setOnClickListener { viewModel.validatorClicked() }
         binder.subtensorStakeConfirmConfirm.prepareForProgress(viewLifecycleOwner)
         binder.subtensorStakeConfirmConfirm.setOnClickListener { viewModel.confirmClicked() }
+
+        // Nova-fee disclosure — visible only when the fee applies (subnet +
+        // recipient set). Inert today (recipient null → hidden). The caption is
+        // static; the fee row's value is observed in subscribe().
+        binder.subtensorStakeConfirmNovaFee.setVisible(viewModel.novaFeeApplies)
+        binder.subtensorStakeConfirmNovaFeeDisclaimer.setVisible(viewModel.novaFeeApplies)
+        binder.subtensorStakeConfirmNovaFeeDisclaimer.text = getString(
+            io.novafoundation.nova.feature_staking_impl.R.string.subtensor_setup_nova_fee_disclaimer,
+            io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants.NOVA_FEE_PERCENT_DISPLAY,
+        )
     }
 
     override fun inject() {
@@ -48,6 +59,7 @@ class SubtensorStakeConfirmFragment : BaseFragment<SubtensorStakeConfirmViewMode
         viewModel.walletUiFlow.observe(binder.subtensorStakeConfirmExtrinsicInformation::setWallet)
         viewModel.originAddressModelFlow.observe(binder.subtensorStakeConfirmExtrinsicInformation::setAccount)
         viewModel.feeStatusFlow.observe(binder.subtensorStakeConfirmExtrinsicInformation::setFeeStatus)
+        viewModel.novaFeeStatusFlow.observe(binder.subtensorStakeConfirmNovaFee::setFeeStatus)
         viewModel.validatorLabel.observe { binder.subtensorStakeConfirmValidator.showValue(it) }
         viewModel.submitting.observe { binder.subtensorStakeConfirmConfirm.setProgressState(it) }
         viewModel.toastEvents.observeEvent { msg ->

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmFragment.kt
@@ -1,0 +1,57 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm
+
+import android.os.Bundle
+import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.view.setProgressState
+import io.novafoundation.nova.feature_account_api.presenatation.actions.setupExternalActions
+import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
+import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorStakeConfirmBinding
+import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+
+class SubtensorStakeConfirmFragment : BaseFragment<SubtensorStakeConfirmViewModel, FragmentSubtensorStakeConfirmBinding>() {
+
+    companion object {
+        private const val PAYLOAD_KEY = "subtensor_stake_confirm_payload"
+
+        fun bundle(payload: SubtensorStakeConfirmPayload): Bundle = Bundle().apply {
+            putParcelable(PAYLOAD_KEY, payload)
+        }
+    }
+
+    override fun createBinding() = FragmentSubtensorStakeConfirmBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+        binder.subtensorStakeConfirmToolbar.setHomeButtonListener { viewModel.backClicked() }
+        binder.subtensorStakeConfirmExtrinsicInformation.setOnAccountClickedListener { viewModel.originAccountClicked() }
+        binder.subtensorStakeConfirmValidator.setOnClickListener { viewModel.validatorClicked() }
+        binder.subtensorStakeConfirmConfirm.prepareForProgress(viewLifecycleOwner)
+        binder.subtensorStakeConfirmConfirm.setOnClickListener { viewModel.confirmClicked() }
+    }
+
+    override fun inject() {
+        val payload = argument<SubtensorStakeConfirmPayload>(PAYLOAD_KEY)
+        FeatureUtils.getFeature<StakingFeatureComponent>(
+            requireContext(),
+            StakingFeatureApi::class.java,
+        )
+            .subtensorStakeConfirmFactory()
+            .create(this, payload)
+            .inject(this)
+    }
+
+    override fun subscribe(viewModel: SubtensorStakeConfirmViewModel) {
+        setupExternalActions(viewModel)
+
+        viewModel.titleText.observe { binder.subtensorStakeConfirmToolbar.setTitle(it) }
+        viewModel.amountModelFlow.observe(binder.subtensorStakeConfirmAmount::setAmount)
+        viewModel.walletUiFlow.observe(binder.subtensorStakeConfirmExtrinsicInformation::setWallet)
+        viewModel.originAddressModelFlow.observe(binder.subtensorStakeConfirmExtrinsicInformation::setAccount)
+        viewModel.feeStatusFlow.observe(binder.subtensorStakeConfirmExtrinsicInformation::setFeeStatus)
+        viewModel.validatorLabel.observe { binder.subtensorStakeConfirmValidator.showValue(it) }
+        viewModel.submitting.observe { binder.subtensorStakeConfirmConfirm.setProgressState(it) }
+        viewModel.toastEvents.observeEvent { msg ->
+            android.widget.Toast.makeText(requireContext(), msg, android.widget.Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmPayload.kt
@@ -1,0 +1,24 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm
+
+import android.os.Parcelable
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
+import kotlinx.parcelize.Parcelize
+import java.math.BigInteger
+
+/**
+ * Payload threaded from the Subtensor stake setup screen into Confirm.
+ * Mirrors iOS `SubtensorStakeConfirmViewFactory.createView` argument set
+ * (chainAsset, validator, amount). Fee is snapshotted on Setup so what
+ * the user agreed to is what they sign — Nova's other Confirm flows use
+ * the same idiom (see ConfirmBondMorePayload).
+ */
+@Parcelize
+data class SubtensorStakeConfirmPayload(
+    val netuid: Int,
+    val hotkeyAddress: String,
+    /** Validator identity name from delegates registry; null when unknown. */
+    val validatorIdentity: String?,
+    val amountInPlanks: BigInteger,
+    val fee: FeeParcelModel,
+    val subnetName: String?,
+) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmViewModel.kt
@@ -1,0 +1,166 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm
+
+import androidx.lifecycle.viewModelScope
+import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.utils.Event
+import io.novafoundation.nova.common.utils.flowOf
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
+import io.novafoundation.nova.feature_account_api.presenatation.account.icon.createAccountAddressModel
+import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.WalletUiUseCase
+import io.novafoundation.nova.feature_account_api.presenatation.actions.ExternalActions
+import io.novafoundation.nova.feature_account_api.presenatation.actions.showAddressActions
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
+import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.formatAmountToAmountModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeStatus
+import io.novafoundation.nova.runtime.state.chain
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+class SubtensorStakeConfirmViewModel(
+    private val router: StakingRouter,
+    private val dashboardRouter: StakingDashboardRouter,
+    private val resourceManager: ResourceManager,
+    private val stakingSharedState: StakingSharedState,
+    private val accountRepository: AccountRepository,
+    private val submitInteractor: SubtensorStakeSubmitInteractor,
+    private val assetUseCase: AssetUseCase,
+    private val addressIconGenerator: AddressIconGenerator,
+    private val walletUiUseCase: WalletUiUseCase,
+    private val amountFormatter: AmountFormatter,
+    private val externalActions: ExternalActions.Presentation,
+    private val payload: SubtensorStakeConfirmPayload,
+) : BaseViewModel(),
+    ExternalActions by externalActions {
+
+    val isRoot: Boolean = payload.netuid == SubtensorStakingConstants.ROOT_NETUID
+
+    val titleText: StateFlow<String> = MutableStateFlow(resolveTitle()).asStateFlow()
+
+    private val _submitting = MutableStateFlow(false)
+    val submitting: StateFlow<Boolean> = _submitting.asStateFlow()
+
+    val toastEvents = androidx.lifecycle.MutableLiveData<Event<String>>()
+
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
+    private val assetFlow = assetUseCase.currentAssetFlow().shareInBackground()
+
+    /** Big-amount header at the top (token + fiat). */
+    val amountModelFlow = assetFlow.map { asset ->
+        val tao = asset.token.amountFromPlanks(payload.amountInPlanks)
+        amountFormatter.formatAmountToAmountModel(tao, asset)
+    }.shareInBackground()
+
+    val walletUiFlow = walletUiUseCase.selectedWalletUiFlow().shareInBackground()
+
+    val originAddressModelFlow = flowOf {
+        val chain = stakingSharedState.chain()
+        val coldkey = accountRepository.getSelectedMetaAccount().requireAccountIdIn(chain)
+        addressIconGenerator.createAccountAddressModel(chain, coldkey.toAddress(chain.addressPrefix.toShort()))
+    }.shareInBackground()
+
+    val feeStatusFlow = assetFlow.map { asset ->
+        val feeModel = mapFeeToFeeModel(
+            fee = decimalFee,
+            token = asset.token,
+            amountFormatter = amountFormatter,
+        )
+        FeeStatus.Loaded(feeModel)
+    }.shareInBackground()
+
+    /** Validator row label. Identity threading is part of the Validator Picker iOS-parity work. */
+    val validatorLabel: StateFlow<String> = MutableStateFlow(formatValidator()).asStateFlow()
+
+    fun confirmClicked() {
+        if (_submitting.value) return
+        sendTransaction()
+    }
+
+    fun backClicked() {
+        if (_submitting.value) return
+        router.back()
+    }
+
+    fun originAccountClicked() = launch {
+        val chain = stakingSharedState.chain()
+        val coldkey = accountRepository.getSelectedMetaAccount().requireAccountIdIn(chain)
+        externalActions.showAddressActions(coldkey.toAddress(chain.addressPrefix.toShort()), chain)
+    }
+
+    fun validatorClicked() = launch {
+        val chain = stakingSharedState.chain()
+        externalActions.showAddressActions(payload.hotkeyAddress, chain)
+    }
+
+    private fun sendTransaction() {
+        _submitting.value = true
+        viewModelScope.launch {
+            val hotkeyBytes = runCatching { payload.hotkeyAddress.toAccountId() }.getOrNull()
+            if (hotkeyBytes == null) {
+                _submitting.value = false
+                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_setup_invalid_validator))
+                return@launch
+            }
+
+            val result = submitInteractor.submitStake(
+                netuid = payload.netuid,
+                hotkey = hotkeyBytes,
+                amountInPlanks = payload.amountInPlanks,
+            )
+            _submitting.value = false
+            result.fold(
+                onSuccess = {
+                    // Match the canonical Nova pattern (nomination-pools /
+                    // parachain confirm flows): plain "Transaction submitted"
+                    // toast on success, then navigate back to the dashboard.
+                    showToast(resourceManager.getString(R.string.common_transaction_submitted))
+                    dashboardRouter.returnToStakingDashboard()
+                },
+                onFailure = { error ->
+                    val message = error.localizedMessage
+                        ?: resourceManager.getString(R.string.subtensor_setup_submit_failed)
+                    toastEvents.value = Event(message)
+                },
+            )
+        }
+    }
+
+    private fun resolveTitle(): String = when {
+        isRoot -> resourceManager.getString(R.string.common_confirm_title)
+        !payload.subnetName.isNullOrBlank() -> resourceManager.getString(
+            R.string.subtensor_confirm_subnet_title,
+            payload.subnetName,
+        )
+        else -> resourceManager.getString(
+            R.string.subtensor_confirm_subnet_title,
+            "SN${payload.netuid}",
+        )
+    }
+
+    private fun formatValidator(): String {
+        val short = if (payload.hotkeyAddress.length <= 10) payload.hotkeyAddress
+        else "${payload.hotkeyAddress.take(6)}...${payload.hotkeyAddress.takeLast(4)}"
+        // iOS Confirm shows "Identity (5GgYg...XEm9zT)" when an identity is
+        // known, falls back to the bare short hotkey otherwise.
+        val identity = payload.validatorIdentity?.takeIf { it.isNotBlank() }
+        return if (identity != null) "$identity ($short)" else short
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/SubtensorStakeConfirmViewModel.kt
@@ -18,6 +18,7 @@ import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorSta
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.common.SubtensorNovaFee
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
@@ -84,6 +85,25 @@ class SubtensorStakeConfirmViewModel(
             amountFormatter = amountFormatter,
         )
         FeeStatus.Loaded(feeModel)
+    }.shareInBackground()
+
+    /** True only when the Nova fee applies (subnet + recipient set). Drives the
+     *  fee row + caption visibility. Inert (false) today since the recipient is null. */
+    val novaFeeApplies: Boolean = SubtensorNovaFee.feeApplies(payload.netuid)
+
+    /**
+     * Nova service-fee row — 0.3% of the confirmed stake amount, in TAO. Sits
+     * beneath the network-fee row in [GenericExtrinsicInformationView]. Emits
+     * [FeeStatus.NoFee] (hidden) when the fee doesn't apply. Isolated from the
+     * network-fee flow.
+     */
+    val novaFeeStatusFlow = assetFlow.map { asset ->
+        SubtensorNovaFee.nativeFeeStatus(
+            netuid = payload.netuid,
+            grossPlanks = payload.amountInPlanks,
+            token = asset.token,
+            amountFormatter = amountFormatter,
+        )
     }.shareInBackground()
 
     /** Validator row label. Identity threading is part of the Validator Picker iOS-parity work. */

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/di/SubtensorStakeConfirmComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/di/SubtensorStakeConfirmComponent.kt
@@ -1,0 +1,27 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.di
+
+import androidx.fragment.app.Fragment
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.novafoundation.nova.common.di.scope.ScreenScope
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmFragment
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmPayload
+
+@Subcomponent(
+    modules = [
+        SubtensorStakeConfirmModule::class,
+    ],
+)
+@ScreenScope
+interface SubtensorStakeConfirmComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance fragment: Fragment,
+            @BindsInstance payload: SubtensorStakeConfirmPayload,
+        ): SubtensorStakeConfirmComponent
+    }
+
+    fun inject(fragment: SubtensorStakeConfirmFragment)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/di/SubtensorStakeConfirmModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/confirm/di/SubtensorStakeConfirmModule.kt
@@ -1,0 +1,83 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.di
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
+import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.WalletUiUseCase
+import io.novafoundation.nova.feature_account_api.presenatation.actions.ExternalActions
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmPayload
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmViewModel
+import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
+
+@Module(includes = [ViewModelModule::class])
+class SubtensorStakeConfirmModule {
+
+    @Provides
+    fun provideSubtensorStakeSubmitInteractor(
+        extrinsicService: ExtrinsicService,
+        stakingSharedState: StakingSharedState,
+        accountRepository: AccountRepository,
+        subnetFetcher: SubtensorSubnetFetcher,
+        positionCache: SubtensorPositionCache,
+    ): SubtensorStakeSubmitInteractor = SubtensorStakeSubmitInteractor(
+        extrinsicService = extrinsicService,
+        stakingSharedState = stakingSharedState,
+        accountRepository = accountRepository,
+        subnetFetcher = subnetFetcher,
+        positionCache = positionCache,
+    )
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SubtensorStakeConfirmViewModel::class)
+    fun provideViewModel(
+        router: StakingRouter,
+        dashboardRouter: StakingDashboardRouter,
+        resourceManager: ResourceManager,
+        stakingSharedState: StakingSharedState,
+        accountRepository: AccountRepository,
+        submitInteractor: SubtensorStakeSubmitInteractor,
+        assetUseCase: AssetUseCase,
+        addressIconGenerator: AddressIconGenerator,
+        walletUiUseCase: WalletUiUseCase,
+        amountFormatter: AmountFormatter,
+        externalActions: ExternalActions.Presentation,
+        payload: SubtensorStakeConfirmPayload,
+    ): ViewModel = SubtensorStakeConfirmViewModel(
+        router = router,
+        dashboardRouter = dashboardRouter,
+        resourceManager = resourceManager,
+        stakingSharedState = stakingSharedState,
+        accountRepository = accountRepository,
+        submitInteractor = submitInteractor,
+        assetUseCase = assetUseCase,
+        addressIconGenerator = addressIconGenerator,
+        walletUiUseCase = walletUiUseCase,
+        amountFormatter = amountFormatter,
+        externalActions = externalActions,
+        payload = payload,
+    )
+
+    @Provides
+    fun provideViewModelInstance(
+        fragment: Fragment,
+        viewModelFactory: ViewModelProvider.Factory,
+    ): SubtensorStakeConfirmViewModel =
+        ViewModelProvider(fragment, viewModelFactory).get(SubtensorStakeConfirmViewModel::class.java)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupFragment.kt
@@ -1,0 +1,68 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup
+
+import android.os.Bundle
+import androidx.core.widget.doAfterTextChanged
+import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.view.setProgressState
+import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
+import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorStakeSetupBinding
+import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+
+class SubtensorStakeSetupFragment : BaseFragment<SubtensorStakeSetupViewModel, FragmentSubtensorStakeSetupBinding>() {
+
+    companion object {
+        private const val ARG_NETUID = "netuid"
+        private const val ARG_SUBNET_NAME = "subnetName"
+
+        /**
+         * Saved-state-handle key the validator picker uses to report its
+         * selection back to this screen. Picker writes the SS58 hotkey;
+         * the ViewModel observes via [StakingRouter.subtensorSelectedValidatorFlow].
+         */
+        const val KEY_SELECTED_VALIDATOR_HOTKEY = "subtensor_setup_selected_hotkey"
+
+        fun bundle(netuid: Int, subnetName: String? = null): Bundle = Bundle().apply {
+            putInt(ARG_NETUID, netuid)
+            if (subnetName != null) putString(ARG_SUBNET_NAME, subnetName)
+        }
+    }
+
+    override fun createBinding() = FragmentSubtensorStakeSetupBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+        binder.subtensorStakeSetupToolbar.setHomeButtonListener { viewModel.backClicked() }
+        binder.subtensorStakeSetupValidator.setOnClickListener { viewModel.selectValidatorClicked() }
+        binder.subtensorStakeSetupAmount.doAfterTextChanged { viewModel.amountChanged(it?.toString().orEmpty()) }
+        binder.subtensorStakeSetupContinue.prepareForProgress(viewLifecycleOwner)
+        binder.subtensorStakeSetupContinue.setOnClickListener { viewModel.continueClicked() }
+    }
+
+    override fun inject() {
+        val netuid = arguments?.getInt(ARG_NETUID) ?: 0
+        val subnetName = arguments?.getString(ARG_SUBNET_NAME)
+        FeatureUtils.getFeature<StakingFeatureComponent>(
+            requireContext(),
+            StakingFeatureApi::class.java,
+        )
+            .subtensorStakeSetupFactory()
+            .create(this, netuid, subnetName)
+            .inject(this)
+    }
+
+    override fun subscribe(viewModel: SubtensorStakeSetupViewModel) {
+        viewModel.canContinue.observe { enabled ->
+            binder.subtensorStakeSetupContinue.isEnabled = enabled
+        }
+        viewModel.titleText.observe { binder.subtensorStakeSetupToolbar.setTitle(it) }
+        viewModel.selectedValidatorLabel.observe { label ->
+            binder.subtensorStakeSetupValidatorLabel.text = label
+        }
+        viewModel.submitting.observe { submitting ->
+            binder.subtensorStakeSetupContinue.setProgressState(submitting)
+        }
+        viewModel.toastEvents.observeEvent { message ->
+            android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupFragment.kt
@@ -1,13 +1,14 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup
 
 import android.os.Bundle
-import androidx.core.widget.doAfterTextChanged
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.view.setProgressState
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
 import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorStakeSetupBinding
 import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.setupAmountChooser
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.setupFeeLoading
 
 class SubtensorStakeSetupFragment : BaseFragment<SubtensorStakeSetupViewModel, FragmentSubtensorStakeSetupBinding>() {
 
@@ -17,10 +18,11 @@ class SubtensorStakeSetupFragment : BaseFragment<SubtensorStakeSetupViewModel, F
 
         /**
          * Saved-state-handle key the validator picker uses to report its
-         * selection back to this screen. Picker writes the SS58 hotkey;
-         * the ViewModel observes via [StakingRouter.subtensorSelectedValidatorFlow].
+         * selection back to this screen. Picker writes a
+         * [SubtensorPickedValidator] (hotkey + identity); the ViewModel
+         * observes via [StakingRouter.subtensorSelectedValidatorFlow].
          */
-        const val KEY_SELECTED_VALIDATOR_HOTKEY = "subtensor_setup_selected_hotkey"
+        const val KEY_SELECTED_VALIDATOR = "subtensor_setup_selected_validator"
 
         fun bundle(netuid: Int, subnetName: String? = null): Bundle = Bundle().apply {
             putInt(ARG_NETUID, netuid)
@@ -33,9 +35,12 @@ class SubtensorStakeSetupFragment : BaseFragment<SubtensorStakeSetupViewModel, F
     override fun initViews() {
         binder.subtensorStakeSetupToolbar.setHomeButtonListener { viewModel.backClicked() }
         binder.subtensorStakeSetupValidator.setOnClickListener { viewModel.selectValidatorClicked() }
-        binder.subtensorStakeSetupAmount.doAfterTextChanged { viewModel.amountChanged(it?.toString().orEmpty()) }
         binder.subtensorStakeSetupContinue.prepareForProgress(viewLifecycleOwner)
         binder.subtensorStakeSetupContinue.setOnClickListener { viewModel.continueClicked() }
+
+        // Min stake row is static — set once and forget. Mirrors iOS
+        // `TitleAmountView.dark()` rendered with `MIN_NOMINATOR_STAKE_RAO`.
+        binder.subtensorStakeSetupMinStake.showValue("0.01 TAO")
     }
 
     override fun inject() {
@@ -51,18 +56,18 @@ class SubtensorStakeSetupFragment : BaseFragment<SubtensorStakeSetupViewModel, F
     }
 
     override fun subscribe(viewModel: SubtensorStakeSetupViewModel) {
-        viewModel.canContinue.observe { enabled ->
-            binder.subtensorStakeSetupContinue.isEnabled = enabled
-        }
+        // Canonical Nova staking-flow wiring — same setup helpers used by
+        // bond_more, parachain start, nomination-pools setup, etc. so the
+        // amount/fee rows look + behave identically across all flows.
+        setupAmountChooser(viewModel.amountChooserMixin, binder.subtensorStakeSetupAmount)
+        setupFeeLoading(viewModel.originFeeMixin, binder.subtensorStakeSetupFee)
+
         viewModel.titleText.observe { binder.subtensorStakeSetupToolbar.setTitle(it) }
-        viewModel.selectedValidatorLabel.observe { label ->
-            binder.subtensorStakeSetupValidatorLabel.text = label
-        }
-        viewModel.submitting.observe { submitting ->
-            binder.subtensorStakeSetupContinue.setProgressState(submitting)
-        }
-        viewModel.toastEvents.observeEvent { message ->
-            android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
+        viewModel.validatorTargetModel.observe { binder.subtensorStakeSetupValidator.setModel(it) }
+        viewModel.canContinue.observe { binder.subtensorStakeSetupContinue.isEnabled = it }
+        viewModel.submitting.observe { binder.subtensorStakeSetupContinue.setProgressState(it) }
+        viewModel.toastEvents.observeEvent { msg ->
+            android.widget.Toast.makeText(requireContext(), msg, android.widget.Toast.LENGTH_LONG).show()
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupFragment.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake
 import android.os.Bundle
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.setVisible
 import io.novafoundation.nova.common.view.setProgressState
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
 import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorStakeSetupBinding
@@ -41,6 +42,16 @@ class SubtensorStakeSetupFragment : BaseFragment<SubtensorStakeSetupViewModel, F
         // Min stake row is static — set once and forget. Mirrors iOS
         // `TitleAmountView.dark()` rendered with `MIN_NOMINATOR_STAKE_RAO`.
         binder.subtensorStakeSetupMinStake.showValue("0.01 TAO")
+
+        // Nova-fee disclosure — visible only when the fee applies (subnet +
+        // recipient set). Inert today (recipient null → hidden). The caption is
+        // static; the fee row's value is observed in subscribe().
+        binder.subtensorStakeSetupNovaFee.setVisible(viewModel.novaFeeApplies)
+        binder.subtensorStakeSetupNovaFeeDisclaimer.setVisible(viewModel.novaFeeApplies)
+        binder.subtensorStakeSetupNovaFeeDisclaimer.text = getString(
+            io.novafoundation.nova.feature_staking_impl.R.string.subtensor_setup_nova_fee_disclaimer,
+            io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants.NOVA_FEE_PERCENT_DISPLAY,
+        )
     }
 
     override fun inject() {
@@ -61,6 +72,10 @@ class SubtensorStakeSetupFragment : BaseFragment<SubtensorStakeSetupViewModel, F
         // amount/fee rows look + behave identically across all flows.
         setupAmountChooser(viewModel.amountChooserMixin, binder.subtensorStakeSetupAmount)
         setupFeeLoading(viewModel.originFeeMixin, binder.subtensorStakeSetupFee)
+
+        // Nova-fee row — observed independently of the network-fee mixin. Reuses
+        // the standard FeeView.setFeeStatus binding; NoFee hides the row.
+        viewModel.novaFeeStatusFlow.observe(binder.subtensorStakeSetupNovaFee::setFeeStatus)
 
         viewModel.titleText.observe { binder.subtensorStakeSetupToolbar.setTitle(it) }
         viewModel.validatorTargetModel.observe { binder.subtensorStakeSetupValidator.setModel(it) }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupViewModel.kt
@@ -1,0 +1,147 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup
+
+import androidx.lifecycle.viewModelScope
+import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.utils.Event
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.runtime.state.chainAsset
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+
+class SubtensorStakeSetupViewModel(
+    private val router: StakingRouter,
+    private val dashboardRouter: StakingDashboardRouter,
+    private val resourceManager: ResourceManager,
+    private val stakingSharedState: StakingSharedState,
+    private val submitInteractor: SubtensorStakeSubmitInteractor,
+    val netuid: Int,
+    private val subnetName: String?,
+) : BaseViewModel() {
+
+    val isRoot: Boolean = netuid == SubtensorStakingConstants.ROOT_NETUID
+
+    val titleText: StateFlow<String> = MutableStateFlow(resolveTitle()).asStateFlow()
+
+    private val _selectedValidatorHotkey = MutableStateFlow<String?>(null)
+    val selectedValidatorHotkey: StateFlow<String?> = _selectedValidatorHotkey.asStateFlow()
+
+    val selectedValidatorLabel: StateFlow<String> = _selectedValidatorHotkey
+        .map(::formatValidatorLabel)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, formatValidatorLabel(null))
+
+    private val _amount = MutableStateFlow("")
+    val amount: StateFlow<String> = _amount.asStateFlow()
+
+    private val _submitting = MutableStateFlow(false)
+    val submitting: StateFlow<Boolean> = _submitting.asStateFlow()
+
+    val toastEvents = androidx.lifecycle.MutableLiveData<Event<String>>()
+
+    val canContinue: StateFlow<Boolean> = combine(
+        _selectedValidatorHotkey,
+        _amount,
+        _submitting,
+    ) { hotkey, amt, submitting ->
+        !submitting && hotkey != null && amt.isNotBlank() && (amt.toDoubleOrNull() ?: 0.0) > 0.0
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    init {
+        // Validator picker reports its selection by stuffing the chosen
+        // hotkey into our nav back-stack entry's saved state. The router
+        // exposes that as a flow — same pattern as the crowdloan-bonus
+        // round-trip.
+        router.subtensorSelectedValidatorFlow
+            .filterNotNull()
+            .onEach { hotkey -> _selectedValidatorHotkey.value = hotkey }
+            .launchIn(viewModelScope)
+    }
+
+    fun amountChanged(text: String) {
+        _amount.value = text
+    }
+
+    fun selectValidatorClicked() {
+        router.openSubtensorValidatorPicker(netuid)
+    }
+
+    fun continueClicked() {
+        if (_submitting.value) return
+        val hotkeyAddress = _selectedValidatorHotkey.value ?: return
+        val amountTao = _amount.value.toBigDecimalOrNull() ?: return
+        if (amountTao <= BigDecimal.ZERO) return
+
+        submitStake(hotkeyAddress, amountTao)
+    }
+
+    fun backClicked() {
+        if (_submitting.value) return
+        router.back()
+    }
+
+    private fun submitStake(hotkeyAddress: String, amountTao: BigDecimal) {
+        _submitting.value = true
+        viewModelScope.launch {
+            val precision = runCatching { stakingSharedState.chainAsset().precision.value.toInt() }.getOrDefault(9)
+            val planks = amountTao
+                .multiply(BigDecimal.TEN.pow(precision))
+                .toBigInteger()
+
+            val hotkeyBytes = runCatching { hotkeyAddress.toAccountId() }.getOrNull()
+            if (hotkeyBytes == null) {
+                _submitting.value = false
+                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_setup_invalid_validator))
+                return@launch
+            }
+
+            val result = submitInteractor.submitStake(
+                netuid = netuid,
+                hotkey = hotkeyBytes,
+                amountInPlanks = planks,
+            )
+            _submitting.value = false
+            result.fold(
+                onSuccess = {
+                    // Pop straight back to the multistaking dashboard. The
+                    // dashboard's next sync (cache was just invalidated)
+                    // surfaces the new position automatically.
+                    dashboardRouter.returnToStakingDashboard()
+                },
+                onFailure = { error ->
+                    val message = error.localizedMessage
+                        ?: resourceManager.getString(R.string.subtensor_setup_submit_failed)
+                    toastEvents.value = Event(message)
+                },
+            )
+        }
+    }
+
+    private fun resolveTitle(): String = when {
+        isRoot -> resourceManager.getString(R.string.subtensor_stake_more)
+        !subnetName.isNullOrBlank() -> subnetName
+        else -> "Subnet $netuid"
+    }
+
+    private fun formatValidatorLabel(hotkey: String?): String {
+        if (hotkey.isNullOrBlank()) {
+            return resourceManager.getString(R.string.subtensor_setup_select_validator)
+        }
+        return if (hotkey.length <= 10) hotkey else "${hotkey.take(6)}…${hotkey.takeLast(4)}"
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupViewModel.kt
@@ -2,15 +2,31 @@ package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake
 
 import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.presentation.ColoredText
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
+import io.novafoundation.nova.common.utils.shareInBackground
+import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.TransactionOrigin
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
-import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.extrinsic.addStakeLimit
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
-import io.novafoundation.nova.runtime.state.chainAsset
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmPayload
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorPickedValidator
+import io.novafoundation.nova.feature_staking_impl.presentation.view.stakingTarget.StakingTargetModel
+import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.model.withAmount
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.awaitOptionalFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.connectWith
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.createDefault
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.maxAction.MaxActionProviderFactory
+import io.novafoundation.nova.runtime.state.chain
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -18,19 +34,25 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
+import java.math.BigInteger
 
 class SubtensorStakeSetupViewModel(
     private val router: StakingRouter,
     private val dashboardRouter: StakingDashboardRouter,
     private val resourceManager: ResourceManager,
     private val stakingSharedState: StakingSharedState,
-    private val submitInteractor: SubtensorStakeSubmitInteractor,
+    private val extrinsicService: ExtrinsicService,
+    private val assetUseCase: AssetUseCase,
+    feeLoaderMixinFactory: FeeLoaderMixinV2.Factory,
+    maxActionProviderFactory: MaxActionProviderFactory,
+    amountChooserMixinFactory: AmountChooserMixin.Factory,
     val netuid: Int,
     private val subnetName: String?,
 ) : BaseViewModel() {
@@ -39,42 +61,56 @@ class SubtensorStakeSetupViewModel(
 
     val titleText: StateFlow<String> = MutableStateFlow(resolveTitle()).asStateFlow()
 
-    private val _selectedValidatorHotkey = MutableStateFlow<String?>(null)
-    val selectedValidatorHotkey: StateFlow<String?> = _selectedValidatorHotkey.asStateFlow()
+    private val _selectedValidator = MutableStateFlow<SubtensorPickedValidator?>(null)
+    val selectedValidator: StateFlow<SubtensorPickedValidator?> = _selectedValidator.asStateFlow()
 
-    val selectedValidatorLabel: StateFlow<String> = _selectedValidatorHotkey
-        .map(::formatValidatorLabel)
-        .stateIn(viewModelScope, SharingStarted.Eagerly, formatValidatorLabel(null))
-
-    private val _amount = MutableStateFlow("")
-    val amount: StateFlow<String> = _amount.asStateFlow()
+    val validatorTargetModel: StateFlow<StakingTargetModel> = _selectedValidator
+        .map(::buildTargetModel)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, buildTargetModel(null))
 
     private val _submitting = MutableStateFlow(false)
     val submitting: StateFlow<Boolean> = _submitting.asStateFlow()
 
     val toastEvents = androidx.lifecycle.MutableLiveData<Event<String>>()
 
+    private val assetFlow = assetUseCase.currentAssetFlow().shareInBackground()
+
+    private val selectedChainAsset = assetFlow
+        .map { it.token.configuration }
+        .shareInBackground()
+
+    private val stakeableBalance = assetFlow
+        .map { it.token.configuration.withAmount(it.transferableInPlanks) }
+        .shareInBackground()
+
+    /** Fee row mixin — wired to amount + hotkey via [connectWith] in init. */
+    val originFeeMixin = feeLoaderMixinFactory.createDefault(this, selectedChainAsset)
+
+    private val maxActionProvider = maxActionProviderFactory.createCustom(viewModelScope) {
+        stakeableBalance.asMaxAmountProvider().deductFee(originFeeMixin)
+    }
+
+    val amountChooserMixin: AmountChooserMixin.Presentation = amountChooserMixinFactory.create(
+        scope = this,
+        assetFlow = assetFlow,
+        maxActionProvider = maxActionProvider,
+    )
+
     val canContinue: StateFlow<Boolean> = combine(
-        _selectedValidatorHotkey,
-        _amount,
+        _selectedValidator,
+        amountChooserMixin.amount,
         _submitting,
-    ) { hotkey, amt, submitting ->
-        !submitting && hotkey != null && amt.isNotBlank() && (amt.toDoubleOrNull() ?: 0.0) > 0.0
+    ) { picked, amount, submitting ->
+        !submitting && picked != null && amount > BigDecimal.ZERO
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     init {
-        // Validator picker reports its selection by stuffing the chosen
-        // hotkey into our nav back-stack entry's saved state. The router
-        // exposes that as a flow — same pattern as the crowdloan-bonus
-        // round-trip.
         router.subtensorSelectedValidatorFlow
             .filterNotNull()
-            .onEach { hotkey -> _selectedValidatorHotkey.value = hotkey }
+            .onEach { picked -> _selectedValidator.value = picked }
             .launchIn(viewModelScope)
-    }
 
-    fun amountChanged(text: String) {
-        _amount.value = text
+        listenFee()
     }
 
     fun selectValidatorClicked() {
@@ -83,11 +119,12 @@ class SubtensorStakeSetupViewModel(
 
     fun continueClicked() {
         if (_submitting.value) return
-        val hotkeyAddress = _selectedValidatorHotkey.value ?: return
-        val amountTao = _amount.value.toBigDecimalOrNull() ?: return
-        if (amountTao <= BigDecimal.ZERO) return
-
-        submitStake(hotkeyAddress, amountTao)
+        viewModelScope.launch {
+            val picked = _selectedValidator.value ?: return@launch
+            val amountTao = amountChooserMixin.amount.first()
+            if (amountTao <= BigDecimal.ZERO) return@launch
+            openConfirm(picked, amountTao)
+        }
     }
 
     fun backClicked() {
@@ -95,39 +132,64 @@ class SubtensorStakeSetupViewModel(
         router.back()
     }
 
-    private fun submitStake(hotkeyAddress: String, amountTao: BigDecimal) {
+    private fun listenFee() {
+        originFeeMixin.connectWith(
+            inputSource1 = amountChooserMixin.backPressuredPlanks,
+            inputSource2 = _selectedValidator,
+        ) { _, amountPlanks, picked ->
+            val realAmount = amountPlanks.takeIf { it > BigInteger.ZERO } ?: BigInteger.valueOf(1_000_000_000L)
+            val realHotkey = picked?.hotkeyAddress?.let { runCatching { it.toAccountId() }.getOrNull() } ?: ByteArray(32)
+            extrinsicService.estimateFee(
+                chain = stakingSharedState.chain(),
+                origin = TransactionOrigin.SelectedWallet,
+            ) {
+                addStakeLimit(hotkey = realHotkey, netuid = netuid, amount = realAmount)
+            }
+        }
+    }
+
+    private fun openConfirm(picked: SubtensorPickedValidator, amountTao: BigDecimal) {
         _submitting.value = true
         viewModelScope.launch {
-            val precision = runCatching { stakingSharedState.chainAsset().precision.value.toInt() }.getOrDefault(9)
-            val planks = amountTao
-                .multiply(BigDecimal.TEN.pow(precision))
-                .toBigInteger()
+            val fee = originFeeMixin.awaitOptionalFee()
 
-            val hotkeyBytes = runCatching { hotkeyAddress.toAccountId() }.getOrNull()
+            val asset = assetFlow.first()
+            val precision = asset.token.configuration.precision.value.toInt()
+            val planks = amountTao.multiply(BigDecimal.TEN.pow(precision)).toBigInteger()
+
+            // Min-stake guard: chain rejects anything below MIN_NOMINATOR_STAKE_RAO
+            // (0.01 TAO = 10_000_000 RAO). iOS leaves this to the chain, but
+            // toasting upfront avoids the wasted-gas round-trip and spares the
+            // user a confusing extrinsic-rejection error.
+            if (planks < SubtensorStakingConstants.MIN_NOMINATOR_STAKE_RAO) {
+                _submitting.value = false
+                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_stake_below_min))
+                return@launch
+            }
+
+            val hotkeyBytes = runCatching { picked.hotkeyAddress.toAccountId() }.getOrNull()
             if (hotkeyBytes == null) {
                 _submitting.value = false
                 toastEvents.value = Event(resourceManager.getString(R.string.subtensor_setup_invalid_validator))
                 return@launch
             }
 
-            val result = submitInteractor.submitStake(
-                netuid = netuid,
-                hotkey = hotkeyBytes,
-                amountInPlanks = planks,
-            )
+            if (fee == null) {
+                _submitting.value = false
+                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_setup_submit_failed))
+                return@launch
+            }
+
             _submitting.value = false
-            result.fold(
-                onSuccess = {
-                    // Pop straight back to the multistaking dashboard. The
-                    // dashboard's next sync (cache was just invalidated)
-                    // surfaces the new position automatically.
-                    dashboardRouter.returnToStakingDashboard()
-                },
-                onFailure = { error ->
-                    val message = error.localizedMessage
-                        ?: resourceManager.getString(R.string.subtensor_setup_submit_failed)
-                    toastEvents.value = Event(message)
-                },
+            router.openSubtensorStakeConfirm(
+                SubtensorStakeConfirmPayload(
+                    netuid = netuid,
+                    hotkeyAddress = picked.hotkeyAddress,
+                    validatorIdentity = picked.identity,
+                    amountInPlanks = planks,
+                    fee = mapFeeToParcel(fee),
+                    subnetName = subnetName,
+                )
             )
         }
     }
@@ -138,10 +200,34 @@ class SubtensorStakeSetupViewModel(
         else -> "Subnet $netuid"
     }
 
-    private fun formatValidatorLabel(hotkey: String?): String {
-        if (hotkey.isNullOrBlank()) {
-            return resourceManager.getString(R.string.subtensor_setup_select_validator)
+    private fun buildTargetModel(picked: SubtensorPickedValidator?): StakingTargetModel {
+        if (picked == null) {
+            return StakingTargetModel(
+                title = resourceManager.getString(R.string.subtensor_setup_select_validator),
+                subtitle = null,
+                icon = null,
+            )
         }
-        return if (hotkey.length <= 10) hotkey else "${hotkey.take(6)}…${hotkey.takeLast(4)}"
+        val short = shorten(picked.hotkeyAddress)
+        // Mirror iOS StackAccountSelectionCell: identity as the bold title,
+        // truncated hotkey as the gray subtitle. When identity is unknown
+        // the hotkey takes the title slot.
+        val identity = picked.identity?.takeIf { it.isNotBlank() }
+        return if (identity != null) {
+            StakingTargetModel(
+                title = identity,
+                subtitle = ColoredText(text = short, colorRes = R.color.text_secondary),
+                icon = null,
+            )
+        } else {
+            StakingTargetModel(
+                title = short,
+                subtitle = null,
+                icon = null,
+            )
+        }
     }
+
+    private fun shorten(address: String): String =
+        if (address.length <= 10) address else "${address.take(6)}...${address.takeLast(4)}"
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/SubtensorStakeSetupViewModel.kt
@@ -14,12 +14,16 @@ import io.novafoundation.nova.feature_staking_impl.data.subtensor.extrinsic.addS
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.common.SubtensorNovaFee
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.confirm.SubtensorStakeConfirmPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorPickedValidator
 import io.novafoundation.nova.feature_staking_impl.presentation.view.stakingTarget.StakingTargetModel
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.withAmount
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeDisplay
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeStatus
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.awaitOptionalFee
@@ -50,6 +54,7 @@ class SubtensorStakeSetupViewModel(
     private val stakingSharedState: StakingSharedState,
     private val extrinsicService: ExtrinsicService,
     private val assetUseCase: AssetUseCase,
+    private val amountFormatter: AmountFormatter,
     feeLoaderMixinFactory: FeeLoaderMixinV2.Factory,
     maxActionProviderFactory: MaxActionProviderFactory,
     amountChooserMixinFactory: AmountChooserMixin.Factory,
@@ -58,6 +63,10 @@ class SubtensorStakeSetupViewModel(
 ) : BaseViewModel() {
 
     val isRoot: Boolean = netuid == SubtensorStakingConstants.ROOT_NETUID
+
+    /** True only when the Nova fee applies (subnet + recipient set). Drives the
+     *  fee row + caption visibility. Inert (false) today since the recipient is null. */
+    val novaFeeApplies: Boolean = SubtensorNovaFee.feeApplies(netuid)
 
     val titleText: StateFlow<String> = MutableStateFlow(resolveTitle()).asStateFlow()
 
@@ -95,6 +104,25 @@ class SubtensorStakeSetupViewModel(
         assetFlow = assetFlow,
         maxActionProvider = maxActionProvider,
     )
+
+    /**
+     * Nova service-fee row — live 0.3% of the typed stake amount, in TAO.
+     * Sits beside [originFeeMixin]'s network-fee row. Emits [FeeStatus.NoFee]
+     * (hidden) when the fee doesn't apply (root / no recipient). Isolated from
+     * the network-fee mixin. Declared after [amountChooserMixin] since it reads
+     * its back-pressured planks.
+     */
+    val novaFeeStatusFlow: StateFlow<FeeStatus<*, FeeDisplay>> = combine(
+        assetFlow,
+        amountChooserMixin.backPressuredPlanks,
+    ) { asset, amountPlanks ->
+        SubtensorNovaFee.nativeFeeStatus(
+            netuid = netuid,
+            grossPlanks = amountPlanks,
+            token = asset.token,
+            amountFormatter = amountFormatter,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, FeeStatus.NoFee)
 
     val canContinue: StateFlow<Boolean> = combine(
         _selectedValidator,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/di/SubtensorStakeSetupComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/di/SubtensorStakeSetupComponent.kt
@@ -1,0 +1,27 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.di
+
+import androidx.fragment.app.Fragment
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.novafoundation.nova.common.di.scope.ScreenScope
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupFragment
+
+@Subcomponent(
+    modules = [
+        SubtensorStakeSetupModule::class,
+    ],
+)
+@ScreenScope
+interface SubtensorStakeSetupComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance fragment: Fragment,
+            @BindsInstance netuid: Int,
+            @BindsInstance subnetName: String?,
+        ): SubtensorStakeSetupComponent
+    }
+
+    fun inject(fragment: SubtensorStakeSetupFragment)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/di/SubtensorStakeSetupModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/di/SubtensorStakeSetupModule.kt
@@ -1,0 +1,66 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.di
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
+import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupViewModel
+
+@Module(includes = [ViewModelModule::class])
+class SubtensorStakeSetupModule {
+
+    @Provides
+    fun provideSubtensorStakeSubmitInteractor(
+        extrinsicService: ExtrinsicService,
+        stakingSharedState: StakingSharedState,
+        accountRepository: AccountRepository,
+        subnetFetcher: SubtensorSubnetFetcher,
+        positionCache: SubtensorPositionCache,
+    ): SubtensorStakeSubmitInteractor = SubtensorStakeSubmitInteractor(
+        extrinsicService = extrinsicService,
+        stakingSharedState = stakingSharedState,
+        accountRepository = accountRepository,
+        subnetFetcher = subnetFetcher,
+        positionCache = positionCache,
+    )
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SubtensorStakeSetupViewModel::class)
+    fun provideViewModel(
+        router: StakingRouter,
+        dashboardRouter: StakingDashboardRouter,
+        resourceManager: ResourceManager,
+        stakingSharedState: StakingSharedState,
+        submitInteractor: SubtensorStakeSubmitInteractor,
+        netuid: Int,
+        subnetName: String?,
+    ): ViewModel = SubtensorStakeSetupViewModel(
+        router = router,
+        dashboardRouter = dashboardRouter,
+        resourceManager = resourceManager,
+        stakingSharedState = stakingSharedState,
+        submitInteractor = submitInteractor,
+        netuid = netuid,
+        subnetName = subnetName,
+    )
+
+    @Provides
+    fun provideViewModelInstance(
+        fragment: Fragment,
+        viewModelFactory: ViewModelProvider.Factory,
+    ): SubtensorStakeSetupViewModel = ViewModelProvider(fragment, viewModelFactory).get(SubtensorStakeSetupViewModel::class.java)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/di/SubtensorStakeSetupModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/di/SubtensorStakeSetupModule.kt
@@ -10,32 +10,17 @@ import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
-import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
-import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
-import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
-import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupViewModel
+import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.maxAction.MaxActionProviderFactory
 
 @Module(includes = [ViewModelModule::class])
 class SubtensorStakeSetupModule {
-
-    @Provides
-    fun provideSubtensorStakeSubmitInteractor(
-        extrinsicService: ExtrinsicService,
-        stakingSharedState: StakingSharedState,
-        accountRepository: AccountRepository,
-        subnetFetcher: SubtensorSubnetFetcher,
-        positionCache: SubtensorPositionCache,
-    ): SubtensorStakeSubmitInteractor = SubtensorStakeSubmitInteractor(
-        extrinsicService = extrinsicService,
-        stakingSharedState = stakingSharedState,
-        accountRepository = accountRepository,
-        subnetFetcher = subnetFetcher,
-        positionCache = positionCache,
-    )
 
     @Provides
     @IntoMap
@@ -45,7 +30,11 @@ class SubtensorStakeSetupModule {
         dashboardRouter: StakingDashboardRouter,
         resourceManager: ResourceManager,
         stakingSharedState: StakingSharedState,
-        submitInteractor: SubtensorStakeSubmitInteractor,
+        extrinsicService: ExtrinsicService,
+        assetUseCase: AssetUseCase,
+        feeLoaderMixinFactory: FeeLoaderMixinV2.Factory,
+        maxActionProviderFactory: MaxActionProviderFactory,
+        amountChooserMixinFactory: AmountChooserMixin.Factory,
         netuid: Int,
         subnetName: String?,
     ): ViewModel = SubtensorStakeSetupViewModel(
@@ -53,7 +42,11 @@ class SubtensorStakeSetupModule {
         dashboardRouter = dashboardRouter,
         resourceManager = resourceManager,
         stakingSharedState = stakingSharedState,
-        submitInteractor = submitInteractor,
+        extrinsicService = extrinsicService,
+        assetUseCase = assetUseCase,
+        feeLoaderMixinFactory = feeLoaderMixinFactory,
+        maxActionProviderFactory = maxActionProviderFactory,
+        amountChooserMixinFactory = amountChooserMixinFactory,
         netuid = netuid,
         subnetName = subnetName,
     )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/di/SubtensorStakeSetupModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/setup/di/SubtensorStakeSetupModule.kt
@@ -15,6 +15,7 @@ import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboard
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupViewModel
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.AmountChooserMixin
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.maxAction.MaxActionProviderFactory
@@ -32,6 +33,7 @@ class SubtensorStakeSetupModule {
         stakingSharedState: StakingSharedState,
         extrinsicService: ExtrinsicService,
         assetUseCase: AssetUseCase,
+        amountFormatter: AmountFormatter,
         feeLoaderMixinFactory: FeeLoaderMixinV2.Factory,
         maxActionProviderFactory: MaxActionProviderFactory,
         amountChooserMixinFactory: AmountChooserMixin.Factory,
@@ -44,6 +46,7 @@ class SubtensorStakeSetupModule {
         stakingSharedState = stakingSharedState,
         extrinsicService = extrinsicService,
         assetUseCase = assetUseCase,
+        amountFormatter = amountFormatter,
         feeLoaderMixinFactory = feeLoaderMixinFactory,
         maxActionProviderFactory = maxActionProviderFactory,
         amountChooserMixinFactory = amountChooserMixinFactory,

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/SubtensorSubnetPickerFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/SubtensorSubnetPickerFragment.kt
@@ -2,10 +2,14 @@ package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake
 
 import android.view.View
 import android.widget.LinearLayout
+import android.widget.RadioButton
 import android.widget.TextView
 import androidx.core.view.isVisible
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.keyboard.showSoftKeyboard
+import io.novafoundation.nova.common.utils.onTextChanged
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorSubnetPickerBinding
@@ -13,10 +17,25 @@ import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
 
 class SubtensorSubnetPickerFragment : BaseFragment<SubtensorSubnetPickerViewModel, FragmentSubtensorSubnetPickerBinding>() {
 
+    private var filterIconView: android.widget.ImageView? = null
+
     override fun createBinding() = FragmentSubtensorSubnetPickerBinding.inflate(layoutInflater)
 
     override fun initViews() {
         binder.subtensorSubnetPickerToolbar.setHomeButtonListener { viewModel.backClicked() }
+
+        // Mirrors iOS subnet picker `setupNavigationBar`: filter rightmost,
+        // search to its left.
+        filterIconView = binder.subtensorSubnetPickerToolbar.addCustomAction(R.drawable.ic_filter) {
+            showFilterSheet()
+        }
+        binder.subtensorSubnetPickerToolbar.addCustomAction(R.drawable.ic_search) {
+            toggleSearchVisibility()
+        }
+
+        binder.subtensorSubnetPickerSearch.content.onTextChanged { text ->
+            viewModel.searchQueryChanged(text.toString())
+        }
     }
 
     override fun inject() {
@@ -31,6 +50,7 @@ class SubtensorSubnetPickerFragment : BaseFragment<SubtensorSubnetPickerViewMode
 
     override fun subscribe(viewModel: SubtensorSubnetPickerViewModel) {
         viewModel.state.observe { state -> renderState(state) }
+        viewModel.filterState.observe { state -> renderFilterIcon(state) }
     }
 
     private fun renderState(state: SubtensorSubnetPickerViewModel.UiState) {
@@ -45,16 +65,70 @@ class SubtensorSubnetPickerFragment : BaseFragment<SubtensorSubnetPickerViewMode
     private fun renderRows(rows: List<SubtensorSubnetPickerViewModel.SubnetRow>) {
         val container = binder.subtensorSubnetPickerList
         container.removeAllViews()
-        rows.forEachIndexed { index, row ->
+        rows.forEach { row ->
             val view = layoutInflater.inflate(R.layout.item_subtensor_subnet_picker, container, false)
             view.findViewById<TextView>(R.id.subtensorSubnetPickerRowName).text = row.displayName
             view.findViewById<TextView>(R.id.subtensorSubnetPickerRowNetuid).text = row.netuidLabel
             view.findViewById<TextView>(R.id.subtensorSubnetPickerRowReserve).text = row.taoReserveText
             view.findViewById<TextView>(R.id.subtensorSubnetPickerRowPrice).text = row.priceText
-            view.findViewById<View>(R.id.subtensorSubnetPickerRowDivider).visibility =
-                if (index < rows.size - 1) View.VISIBLE else View.GONE
             view.setOnClickListener { viewModel.subnetClicked(row.netuid) }
             (container as LinearLayout).addView(view)
         }
+    }
+
+    private fun toggleSearchVisibility() {
+        val search = binder.subtensorSubnetPickerSearch
+        if (search.isVisible) {
+            search.isVisible = false
+            search.content.text.clear()
+        } else {
+            search.isVisible = true
+            search.content.showSoftKeyboard()
+        }
+    }
+
+    private fun renderFilterIcon(state: SubtensorSubnetPickerViewModel.FilterState) {
+        val iconRes = if (state.isDefault) R.drawable.ic_filter else R.drawable.ic_filter_indicator
+        filterIconView?.setImageResource(iconRes)
+    }
+
+    private fun showFilterSheet() {
+        val current = viewModel.filterState.value
+        val dialog = BottomSheetDialog(requireContext())
+        val content = layoutInflater.inflate(R.layout.bottom_sheet_subtensor_subnet_filter, null)
+
+        val stakeRadio = content.findViewById<RadioButton>(R.id.subtensorSubnetFilterSortStakeRadio)
+        val netuidRadio = content.findViewById<RadioButton>(R.id.subtensorSubnetFilterSortNetuidRadio)
+        val stakeRow = content.findViewById<View>(R.id.subtensorSubnetFilterSortStakeRow)
+        val netuidRow = content.findViewById<View>(R.id.subtensorSubnetFilterSortNetuidRow)
+        val resetView = content.findViewById<TextView>(R.id.subtensorSubnetFilterReset)
+        val applyButton = content.findViewById<View>(R.id.subtensorSubnetFilterApply)
+
+        var working = current
+        fun render() {
+            stakeRadio.isChecked = working.sort == SubtensorSubnetPickerViewModel.Sort.TOTAL_STAKE_DESC
+            netuidRadio.isChecked = working.sort == SubtensorSubnetPickerViewModel.Sort.NETUID_ASC
+        }
+        render()
+
+        stakeRow.setOnClickListener {
+            working = working.copy(sort = SubtensorSubnetPickerViewModel.Sort.TOTAL_STAKE_DESC)
+            render()
+        }
+        netuidRow.setOnClickListener {
+            working = working.copy(sort = SubtensorSubnetPickerViewModel.Sort.NETUID_ASC)
+            render()
+        }
+        resetView.setOnClickListener {
+            working = SubtensorSubnetPickerViewModel.FilterState.DEFAULT
+            render()
+        }
+        applyButton.setOnClickListener {
+            viewModel.filterChanged(working)
+            dialog.dismiss()
+        }
+
+        dialog.setContentView(content)
+        dialog.show()
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/SubtensorSubnetPickerFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/SubtensorSubnetPickerFragment.kt
@@ -1,0 +1,60 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker
+
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.view.isVisible
+import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorSubnetPickerBinding
+import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+
+class SubtensorSubnetPickerFragment : BaseFragment<SubtensorSubnetPickerViewModel, FragmentSubtensorSubnetPickerBinding>() {
+
+    override fun createBinding() = FragmentSubtensorSubnetPickerBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+        binder.subtensorSubnetPickerToolbar.setHomeButtonListener { viewModel.backClicked() }
+    }
+
+    override fun inject() {
+        FeatureUtils.getFeature<StakingFeatureComponent>(
+            requireContext(),
+            StakingFeatureApi::class.java,
+        )
+            .subtensorSubnetPickerFactory()
+            .create(this)
+            .inject(this)
+    }
+
+    override fun subscribe(viewModel: SubtensorSubnetPickerViewModel) {
+        viewModel.state.observe { state -> renderState(state) }
+    }
+
+    private fun renderState(state: SubtensorSubnetPickerViewModel.UiState) {
+        binder.subtensorSubnetPickerProgress.isVisible = state is SubtensorSubnetPickerViewModel.UiState.Loading
+        binder.subtensorSubnetPickerEmpty.isVisible = state is SubtensorSubnetPickerViewModel.UiState.Empty
+        binder.subtensorSubnetPickerList.isVisible = state is SubtensorSubnetPickerViewModel.UiState.Loaded
+        if (state is SubtensorSubnetPickerViewModel.UiState.Loaded) {
+            renderRows(state.rows)
+        }
+    }
+
+    private fun renderRows(rows: List<SubtensorSubnetPickerViewModel.SubnetRow>) {
+        val container = binder.subtensorSubnetPickerList
+        container.removeAllViews()
+        rows.forEachIndexed { index, row ->
+            val view = layoutInflater.inflate(R.layout.item_subtensor_subnet_picker, container, false)
+            view.findViewById<TextView>(R.id.subtensorSubnetPickerRowName).text = row.displayName
+            view.findViewById<TextView>(R.id.subtensorSubnetPickerRowNetuid).text = row.netuidLabel
+            view.findViewById<TextView>(R.id.subtensorSubnetPickerRowReserve).text = row.taoReserveText
+            view.findViewById<TextView>(R.id.subtensorSubnetPickerRowPrice).text = row.priceText
+            view.findViewById<View>(R.id.subtensorSubnetPickerRowDivider).visibility =
+                if (index < rows.size - 1) View.VISIBLE else View.GONE
+            view.setOnClickListener { viewModel.subnetClicked(row.netuid) }
+            (container as LinearLayout).addView(view)
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/SubtensorSubnetPickerViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/SubtensorSubnetPickerViewModel.kt
@@ -1,0 +1,92 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker
+
+import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorSubnetInfo
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.math.BigInteger
+
+class SubtensorSubnetPickerViewModel(
+    private val router: StakingRouter,
+    private val subnetFetcher: SubtensorSubnetFetcher,
+) : BaseViewModel() {
+
+    sealed interface UiState {
+        object Loading : UiState
+        object Empty : UiState
+        data class Loaded(val rows: List<SubnetRow>) : UiState
+    }
+
+    data class SubnetRow(
+        val netuid: Int,
+        val displayName: String,
+        val netuidLabel: String,
+        val taoReserveText: String,
+        val priceText: String,
+    )
+
+    private val _state = MutableStateFlow<UiState>(UiState.Loading)
+    val state: StateFlow<UiState> = _state.asStateFlow()
+
+    private var loadedSubnets: List<SubtensorSubnetInfo> = emptyList()
+
+    init {
+        launch { load() }
+    }
+
+    private suspend fun load() {
+        _state.value = UiState.Loading
+        val subnets = runCatching {
+            withContext(Dispatchers.IO) { subnetFetcher.fetchAllSubnets() }
+        }.getOrDefault(emptyList())
+        loadedSubnets = subnets
+        if (subnets.isEmpty()) {
+            _state.value = UiState.Empty
+            return
+        }
+        // Match iOS default sort: total stake descending. Lets users see
+        // the largest subnets at the top — same UX as the validator picker.
+        val rows = subnets
+            .sortedByDescending { it.taoReserve }
+            .map(::toRow)
+        _state.value = UiState.Loaded(rows)
+    }
+
+    fun subnetClicked(netuid: Int) {
+        val name = loadedSubnets.firstOrNull { it.netuid == netuid }?.name
+        router.openSubtensorStakeSetup(netuid = netuid, subnetName = name)
+    }
+
+    fun backClicked() {
+        router.back()
+    }
+
+    private fun toRow(info: SubtensorSubnetInfo): SubnetRow {
+        return SubnetRow(
+            netuid = info.netuid,
+            displayName = info.name?.takeIf { it.isNotBlank() } ?: "Subnet ${info.netuid}",
+            netuidLabel = "SN${info.netuid}",
+            taoReserveText = formatTaoWhole(info.taoReserve),
+            priceText = formatSpotPrice(info.spotPrice),
+        )
+    }
+
+    private fun formatTaoWhole(rao: BigInteger): String {
+        if (rao.signum() <= 0) return "—"
+        // 1 TAO = 1e9 RAO. The picker shows whole TAO so big-pool subnets
+        // read at a glance — the spot price column carries the precision.
+        val taoWhole = rao.divide(BigInteger.TEN.pow(9))
+        return "%,d TAO".format(taoWhole.toLong())
+    }
+
+    private fun formatSpotPrice(spotPrice: Double): String {
+        if (spotPrice <= 0.0) return "—"
+        return "%.4f TAO/α".format(spotPrice)
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/SubtensorSubnetPickerViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/SubtensorSubnetPickerViewModel.kt
@@ -1,13 +1,17 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker
 
+import androidx.lifecycle.viewModelScope
 import io.novafoundation.nova.common.base.BaseViewModel
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorSubnetInfo
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.math.BigInteger
@@ -16,6 +20,18 @@ class SubtensorSubnetPickerViewModel(
     private val router: StakingRouter,
     private val subnetFetcher: SubtensorSubnetFetcher,
 ) : BaseViewModel() {
+
+    /** Sort options. Mirrors iOS `SubtensorSubnetFilterViewController.Sort`. */
+    enum class Sort { TOTAL_STAKE_DESC, NETUID_ASC }
+
+    data class FilterState(val sort: Sort = Sort.TOTAL_STAKE_DESC) {
+        val isDefault: Boolean
+            get() = sort == Sort.TOTAL_STAKE_DESC
+
+        companion object {
+            val DEFAULT = FilterState()
+        }
+    }
 
     sealed interface UiState {
         object Loading : UiState
@@ -31,8 +47,22 @@ class SubtensorSubnetPickerViewModel(
         val priceText: String,
     )
 
-    private val _state = MutableStateFlow<UiState>(UiState.Loading)
-    val state: StateFlow<UiState> = _state.asStateFlow()
+    private val _allRows = MutableStateFlow<List<SubnetRow>?>(null)
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private val _filterState = MutableStateFlow(FilterState.DEFAULT)
+    val filterState: StateFlow<FilterState> = _filterState.asStateFlow()
+
+    private val _loadStatus = MutableStateFlow<LoadStatus>(LoadStatus.Loading)
+
+    val state: StateFlow<UiState> = combine(
+        _loadStatus,
+        _allRows,
+        _searchQuery,
+        _filterState,
+    ) { status, rows, query, filters -> resolve(status, rows, query, filters) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, UiState.Loading)
 
     private var loadedSubnets: List<SubtensorSubnetInfo> = emptyList()
 
@@ -41,21 +71,13 @@ class SubtensorSubnetPickerViewModel(
     }
 
     private suspend fun load() {
-        _state.value = UiState.Loading
+        _loadStatus.value = LoadStatus.Loading
         val subnets = runCatching {
             withContext(Dispatchers.IO) { subnetFetcher.fetchAllSubnets() }
         }.getOrDefault(emptyList())
         loadedSubnets = subnets
-        if (subnets.isEmpty()) {
-            _state.value = UiState.Empty
-            return
-        }
-        // Match iOS default sort: total stake descending. Lets users see
-        // the largest subnets at the top — same UX as the validator picker.
-        val rows = subnets
-            .sortedByDescending { it.taoReserve }
-            .map(::toRow)
-        _state.value = UiState.Loaded(rows)
+        _allRows.value = subnets.map(::toRow)
+        _loadStatus.value = LoadStatus.Loaded
     }
 
     fun subnetClicked(netuid: Int) {
@@ -66,6 +88,50 @@ class SubtensorSubnetPickerViewModel(
     fun backClicked() {
         router.back()
     }
+
+    fun searchQueryChanged(text: String) {
+        _searchQuery.value = text
+    }
+
+    fun filterChanged(state: FilterState) {
+        _filterState.value = state
+    }
+
+    private fun resolve(
+        status: LoadStatus,
+        allRows: List<SubnetRow>?,
+        query: String,
+        filters: FilterState,
+    ): UiState = when (status) {
+        LoadStatus.Loading -> UiState.Loading
+        LoadStatus.Loaded -> {
+            val rows = allRows ?: emptyList()
+            val searched = applySearch(rows, query)
+            val sorted = applySort(searched, filters.sort)
+            if (sorted.isEmpty()) UiState.Empty else UiState.Loaded(sorted)
+        }
+    }
+
+    private fun applySearch(rows: List<SubnetRow>, query: String): List<SubnetRow> {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return rows
+        val lower = trimmed.lowercase()
+        return rows.filter { row ->
+            row.displayName.lowercase().contains(lower) ||
+                row.netuidLabel.lowercase().contains(lower) ||
+                row.netuid.toString() == trimmed
+        }
+    }
+
+    private fun applySort(rows: List<SubnetRow>, sort: Sort): List<SubnetRow> {
+        return when (sort) {
+            Sort.TOTAL_STAKE_DESC -> rows.sortedByDescending { rowReserve(it.netuid) }
+            Sort.NETUID_ASC -> rows.sortedBy { it.netuid }
+        }
+    }
+
+    private fun rowReserve(netuid: Int): BigInteger =
+        loadedSubnets.firstOrNull { it.netuid == netuid }?.taoReserve ?: BigInteger.ZERO
 
     private fun toRow(info: SubtensorSubnetInfo): SubnetRow {
         return SubnetRow(
@@ -79,8 +145,6 @@ class SubtensorSubnetPickerViewModel(
 
     private fun formatTaoWhole(rao: BigInteger): String {
         if (rao.signum() <= 0) return "—"
-        // 1 TAO = 1e9 RAO. The picker shows whole TAO so big-pool subnets
-        // read at a glance — the spot price column carries the precision.
         val taoWhole = rao.divide(BigInteger.TEN.pow(9))
         return "%,d TAO".format(taoWhole.toLong())
     }
@@ -89,4 +153,6 @@ class SubtensorSubnetPickerViewModel(
         if (spotPrice <= 0.0) return "—"
         return "%.4f TAO/α".format(spotPrice)
     }
+
+    private enum class LoadStatus { Loading, Loaded }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/di/SubtensorSubnetPickerComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/di/SubtensorSubnetPickerComponent.kt
@@ -1,0 +1,23 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker.di
+
+import androidx.fragment.app.Fragment
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.novafoundation.nova.common.di.scope.ScreenScope
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker.SubtensorSubnetPickerFragment
+
+@Subcomponent(
+    modules = [
+        SubtensorSubnetPickerModule::class,
+    ],
+)
+@ScreenScope
+interface SubtensorSubnetPickerComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance fragment: Fragment): SubtensorSubnetPickerComponent
+    }
+
+    fun inject(fragment: SubtensorSubnetPickerFragment)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/di/SubtensorSubnetPickerModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/subnetPicker/di/SubtensorSubnetPickerModule.kt
@@ -1,0 +1,35 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker.di
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
+import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.subnetPicker.SubtensorSubnetPickerViewModel
+
+@Module(includes = [ViewModelModule::class])
+class SubtensorSubnetPickerModule {
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SubtensorSubnetPickerViewModel::class)
+    fun provideViewModel(
+        router: StakingRouter,
+        subnetFetcher: SubtensorSubnetFetcher,
+    ): ViewModel = SubtensorSubnetPickerViewModel(
+        router = router,
+        subnetFetcher = subnetFetcher,
+    )
+
+    @Provides
+    fun provideViewModelInstance(
+        fragment: Fragment,
+        viewModelFactory: ViewModelProvider.Factory,
+    ): SubtensorSubnetPickerViewModel =
+        ViewModelProvider(fragment, viewModelFactory).get(SubtensorSubnetPickerViewModel::class.java)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/type/SubtensorStakeTypeFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/type/SubtensorStakeTypeFragment.kt
@@ -1,0 +1,48 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type
+
+import androidx.core.text.HtmlCompat
+import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorStakeTypeBinding
+import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+
+class SubtensorStakeTypeFragment : BaseFragment<SubtensorStakeTypeViewModel, FragmentSubtensorStakeTypeBinding>() {
+
+    override fun createBinding() = FragmentSubtensorStakeTypeBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+        binder.subtensorStakeTypeToolbar.setHomeButtonListener { viewModel.backClicked() }
+        binder.subtensorStakeTypeRootCard.setOnClickListener { viewModel.selectRoot() }
+        binder.subtensorStakeTypeSubnetCard.setOnClickListener { viewModel.selectSubnet() }
+        binder.subtensorStakeTypeContinue.setOnClickListener { viewModel.continueClicked() }
+
+        // The wiki footer has an inline accent-coloured "Nova Wiki >" link.
+        // The string is HTML-formatted so the colour stays in res/.
+        binder.subtensorStakeTypeWikiFooter.text = HtmlCompat.fromHtml(
+            getString(R.string.subtensor_stake_type_wiki_footer),
+            HtmlCompat.FROM_HTML_MODE_LEGACY,
+        )
+    }
+
+    override fun inject() {
+        FeatureUtils.getFeature<StakingFeatureComponent>(
+            requireContext(),
+            StakingFeatureApi::class.java,
+        )
+            .subtensorStakeTypeFactory()
+            .create(this)
+            .inject(this)
+    }
+
+    override fun subscribe(viewModel: SubtensorStakeTypeViewModel) {
+        viewModel.selection.observe { selection ->
+            val root = selection == SubtensorStakeTypeViewModel.Selection.ROOT
+            binder.subtensorStakeTypeRootRadio.isChecked = root
+            binder.subtensorStakeTypeSubnetRadio.isChecked = !root
+            binder.subtensorStakeTypeRootCard.isSelected = root
+            binder.subtensorStakeTypeSubnetCard.isSelected = !root
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/type/SubtensorStakeTypeViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/type/SubtensorStakeTypeViewModel.kt
@@ -1,0 +1,37 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type
+
+import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class SubtensorStakeTypeViewModel(
+    private val router: StakingRouter,
+) : BaseViewModel() {
+
+    enum class Selection { ROOT, SUBNET }
+
+    private val _selection = MutableStateFlow(Selection.ROOT)
+    val selection: StateFlow<Selection> = _selection.asStateFlow()
+
+    fun selectRoot() {
+        _selection.value = Selection.ROOT
+    }
+
+    fun selectSubnet() {
+        _selection.value = Selection.SUBNET
+    }
+
+    fun continueClicked() {
+        when (_selection.value) {
+            Selection.ROOT -> router.openSubtensorStakeSetup(SubtensorStakingConstants.ROOT_NETUID)
+            Selection.SUBNET -> router.openSubtensorSubnetPicker()
+        }
+    }
+
+    fun backClicked() {
+        router.back()
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/type/di/SubtensorStakeTypeComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/type/di/SubtensorStakeTypeComponent.kt
@@ -1,0 +1,23 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type.di
+
+import androidx.fragment.app.Fragment
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.novafoundation.nova.common.di.scope.ScreenScope
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type.SubtensorStakeTypeFragment
+
+@Subcomponent(
+    modules = [
+        SubtensorStakeTypeModule::class,
+    ],
+)
+@ScreenScope
+interface SubtensorStakeTypeComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(@BindsInstance fragment: Fragment): SubtensorStakeTypeComponent
+    }
+
+    fun inject(fragment: SubtensorStakeTypeFragment)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/type/di/SubtensorStakeTypeModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/type/di/SubtensorStakeTypeModule.kt
@@ -1,0 +1,31 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type.di
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
+import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.type.SubtensorStakeTypeViewModel
+
+@Module(includes = [ViewModelModule::class])
+class SubtensorStakeTypeModule {
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SubtensorStakeTypeViewModel::class)
+    fun provideViewModel(
+        router: StakingRouter,
+    ): ViewModel = SubtensorStakeTypeViewModel(
+        router = router,
+    )
+
+    @Provides
+    fun provideViewModelInstance(
+        fragment: Fragment,
+        viewModelFactory: ViewModelProvider.Factory,
+    ): SubtensorStakeTypeViewModel = ViewModelProvider(fragment, viewModelFactory).get(SubtensorStakeTypeViewModel::class.java)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorPickedValidator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorPickedValidator.kt
@@ -1,0 +1,16 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Selection threaded back from [SubtensorValidatorPickerFragment] to the
+ * stake setup screen. Pairs the SS58 hotkey (used for extrinsic signing
+ * and address-actions) with the resolved identity (used for cell labels
+ * on Setup + Confirm) so we don't need a second lookup downstream.
+ */
+@Parcelize
+data class SubtensorPickedValidator(
+    val hotkeyAddress: String,
+    val identity: String?,
+) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorValidatorPickerFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorValidatorPickerFragment.kt
@@ -3,10 +3,15 @@ package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake
 import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
+import android.widget.RadioButton
 import android.widget.TextView
 import androidx.core.view.isVisible
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.switchmaterial.SwitchMaterial
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.keyboard.showSoftKeyboard
+import io.novafoundation.nova.common.utils.onTextChanged
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorValidatorPickerBinding
@@ -20,10 +25,25 @@ class SubtensorValidatorPickerFragment : BaseFragment<SubtensorValidatorPickerVi
         fun bundle(netuid: Int): Bundle = Bundle().apply { putInt(ARG_NETUID, netuid) }
     }
 
+    private var filterIconView: android.widget.ImageView? = null
+
     override fun createBinding() = FragmentSubtensorValidatorPickerBinding.inflate(layoutInflater)
 
     override fun initViews() {
         binder.subtensorValidatorPickerToolbar.setHomeButtonListener { viewModel.backClicked() }
+
+        // Mirrors iOS `setupNavigationBar`: filter rightmost, then search.
+        // `addCustomAction` adds at index 0, so first call lands rightmost.
+        filterIconView = binder.subtensorValidatorPickerToolbar.addCustomAction(R.drawable.ic_filter) {
+            showFilterSheet()
+        }
+        binder.subtensorValidatorPickerToolbar.addCustomAction(R.drawable.ic_search) {
+            toggleSearchVisibility()
+        }
+
+        binder.subtensorValidatorPickerSearch.content.onTextChanged { text ->
+            viewModel.searchQueryChanged(text.toString())
+        }
     }
 
     override fun inject() {
@@ -39,6 +59,7 @@ class SubtensorValidatorPickerFragment : BaseFragment<SubtensorValidatorPickerVi
 
     override fun subscribe(viewModel: SubtensorValidatorPickerViewModel) {
         viewModel.state.observe { state -> renderState(state) }
+        viewModel.filterState.observe { state -> renderFilterIcon(state) }
     }
 
     private fun renderState(state: SubtensorValidatorPickerViewModel.UiState) {
@@ -54,23 +75,104 @@ class SubtensorValidatorPickerFragment : BaseFragment<SubtensorValidatorPickerVi
     private fun renderRows(rows: List<SubtensorValidatorPickerViewModel.ValidatorRow>) {
         val container = binder.subtensorValidatorPickerList
         container.removeAllViews()
-        rows.forEachIndexed { index, row ->
+        rows.forEach { row ->
             val view = layoutInflater.inflate(R.layout.item_subtensor_validator_picker, container, false)
-            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowName).text = row.displayName
-            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowHotkey).apply {
-                text = row.hotkeyShort
-                isVisible = row.displayName != row.hotkeyShort
+            val iconView = view.findViewById<android.widget.ImageView>(R.id.subtensorValidatorPickerRowIcon)
+            iconView.setImageDrawable(row.identicon)
+            iconView.isVisible = row.identicon != null
+
+            val nameView = view.findViewById<TextView>(R.id.subtensorValidatorPickerRowName)
+            nameView.text = row.displayName
+            nameView.typeface = if (row.isHotkeyDisplayed) {
+                android.graphics.Typeface.MONOSPACE
+            } else {
+                android.graphics.Typeface.DEFAULT
             }
-            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowStake).text = row.totalStakeText
-            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowMeta).apply {
-                val parts = listOf(row.aprText, row.commissionText).filter { it.isNotEmpty() }
-                text = parts.joinToString(" · ")
-                isVisible = parts.isNotEmpty()
+
+            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowApr).text = row.aprText
+            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowCommission).apply {
+                text = row.commissionText
+                isVisible = row.commissionText.isNotEmpty()
             }
-            view.findViewById<View>(R.id.subtensorValidatorPickerRowDivider).visibility =
-                if (index < rows.size - 1) View.VISIBLE else View.GONE
             view.setOnClickListener { viewModel.rowClicked(row.hotkey) }
             (container as LinearLayout).addView(view)
         }
+    }
+
+    private fun toggleSearchVisibility() {
+        val search = binder.subtensorValidatorPickerSearch
+        if (search.isVisible) {
+            search.isVisible = false
+            search.content.text.clear()
+            // Search query reset is implicit via the EditText listener
+        } else {
+            search.isVisible = true
+            search.content.showSoftKeyboard()
+        }
+    }
+
+    /**
+     * Filter icon stays the default outline when state is at default; flips
+     * to `ic_filter_indicator` (the dotted-active variant) when ANY toggle
+     * or the sort is non-default. Mirrors iOS `refreshFilterButtonStyle`.
+     */
+    private fun renderFilterIcon(state: SubtensorValidatorPickerViewModel.FilterState) {
+        val iconRes = if (state.isDefault) R.drawable.ic_filter else R.drawable.ic_filter_indicator
+        filterIconView?.setImageResource(iconRes)
+    }
+
+    private fun showFilterSheet() {
+        val current = viewModel.filterState.value
+        val dialog = BottomSheetDialog(requireContext())
+        val content = layoutInflater.inflate(R.layout.bottom_sheet_subtensor_validator_filter, null)
+
+        val identitySwitch = content.findViewById<SwitchMaterial>(R.id.subtensorValidatorFilterIdentitySwitch)
+        val commissionSwitch = content.findViewById<SwitchMaterial>(R.id.subtensorValidatorFilterCommissionSwitch)
+        val aprRadio = content.findViewById<RadioButton>(R.id.subtensorValidatorFilterSortAprRadio)
+        val stakeRadio = content.findViewById<RadioButton>(R.id.subtensorValidatorFilterSortStakeRadio)
+        val identityRow = content.findViewById<View>(R.id.subtensorValidatorFilterIdentityRow)
+        val commissionRow = content.findViewById<View>(R.id.subtensorValidatorFilterCommissionRow)
+        val aprRow = content.findViewById<View>(R.id.subtensorValidatorFilterSortAprRow)
+        val stakeRow = content.findViewById<View>(R.id.subtensorValidatorFilterSortStakeRow)
+        val resetView = content.findViewById<TextView>(R.id.subtensorValidatorFilterReset)
+        val applyButton = content.findViewById<View>(R.id.subtensorValidatorFilterApply)
+
+        // Mutable working copy of the filter state — only published on Apply.
+        var working = current
+        fun render() {
+            identitySwitch.isChecked = working.requireIdentity
+            commissionSwitch.isChecked = working.hideMaxCommission
+            aprRadio.isChecked = working.sort == SubtensorValidatorPickerViewModel.Sort.APR_DESC
+            stakeRadio.isChecked = working.sort == SubtensorValidatorPickerViewModel.Sort.TOTAL_STAKE_DESC
+        }
+        render()
+
+        identityRow.setOnClickListener {
+            working = working.copy(requireIdentity = !working.requireIdentity)
+            render()
+        }
+        commissionRow.setOnClickListener {
+            working = working.copy(hideMaxCommission = !working.hideMaxCommission)
+            render()
+        }
+        aprRow.setOnClickListener {
+            working = working.copy(sort = SubtensorValidatorPickerViewModel.Sort.APR_DESC)
+            render()
+        }
+        stakeRow.setOnClickListener {
+            working = working.copy(sort = SubtensorValidatorPickerViewModel.Sort.TOTAL_STAKE_DESC)
+            render()
+        }
+        resetView.setOnClickListener {
+            working = SubtensorValidatorPickerViewModel.FilterState.DEFAULT
+            render()
+        }
+        applyButton.setOnClickListener {
+            viewModel.filterChanged(working)
+            dialog.dismiss()
+        }
+
+        dialog.setContentView(content)
+        dialog.show()
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorValidatorPickerFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorValidatorPickerFragment.kt
@@ -1,0 +1,76 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker
+
+import android.os.Bundle
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.view.isVisible
+import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorValidatorPickerBinding
+import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+
+class SubtensorValidatorPickerFragment : BaseFragment<SubtensorValidatorPickerViewModel, FragmentSubtensorValidatorPickerBinding>() {
+
+    companion object {
+        private const val ARG_NETUID = "netuid"
+
+        fun bundle(netuid: Int): Bundle = Bundle().apply { putInt(ARG_NETUID, netuid) }
+    }
+
+    override fun createBinding() = FragmentSubtensorValidatorPickerBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+        binder.subtensorValidatorPickerToolbar.setHomeButtonListener { viewModel.backClicked() }
+    }
+
+    override fun inject() {
+        val netuid = arguments?.getInt(ARG_NETUID) ?: 0
+        FeatureUtils.getFeature<StakingFeatureComponent>(
+            requireContext(),
+            StakingFeatureApi::class.java,
+        )
+            .subtensorValidatorPickerFactory()
+            .create(this, netuid)
+            .inject(this)
+    }
+
+    override fun subscribe(viewModel: SubtensorValidatorPickerViewModel) {
+        viewModel.state.observe { state -> renderState(state) }
+    }
+
+    private fun renderState(state: SubtensorValidatorPickerViewModel.UiState) {
+        binder.subtensorValidatorPickerProgress.isVisible = state is SubtensorValidatorPickerViewModel.UiState.Loading
+        binder.subtensorValidatorPickerEmpty.isVisible = state is SubtensorValidatorPickerViewModel.UiState.Empty
+        binder.subtensorValidatorPickerError.isVisible = state is SubtensorValidatorPickerViewModel.UiState.Error
+        binder.subtensorValidatorPickerList.isVisible = state is SubtensorValidatorPickerViewModel.UiState.Loaded
+        if (state is SubtensorValidatorPickerViewModel.UiState.Loaded) {
+            renderRows(state.rows)
+        }
+    }
+
+    private fun renderRows(rows: List<SubtensorValidatorPickerViewModel.ValidatorRow>) {
+        val container = binder.subtensorValidatorPickerList
+        container.removeAllViews()
+        rows.forEachIndexed { index, row ->
+            val view = layoutInflater.inflate(R.layout.item_subtensor_validator_picker, container, false)
+            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowName).text = row.displayName
+            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowHotkey).apply {
+                text = row.hotkeyShort
+                isVisible = row.displayName != row.hotkeyShort
+            }
+            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowStake).text = row.totalStakeText
+            view.findViewById<TextView>(R.id.subtensorValidatorPickerRowMeta).apply {
+                val parts = listOf(row.aprText, row.commissionText).filter { it.isNotEmpty() }
+                text = parts.joinToString(" · ")
+                isVisible = parts.isNotEmpty()
+            }
+            view.findViewById<View>(R.id.subtensorValidatorPickerRowDivider).visibility =
+                if (index < rows.size - 1) View.VISIBLE else View.GONE
+            view.setOnClickListener { viewModel.rowClicked(row.hotkey) }
+            (container as LinearLayout).addView(view)
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorValidatorPickerViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorValidatorPickerViewModel.kt
@@ -1,29 +1,54 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker
 
+import android.graphics.drawable.Drawable
+import androidx.lifecycle.viewModelScope
+import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorValidator
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
-import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupFragment
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
-import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
 import io.novafoundation.nova.runtime.state.chain
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.math.BigInteger
 
 class SubtensorValidatorPickerViewModel(
     private val router: StakingRouter,
     private val validatorProvider: SubtensorValidatorProvider,
     private val stakingSharedState: StakingSharedState,
-    private val chainRegistry: ChainRegistry,
+    @Suppress("UnusedPrivateMember") private val chainRegistry: ChainRegistry,
+    private val addressIconGenerator: AddressIconGenerator,
     val netuid: Int,
 ) : BaseViewModel() {
+
+    enum class Sort { APR_DESC, TOTAL_STAKE_DESC }
+
+    /**
+     * Sort + show filters sheet state. Mirrors iOS
+     * `SubtensorValidatorFilterViewController.State` exactly:
+     * default = APR-desc with no toggles on.
+     */
+    data class FilterState(
+        val requireIdentity: Boolean = false,
+        val hideMaxCommission: Boolean = false,
+        val sort: Sort = Sort.APR_DESC,
+    ) {
+        val isDefault: Boolean
+            get() = !requireIdentity && !hideMaxCommission && sort == Sort.APR_DESC
+
+        companion object {
+            val DEFAULT = FilterState()
+        }
+    }
 
     sealed interface UiState {
         object Loading : UiState
@@ -34,15 +59,35 @@ class SubtensorValidatorPickerViewModel(
 
     data class ValidatorRow(
         val hotkey: String,
+        val identity: String?,
         val displayName: String,
-        val hotkeyShort: String,
-        val totalStakeText: String,
-        val commissionText: String,
+        val isHotkeyDisplayed: Boolean,
+        val identicon: Drawable?,
         val aprText: String,
+        val commissionText: String,
     )
 
-    private val _state = MutableStateFlow<UiState>(UiState.Loading)
-    val state: StateFlow<UiState> = _state.asStateFlow()
+    private val _allRows = MutableStateFlow<List<ValidatorRow>?>(null)
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private val _filterState = MutableStateFlow(FilterState.DEFAULT)
+    val filterState: StateFlow<FilterState> = _filterState.asStateFlow()
+
+    private val _loadStatus = MutableStateFlow<LoadStatus>(LoadStatus.Loading)
+
+    /**
+     * Final UI state — combines load status, all rows, search query, and
+     * filters into the currently-visible list. iOS does the equivalent
+     * inside `applyValidators(validators)` on every filter / search change.
+     */
+    val state: StateFlow<UiState> = combine(
+        _loadStatus,
+        _allRows,
+        _searchQuery,
+        _filterState,
+    ) { status, rows, query, filters -> resolve(status, rows, query, filters) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, UiState.Loading)
 
     private var loadedValidators: List<SubtensorValidator> = emptyList()
     private var addressPrefix: Short = 42
@@ -52,69 +97,143 @@ class SubtensorValidatorPickerViewModel(
     }
 
     private suspend fun load() {
-        _state.value = UiState.Loading
+        _loadStatus.value = LoadStatus.Loading
         addressPrefix = stakingSharedState.chain().addressPrefix.toShort()
         val validators = runCatching {
             withContext(Dispatchers.IO) { validatorProvider.fetchValidators(netuid) }
         }.getOrElse {
-            _state.value = UiState.Error
+            _loadStatus.value = LoadStatus.Error
             return
         }
         loadedValidators = validators
-        if (validators.isEmpty()) {
-            _state.value = UiState.Empty
-            return
-        }
-        val rows = validators.map(::toRow)
-        _state.value = UiState.Loaded(rows)
+        _allRows.value = validators.map { toRow(it) }
+        _loadStatus.value = LoadStatus.Loaded
     }
 
     fun rowClicked(hotkey: String) {
-        router.respondAndPopValidatorPicker(hotkey)
+        val identity = loadedValidators.firstOrNull {
+            runCatching { it.hotkey.toAddress(addressPrefix) }.getOrNull() == hotkey
+        }?.identity?.takeIf { it.isNotBlank() }
+        router.respondAndPopValidatorPicker(SubtensorPickedValidator(hotkey, identity))
     }
 
     fun backClicked() {
         router.back()
     }
 
-    private fun toRow(validator: SubtensorValidator): ValidatorRow {
-        val displayAddress = runCatching { validator.hotkey.toAddress(addressPrefix) }
-            .getOrDefault("")
-        val display = validator.identity?.takeIf { it.isNotBlank() } ?: shorten(displayAddress)
+    fun searchQueryChanged(text: String) {
+        _searchQuery.value = text
+    }
+
+    fun filterChanged(state: FilterState) {
+        _filterState.value = state
+    }
+
+    private fun resolve(
+        status: LoadStatus,
+        allRows: List<ValidatorRow>?,
+        query: String,
+        filters: FilterState,
+    ): UiState = when (status) {
+        LoadStatus.Loading -> UiState.Loading
+        LoadStatus.Error -> UiState.Error
+        LoadStatus.Loaded -> {
+            val rows = allRows ?: emptyList()
+            val filtered = applyFilters(rows, filters)
+            val searched = applySearch(filtered, query)
+            val sorted = applySort(searched, filters.sort)
+            if (sorted.isEmpty()) UiState.Empty else UiState.Loaded(sorted)
+        }
+    }
+
+    private fun applyFilters(rows: List<ValidatorRow>, filters: FilterState): List<ValidatorRow> {
+        if (filters.isDefault) return rows
+        val byIdentity = if (filters.requireIdentity) {
+            rows.filter { !it.isHotkeyDisplayed }
+        } else {
+            rows
+        }
+        val byCommission = if (filters.hideMaxCommission) {
+            // iOS hides commission >= 1.0 (i.e. 100%). We mirror by inspecting
+            // the raw validator since the row only carries formatted text.
+            byIdentity.filter { row ->
+                val commission = loadedValidators.firstOrNull { it.hotkey.toAddressOrNull() == row.hotkey }?.commission
+                commission == null || commission < 1.0
+            }
+        } else {
+            byIdentity
+        }
+        return byCommission
+    }
+
+    private fun applySearch(rows: List<ValidatorRow>, query: String): List<ValidatorRow> {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return rows
+        val lower = trimmed.lowercase()
+        return rows.filter { row ->
+            val identityHit = row.identity?.lowercase()?.contains(lower) == true
+            val hotkeyHit = row.hotkey.lowercase().contains(lower)
+            identityHit || hotkeyHit
+        }
+    }
+
+    private fun applySort(rows: List<ValidatorRow>, sort: Sort): List<ValidatorRow> {
+        return when (sort) {
+            Sort.APR_DESC -> rows.sortedWith(
+                compareByDescending<ValidatorRow> { rowApr(it) ?: Double.NEGATIVE_INFINITY }
+                    .thenByDescending { rowTotalStake(it) }
+            )
+            Sort.TOTAL_STAKE_DESC -> rows.sortedByDescending { rowTotalStake(it) }
+        }
+    }
+
+    private fun rowApr(row: ValidatorRow): Double? =
+        loadedValidators.firstOrNull { it.hotkey.toAddressOrNull() == row.hotkey }?.apr
+
+    private fun rowTotalStake(row: ValidatorRow): java.math.BigInteger =
+        loadedValidators.firstOrNull { it.hotkey.toAddressOrNull() == row.hotkey }?.totalStake
+            ?: java.math.BigInteger.ZERO
+
+    private fun ByteArray.toAddressOrNull(): String? =
+        runCatching { this.toAddress(addressPrefix) }.getOrNull()
+
+    private suspend fun toRow(validator: SubtensorValidator): ValidatorRow {
+        val displayAddress = runCatching { validator.hotkey.toAddress(addressPrefix) }.getOrDefault("")
+        val identity = validator.identity?.takeIf { it.isNotBlank() }
+        val isHotkey = identity == null
+        val displayName = identity ?: shorten(displayAddress)
+        val identicon = runCatching {
+            withContext(Dispatchers.Default) {
+                addressIconGenerator.createAddressIcon(validator.hotkey, ICON_SIZE_DP)
+            }
+        }.getOrNull()
         return ValidatorRow(
             hotkey = displayAddress,
-            displayName = display,
-            hotkeyShort = shorten(displayAddress),
-            totalStakeText = formatTao(validator.totalStake),
-            commissionText = formatCommission(validator.commission),
+            identity = identity,
+            displayName = displayName,
+            isHotkeyDisplayed = isHotkey,
+            identicon = identicon,
             aprText = formatApr(validator.apr),
+            commissionText = formatCommission(validator.commission),
         )
     }
 
     private fun shorten(address: String): String =
-        if (address.length <= 10) address else "${address.take(6)}…${address.takeLast(4)}"
+        if (address.length <= 10) address else "${address.take(6)}...${address.takeLast(4)}"
 
-    private fun formatTao(rao: BigInteger): String {
-        if (rao.signum() <= 0) return "—"
-        val tao = rao.toBigDecimal().movePointLeft(9)
-        return "%,.2f TAO".format(tao)
+    private fun formatApr(apr: Double?): String {
+        if (apr == null) return "—"
+        return "%.2f%%".format(apr * 100.0)
     }
 
     private fun formatCommission(commission: Double?): String {
         if (commission == null) return ""
-        return "%.1f%% fee".format(commission * 100.0)
+        return "%d%% commission".format((commission * 100.0).toInt())
     }
 
-    private fun formatApr(apr: Double?): String {
-        if (apr == null) return ""
-        return "%.2f%% APR".format(apr * 100.0)
-    }
+    private enum class LoadStatus { Loading, Loaded, Error }
 
     companion object {
-        const val ARG_NETUID = "validator_picker_netuid"
-
-        // Re-exported here for callers that don't want to import the setup
-        // fragment just to write to its saved state handle.
-        const val KEY_SELECTED_HOTKEY = SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR_HOTKEY
+        private const val ICON_SIZE_DP = 24
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorValidatorPickerViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/SubtensorValidatorPickerViewModel.kt
@@ -1,0 +1,120 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker
+
+import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorValidator
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.setup.SubtensorStakeSetupFragment
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.runtime.state.chain
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.math.BigInteger
+
+class SubtensorValidatorPickerViewModel(
+    private val router: StakingRouter,
+    private val validatorProvider: SubtensorValidatorProvider,
+    private val stakingSharedState: StakingSharedState,
+    private val chainRegistry: ChainRegistry,
+    val netuid: Int,
+) : BaseViewModel() {
+
+    sealed interface UiState {
+        object Loading : UiState
+        object Empty : UiState
+        object Error : UiState
+        data class Loaded(val rows: List<ValidatorRow>) : UiState
+    }
+
+    data class ValidatorRow(
+        val hotkey: String,
+        val displayName: String,
+        val hotkeyShort: String,
+        val totalStakeText: String,
+        val commissionText: String,
+        val aprText: String,
+    )
+
+    private val _state = MutableStateFlow<UiState>(UiState.Loading)
+    val state: StateFlow<UiState> = _state.asStateFlow()
+
+    private var loadedValidators: List<SubtensorValidator> = emptyList()
+    private var addressPrefix: Short = 42
+
+    init {
+        launch { load() }
+    }
+
+    private suspend fun load() {
+        _state.value = UiState.Loading
+        addressPrefix = stakingSharedState.chain().addressPrefix.toShort()
+        val validators = runCatching {
+            withContext(Dispatchers.IO) { validatorProvider.fetchValidators(netuid) }
+        }.getOrElse {
+            _state.value = UiState.Error
+            return
+        }
+        loadedValidators = validators
+        if (validators.isEmpty()) {
+            _state.value = UiState.Empty
+            return
+        }
+        val rows = validators.map(::toRow)
+        _state.value = UiState.Loaded(rows)
+    }
+
+    fun rowClicked(hotkey: String) {
+        router.respondAndPopValidatorPicker(hotkey)
+    }
+
+    fun backClicked() {
+        router.back()
+    }
+
+    private fun toRow(validator: SubtensorValidator): ValidatorRow {
+        val displayAddress = runCatching { validator.hotkey.toAddress(addressPrefix) }
+            .getOrDefault("")
+        val display = validator.identity?.takeIf { it.isNotBlank() } ?: shorten(displayAddress)
+        return ValidatorRow(
+            hotkey = displayAddress,
+            displayName = display,
+            hotkeyShort = shorten(displayAddress),
+            totalStakeText = formatTao(validator.totalStake),
+            commissionText = formatCommission(validator.commission),
+            aprText = formatApr(validator.apr),
+        )
+    }
+
+    private fun shorten(address: String): String =
+        if (address.length <= 10) address else "${address.take(6)}…${address.takeLast(4)}"
+
+    private fun formatTao(rao: BigInteger): String {
+        if (rao.signum() <= 0) return "—"
+        val tao = rao.toBigDecimal().movePointLeft(9)
+        return "%,.2f TAO".format(tao)
+    }
+
+    private fun formatCommission(commission: Double?): String {
+        if (commission == null) return ""
+        return "%.1f%% fee".format(commission * 100.0)
+    }
+
+    private fun formatApr(apr: Double?): String {
+        if (apr == null) return ""
+        return "%.2f%% APR".format(apr * 100.0)
+    }
+
+    companion object {
+        const val ARG_NETUID = "validator_picker_netuid"
+
+        // Re-exported here for callers that don't want to import the setup
+        // fragment just to write to its saved state handle.
+        const val KEY_SELECTED_HOTKEY = SubtensorStakeSetupFragment.KEY_SELECTED_VALIDATOR_HOTKEY
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/di/SubtensorValidatorPickerComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/di/SubtensorValidatorPickerComponent.kt
@@ -1,0 +1,26 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.di
+
+import androidx.fragment.app.Fragment
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.novafoundation.nova.common.di.scope.ScreenScope
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorValidatorPickerFragment
+
+@Subcomponent(
+    modules = [
+        SubtensorValidatorPickerModule::class,
+    ],
+)
+@ScreenScope
+interface SubtensorValidatorPickerComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance fragment: Fragment,
+            @BindsInstance netuid: Int,
+        ): SubtensorValidatorPickerComponent
+    }
+
+    fun inject(fragment: SubtensorValidatorPickerFragment)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/di/SubtensorValidatorPickerModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/di/SubtensorValidatorPickerModule.kt
@@ -1,0 +1,43 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.di
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
+import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.stake.validatorPicker.SubtensorValidatorPickerViewModel
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
+
+@Module(includes = [ViewModelModule::class])
+class SubtensorValidatorPickerModule {
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SubtensorValidatorPickerViewModel::class)
+    fun provideViewModel(
+        router: StakingRouter,
+        validatorProvider: SubtensorValidatorProvider,
+        stakingSharedState: StakingSharedState,
+        chainRegistry: ChainRegistry,
+        netuid: Int,
+    ): ViewModel = SubtensorValidatorPickerViewModel(
+        router = router,
+        validatorProvider = validatorProvider,
+        stakingSharedState = stakingSharedState,
+        chainRegistry = chainRegistry,
+        netuid = netuid,
+    )
+
+    @Provides
+    fun provideViewModelInstance(
+        fragment: Fragment,
+        viewModelFactory: ViewModelProvider.Factory,
+    ): SubtensorValidatorPickerViewModel =
+        ViewModelProvider(fragment, viewModelFactory).get(SubtensorValidatorPickerViewModel::class.java)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/di/SubtensorValidatorPickerModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/stake/validatorPicker/di/SubtensorValidatorPickerModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
@@ -25,12 +26,14 @@ class SubtensorValidatorPickerModule {
         validatorProvider: SubtensorValidatorProvider,
         stakingSharedState: StakingSharedState,
         chainRegistry: ChainRegistry,
+        addressIconGenerator: AddressIconGenerator,
         netuid: Int,
     ): ViewModel = SubtensorValidatorPickerViewModel(
         router = router,
         validatorProvider = validatorProvider,
         stakingSharedState = stakingSharedState,
         chainRegistry = chainRegistry,
+        addressIconGenerator = addressIconGenerator,
         netuid = netuid,
     )
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmFragment.kt
@@ -1,0 +1,65 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm
+
+import android.os.Bundle
+import androidx.core.view.isVisible
+import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.view.setProgressState
+import io.novafoundation.nova.feature_account_api.presenatation.actions.setupExternalActions
+import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
+import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorUnstakeConfirmBinding
+import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+
+class SubtensorUnstakeConfirmFragment : BaseFragment<SubtensorUnstakeConfirmViewModel, FragmentSubtensorUnstakeConfirmBinding>() {
+
+    companion object {
+        private const val PAYLOAD_KEY = "subtensor_unstake_confirm_payload"
+
+        fun bundle(payload: SubtensorUnstakeConfirmPayload): Bundle = Bundle().apply {
+            putParcelable(PAYLOAD_KEY, payload)
+        }
+    }
+
+    override fun createBinding() = FragmentSubtensorUnstakeConfirmBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+        binder.subtensorUnstakeConfirmToolbar.setHomeButtonListener { viewModel.backClicked() }
+        binder.subtensorUnstakeConfirmExtrinsicInformation.setOnAccountClickedListener { viewModel.originAccountClicked() }
+        binder.subtensorUnstakeConfirmValidator.setOnClickListener { viewModel.validatorClicked() }
+        binder.subtensorUnstakeConfirmConfirm.prepareForProgress(viewLifecycleOwner)
+        binder.subtensorUnstakeConfirmConfirm.setOnClickListener { viewModel.confirmClicked() }
+    }
+
+    override fun inject() {
+        val payload = argument<SubtensorUnstakeConfirmPayload>(PAYLOAD_KEY)
+        FeatureUtils.getFeature<StakingFeatureComponent>(
+            requireContext(),
+            StakingFeatureApi::class.java,
+        )
+            .subtensorUnstakeConfirmFactory()
+            .create(this, payload)
+            .inject(this)
+    }
+
+    override fun subscribe(viewModel: SubtensorUnstakeConfirmViewModel) {
+        setupExternalActions(viewModel)
+
+        viewModel.titleText.observe { binder.subtensorUnstakeConfirmToolbar.setTitle(it) }
+        viewModel.amountModelFlow.observe(binder.subtensorUnstakeConfirmAmount::setAmount)
+        viewModel.walletUiFlow.observe(binder.subtensorUnstakeConfirmExtrinsicInformation::setWallet)
+        viewModel.originAddressModelFlow.observe(binder.subtensorUnstakeConfirmExtrinsicInformation::setAccount)
+        viewModel.feeStatusFlow.observe(binder.subtensorUnstakeConfirmExtrinsicInformation::setFeeStatus)
+        viewModel.validatorLabel.observe { binder.subtensorUnstakeConfirmValidator.showValue(it) }
+        viewModel.expectedReceiveLabel.observe { receive ->
+            // Subnet only — the row is hidden on root since 1 alpha = 1 TAO.
+            binder.subtensorUnstakeConfirmReceive.isVisible = receive != null
+            if (receive != null) {
+                binder.subtensorUnstakeConfirmReceive.showValue(receive)
+            }
+        }
+        viewModel.submitting.observe { binder.subtensorUnstakeConfirmConfirm.setProgressState(it) }
+        viewModel.toastEvents.observeEvent { msg ->
+            android.widget.Toast.makeText(requireContext(), msg, android.widget.Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.core.view.isVisible
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.setVisible
 import io.novafoundation.nova.common.view.setProgressState
 import io.novafoundation.nova.feature_account_api.presenatation.actions.setupExternalActions
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
@@ -28,6 +29,17 @@ class SubtensorUnstakeConfirmFragment : BaseFragment<SubtensorUnstakeConfirmView
         binder.subtensorUnstakeConfirmValidator.setOnClickListener { viewModel.validatorClicked() }
         binder.subtensorUnstakeConfirmConfirm.prepareForProgress(viewLifecycleOwner)
         binder.subtensorUnstakeConfirmConfirm.setOnClickListener { viewModel.confirmClicked() }
+
+        // Nova-fee disclosure — visible only when the fee applies (subnet +
+        // recipient set). Inert today (recipient null → hidden). The caption is
+        // static; the fee row's value is observed in subscribe() once reserves
+        // arrive.
+        binder.subtensorUnstakeConfirmNovaFee.setVisible(viewModel.novaFeeApplies)
+        binder.subtensorUnstakeConfirmNovaFeeDisclaimer.setVisible(viewModel.novaFeeApplies)
+        binder.subtensorUnstakeConfirmNovaFeeDisclaimer.text = getString(
+            io.novafoundation.nova.feature_staking_impl.R.string.subtensor_setup_nova_fee_disclaimer,
+            io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants.NOVA_FEE_PERCENT_DISPLAY,
+        )
     }
 
     override fun inject() {
@@ -49,6 +61,7 @@ class SubtensorUnstakeConfirmFragment : BaseFragment<SubtensorUnstakeConfirmView
         viewModel.walletUiFlow.observe(binder.subtensorUnstakeConfirmExtrinsicInformation::setWallet)
         viewModel.originAddressModelFlow.observe(binder.subtensorUnstakeConfirmExtrinsicInformation::setAccount)
         viewModel.feeStatusFlow.observe(binder.subtensorUnstakeConfirmExtrinsicInformation::setFeeStatus)
+        viewModel.novaFeeStatusFlow.observe(binder.subtensorUnstakeConfirmNovaFee::setFeeStatus)
         viewModel.validatorLabel.observe { binder.subtensorUnstakeConfirmValidator.showValue(it) }
         viewModel.expectedReceiveLabel.observe { receive ->
             // Subnet only — the row is hidden on root since 1 alpha = 1 TAO.

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmPayload.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmPayload.kt
@@ -1,0 +1,25 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm
+
+import android.os.Parcelable
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.FeeParcelModel
+import kotlinx.parcelize.Parcelize
+import java.math.BigInteger
+
+/**
+ * Payload threaded from the Subtensor unstake setup screen into Confirm.
+ * Mirrors iOS `SubtensorUnstakeConfirmViewFactory` argument set
+ * (chainAsset, position, amount). [feeInPlanks] is the snapshot taken on
+ * Setup so what the user agreed to is what they sign.
+ */
+@Parcelize
+data class SubtensorUnstakeConfirmPayload(
+    val netuid: Int,
+    val hotkeyAddress: String,
+    /** Validator identity name from delegates registry; null when unknown. */
+    val validatorIdentity: String?,
+    /** Amount the user is unstaking — TAO planks for root, alpha planks for subnet. */
+    val amountInPlanks: BigInteger,
+    /** Full position planks; used by the dust-remainder warning hint. */
+    val positionPlanks: BigInteger,
+    val fee: FeeParcelModel,
+) : Parcelable

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmViewModel.kt
@@ -19,24 +19,29 @@ import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorSta
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.common.SubtensorNovaFee
 import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
 import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
 import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
 import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.formatAmountToAmountModel
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeDisplay
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeStatus
 import io.novafoundation.nova.runtime.state.chain
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
+import java.math.BigInteger
 
 class SubtensorUnstakeConfirmViewModel(
     private val router: StakingRouter,
@@ -115,8 +120,37 @@ class SubtensorUnstakeConfirmViewModel(
     private val _expectedReceiveLabel = MutableStateFlow<String?>(null)
     val expectedReceiveLabel: StateFlow<String?> = _expectedReceiveLabel.asStateFlow()
 
+    /** True only when the Nova fee applies (subnet + recipient set). Drives the
+     *  fee row + caption visibility. Inert (false) today since the recipient is null. */
+    val novaFeeApplies: Boolean = SubtensorNovaFee.feeApplies(payload.netuid)
+
+    /**
+     * Nova service-fee row — 0.3% of the minimum TAO received, in TAO. Computed
+     * in [fetchAmmEstimate] from the same live AMM reserves the "You'll receive"
+     * estimate uses: minTaoOut = amount × spotPrice × (1 - DEFAULT_SLIPPAGE).
+     * Starts as [FeeStatus.NoFee] (hidden) until reserves arrive / when the fee
+     * doesn't apply. Isolated from the network-fee flow.
+     */
+    private val _novaFeeStatus = MutableStateFlow<FeeStatus<*, FeeDisplay>>(FeeStatus.NoFee)
+    val novaFeeStatusFlow: StateFlow<FeeStatus<*, FeeDisplay>> = _novaFeeStatus.asStateFlow()
+
+    /**
+     * Single source of truth for the unstake fee. [fetchAmmEstimate] resolves the
+     * spot price ONCE, uses it for the displayed fee, and stores it here so the
+     * submit path charges the fee from the exact same reserve read (no second
+     * fetch → no displayed-vs-charged drift). [ammResolved] gates confirm until
+     * that estimate settles, mirroring iOS deferring confirm until the commission
+     * resolves. Root has no AMM, so it resolves immediately with a null price.
+     */
+    private var resolvedSpotPrice: Double? = null
+    private val ammResolved = CompletableDeferred<Unit>()
+
     init {
-        if (!isRoot) viewModelScope.launch { fetchAmmEstimate() }
+        if (!isRoot) {
+            viewModelScope.launch { fetchAmmEstimate() }
+        } else {
+            ammResolved.complete(Unit)
+        }
     }
 
     fun confirmClicked() {
@@ -141,20 +175,49 @@ class SubtensorUnstakeConfirmViewModel(
     }
 
     private suspend fun fetchAmmEstimate() {
-        val reserves = runCatching {
-            withContext(Dispatchers.IO) { subnetFetcher.fetchReserves(payload.netuid) }
-        }.getOrNull() ?: return
-        val spotPrice = reserves.spotPrice
-        if (spotPrice <= 0.0) return
+        try {
+            val reserves = runCatching {
+                withContext(Dispatchers.IO) { subnetFetcher.fetchReserves(payload.netuid) }
+            }.getOrNull() ?: return
+            val spotPrice = reserves.spotPrice
+            if (spotPrice <= 0.0) return
 
-        // alpha_amount × spot_price → tao_received. Both sides expressed in
-        // their respective whole-token units, so we work in BigDecimal for
-        // precision (then format with 4 decimals).
-        val alphaAmount = payload.amountInPlanks
-            .toBigDecimal()
-            .movePointLeft(9)
-        val taoReceived = alphaAmount.multiply(BigDecimal.valueOf(spotPrice))
-        _expectedReceiveLabel.value = "≈ %.4f TAO".format(taoReceived)
+            // Resolved once here; reused verbatim by the submit path (see
+            // [resolvedSpotPrice]) so the charged fee matches this displayed one.
+            resolvedSpotPrice = spotPrice
+
+            // Convert alpha planks → whole tokens with the asset's own precision
+            // (alpha shares TAO's 9 decimals on Bittensor); use the SAME precision
+            // going back to planks below so display and charge can't diverge.
+            val asset = assetFlow.first()
+            val precision = asset.token.configuration.precision.value.toInt()
+
+            // alpha_amount × spot_price → tao_received (whole tokens; BigDecimal
+            // for precision, formatted to 4 decimals for the "You'll receive" row).
+            val alphaAmount = payload.amountInPlanks
+                .toBigDecimal()
+                .movePointLeft(precision)
+            val taoReceived = alphaAmount.multiply(BigDecimal.valueOf(spotPrice))
+            _expectedReceiveLabel.value = "≈ %.4f TAO".format(taoReceived)
+
+            // Nova fee = 0.3% of the MINIMUM TAO out (received minus slippage), in
+            // TAO — mirrors iOS, which charges the fee on minTaoOut so it can never
+            // exceed what's actually received. minTaoOut → planks via the same precision.
+            val minTaoOut = taoReceived.multiply(
+                BigDecimal.valueOf(1.0 - SubtensorStakingConstants.DEFAULT_SLIPPAGE)
+            )
+            val minTaoOutPlanks = minTaoOut.movePointRight(precision).toBigInteger().max(BigInteger.ZERO)
+            _novaFeeStatus.value = SubtensorNovaFee.nativeFeeStatus(
+                netuid = payload.netuid,
+                grossPlanks = minTaoOutPlanks,
+                token = asset.token,
+                amountFormatter = amountFormatter,
+            )
+        } finally {
+            // Release a pending confirm() on every path — success, empty reserves,
+            // or non-positive spot — so the user is never stuck behind the gate.
+            ammResolved.complete(Unit)
+        }
     }
 
     private fun sendTransaction() {
@@ -167,10 +230,16 @@ class SubtensorUnstakeConfirmViewModel(
                 return@launch
             }
 
+            // Gate on the AMM estimate so the fee charged comes from the SAME
+            // reserve read the screen displayed (iOS defers confirm likewise).
+            // Root has no AMM and already resolved in init.
+            if (!isRoot) ammResolved.await()
+
             val result = submitInteractor.submitUnstake(
                 netuid = payload.netuid,
                 hotkey = hotkeyBytes,
                 amountInPlanks = payload.amountInPlanks,
+                spotPriceTaoPerAlpha = resolvedSpotPrice,
             )
             _submitting.value = false
             result.fold(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/SubtensorUnstakeConfirmViewModel.kt
@@ -1,0 +1,198 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm
+
+import androidx.lifecycle.viewModelScope
+import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.utils.Event
+import io.novafoundation.nova.common.utils.flowOf
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdIn
+import io.novafoundation.nova.feature_account_api.presenatation.account.icon.createAccountAddressModel
+import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.WalletUiUseCase
+import io.novafoundation.nova.feature_account_api.presenatation.actions.ExternalActions
+import io.novafoundation.nova.feature_account_api.presenatation.actions.showAddressActions
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_wallet_api.data.mappers.mapFeeToFeeModel
+import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.model.amountFromPlanks
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.formatAmountToAmountModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeFromParcel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeStatus
+import io.novafoundation.nova.runtime.state.chain
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.math.BigDecimal
+
+class SubtensorUnstakeConfirmViewModel(
+    private val router: StakingRouter,
+    private val dashboardRouter: StakingDashboardRouter,
+    private val resourceManager: ResourceManager,
+    private val stakingSharedState: StakingSharedState,
+    private val accountRepository: AccountRepository,
+    private val submitInteractor: SubtensorStakeSubmitInteractor,
+    private val assetUseCase: AssetUseCase,
+    private val subnetFetcher: SubtensorSubnetFetcher,
+    private val addressIconGenerator: AddressIconGenerator,
+    private val walletUiUseCase: WalletUiUseCase,
+    private val amountFormatter: AmountFormatter,
+    private val externalActions: ExternalActions.Presentation,
+    private val payload: SubtensorUnstakeConfirmPayload,
+) : BaseViewModel(),
+    ExternalActions by externalActions {
+
+    val isRoot: Boolean = payload.netuid == SubtensorStakingConstants.ROOT_NETUID
+
+    val titleText: StateFlow<String> = MutableStateFlow(resourceManager.getString(R.string.subtensor_unstake)).asStateFlow()
+
+    private val _submitting = MutableStateFlow(false)
+    val submitting: StateFlow<Boolean> = _submitting.asStateFlow()
+
+    val toastEvents = androidx.lifecycle.MutableLiveData<Event<String>>()
+
+    private val decimalFee = mapFeeFromParcel(payload.fee)
+
+    private val assetFlow = assetUseCase.currentAssetFlow().shareInBackground()
+
+    /** Big-amount header. For root the alpha amount IS TAO, so we use the
+     *  canonical formatter (TAO symbol + TAO fiat). For subnet alpha we
+     *  build the AmountModel manually:
+     *    - symbol = "SN<netuid>" (the asset chip ticker, not "TAO")
+     *    - fiat   = null (subnet alpha has no priceId — same as iOS, which
+     *      suppresses fiat for these rows rather than mis-pricing alpha at
+     *      TAO's rate via the staking-shared-state asset). */
+    val amountModelFlow = assetFlow.map { asset ->
+        val amountTokens = asset.token.amountFromPlanks(payload.amountInPlanks)
+        if (isRoot) {
+            amountFormatter.formatAmountToAmountModel(amountTokens, asset)
+        } else {
+            io.novafoundation.nova.feature_wallet_api.presentation.model.AmountModel(
+                token = "%.5f SN${payload.netuid}".format(amountTokens),
+                fiat = null,
+            )
+        }
+    }.shareInBackground()
+
+    val walletUiFlow = walletUiUseCase.selectedWalletUiFlow().shareInBackground()
+
+    val originAddressModelFlow = flowOf {
+        val chain = stakingSharedState.chain()
+        val coldkey = accountRepository.getSelectedMetaAccount().requireAccountIdIn(chain)
+        addressIconGenerator.createAccountAddressModel(chain, coldkey.toAddress(chain.addressPrefix.toShort()))
+    }.shareInBackground()
+
+    val feeStatusFlow = assetFlow.map { asset ->
+        val feeModel = mapFeeToFeeModel(
+            fee = decimalFee,
+            token = asset.token,
+            amountFormatter = amountFormatter,
+        )
+        FeeStatus.Loaded(feeModel)
+    }.shareInBackground()
+
+    val validatorLabel: StateFlow<String> = MutableStateFlow(formatValidator()).asStateFlow()
+
+    /**
+     * "You'll receive" estimate. For root TAO, omitted (1:1 unstake — the
+     * amount is already in TAO). For subnet positions, derived from live
+     * AMM reserves: tao_received ≈ alpha_amount × spot_price (TAO per alpha).
+     * Mirrors iOS `SubtensorUnstakeConfirmPresenter.didReceiveAMMPrice`.
+     */
+    private val _expectedReceiveLabel = MutableStateFlow<String?>(null)
+    val expectedReceiveLabel: StateFlow<String?> = _expectedReceiveLabel.asStateFlow()
+
+    init {
+        if (!isRoot) viewModelScope.launch { fetchAmmEstimate() }
+    }
+
+    fun confirmClicked() {
+        if (_submitting.value) return
+        sendTransaction()
+    }
+
+    fun backClicked() {
+        if (_submitting.value) return
+        router.back()
+    }
+
+    fun originAccountClicked() = launch {
+        val chain = stakingSharedState.chain()
+        val coldkey = accountRepository.getSelectedMetaAccount().requireAccountIdIn(chain)
+        externalActions.showAddressActions(coldkey.toAddress(chain.addressPrefix.toShort()), chain)
+    }
+
+    fun validatorClicked() = launch {
+        val chain = stakingSharedState.chain()
+        externalActions.showAddressActions(payload.hotkeyAddress, chain)
+    }
+
+    private suspend fun fetchAmmEstimate() {
+        val reserves = runCatching {
+            withContext(Dispatchers.IO) { subnetFetcher.fetchReserves(payload.netuid) }
+        }.getOrNull() ?: return
+        val spotPrice = reserves.spotPrice
+        if (spotPrice <= 0.0) return
+
+        // alpha_amount × spot_price → tao_received. Both sides expressed in
+        // their respective whole-token units, so we work in BigDecimal for
+        // precision (then format with 4 decimals).
+        val alphaAmount = payload.amountInPlanks
+            .toBigDecimal()
+            .movePointLeft(9)
+        val taoReceived = alphaAmount.multiply(BigDecimal.valueOf(spotPrice))
+        _expectedReceiveLabel.value = "≈ %.4f TAO".format(taoReceived)
+    }
+
+    private fun sendTransaction() {
+        _submitting.value = true
+        viewModelScope.launch {
+            val hotkeyBytes = runCatching { payload.hotkeyAddress.toAccountId() }.getOrNull()
+            if (hotkeyBytes == null) {
+                _submitting.value = false
+                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_setup_invalid_validator))
+                return@launch
+            }
+
+            val result = submitInteractor.submitUnstake(
+                netuid = payload.netuid,
+                hotkey = hotkeyBytes,
+                amountInPlanks = payload.amountInPlanks,
+            )
+            _submitting.value = false
+            result.fold(
+                onSuccess = {
+                    // Match the canonical Nova pattern: plain "Transaction
+                    // submitted" toast on success, then return to dashboard.
+                    showToast(resourceManager.getString(R.string.common_transaction_submitted))
+                    dashboardRouter.returnToStakingDashboard()
+                },
+                onFailure = { error ->
+                    val message = error.localizedMessage
+                        ?: resourceManager.getString(R.string.subtensor_setup_submit_failed)
+                    toastEvents.value = Event(message)
+                },
+            )
+        }
+    }
+
+    private fun formatValidator(): String {
+        val short = if (payload.hotkeyAddress.length <= 10) payload.hotkeyAddress
+        else "${payload.hotkeyAddress.take(6)}...${payload.hotkeyAddress.takeLast(4)}"
+        val identity = payload.validatorIdentity?.takeIf { it.isNotBlank() }
+        return if (identity != null) "$identity ($short)" else short
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/di/SubtensorUnstakeConfirmComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/di/SubtensorUnstakeConfirmComponent.kt
@@ -1,0 +1,27 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.di
+
+import androidx.fragment.app.Fragment
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.novafoundation.nova.common.di.scope.ScreenScope
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmFragment
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmPayload
+
+@Subcomponent(
+    modules = [
+        SubtensorUnstakeConfirmModule::class,
+    ],
+)
+@ScreenScope
+interface SubtensorUnstakeConfirmComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance fragment: Fragment,
+            @BindsInstance payload: SubtensorUnstakeConfirmPayload,
+        ): SubtensorUnstakeConfirmComponent
+    }
+
+    fun inject(fragment: SubtensorUnstakeConfirmFragment)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/di/SubtensorUnstakeConfirmModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/confirm/di/SubtensorUnstakeConfirmModule.kt
@@ -1,0 +1,85 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.di
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
+import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_account_api.presenatation.account.wallet.WalletUiUseCase
+import io.novafoundation.nova.feature_account_api.presenatation.actions.ExternalActions
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmPayload
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmViewModel
+import io.novafoundation.nova.feature_wallet_api.domain.AssetUseCase
+import io.novafoundation.nova.feature_wallet_api.presentation.formatters.amount.AmountFormatter
+
+@Module(includes = [ViewModelModule::class])
+class SubtensorUnstakeConfirmModule {
+
+    @Provides
+    fun provideSubmitInteractor(
+        extrinsicService: ExtrinsicService,
+        stakingSharedState: StakingSharedState,
+        accountRepository: AccountRepository,
+        subnetFetcher: SubtensorSubnetFetcher,
+        positionCache: SubtensorPositionCache,
+    ): SubtensorStakeSubmitInteractor = SubtensorStakeSubmitInteractor(
+        extrinsicService = extrinsicService,
+        stakingSharedState = stakingSharedState,
+        accountRepository = accountRepository,
+        subnetFetcher = subnetFetcher,
+        positionCache = positionCache,
+    )
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SubtensorUnstakeConfirmViewModel::class)
+    fun provideViewModel(
+        router: StakingRouter,
+        dashboardRouter: StakingDashboardRouter,
+        resourceManager: ResourceManager,
+        stakingSharedState: StakingSharedState,
+        accountRepository: AccountRepository,
+        submitInteractor: SubtensorStakeSubmitInteractor,
+        assetUseCase: AssetUseCase,
+        subnetFetcher: SubtensorSubnetFetcher,
+        addressIconGenerator: AddressIconGenerator,
+        walletUiUseCase: WalletUiUseCase,
+        amountFormatter: AmountFormatter,
+        externalActions: ExternalActions.Presentation,
+        payload: SubtensorUnstakeConfirmPayload,
+    ): ViewModel = SubtensorUnstakeConfirmViewModel(
+        router = router,
+        dashboardRouter = dashboardRouter,
+        resourceManager = resourceManager,
+        stakingSharedState = stakingSharedState,
+        accountRepository = accountRepository,
+        submitInteractor = submitInteractor,
+        assetUseCase = assetUseCase,
+        subnetFetcher = subnetFetcher,
+        addressIconGenerator = addressIconGenerator,
+        walletUiUseCase = walletUiUseCase,
+        amountFormatter = amountFormatter,
+        externalActions = externalActions,
+        payload = payload,
+    )
+
+    @Provides
+    fun provideViewModelInstance(
+        fragment: Fragment,
+        viewModelFactory: ViewModelProvider.Factory,
+    ): SubtensorUnstakeConfirmViewModel =
+        ViewModelProvider(fragment, viewModelFactory).get(SubtensorUnstakeConfirmViewModel::class.java)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupFragment.kt
@@ -1,0 +1,69 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup
+
+import android.os.Bundle
+import androidx.core.widget.doAfterTextChanged
+import io.novafoundation.nova.common.base.BaseFragment
+import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.view.setProgressState
+import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
+import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorUnstakeSetupBinding
+import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+import java.math.BigInteger
+
+class SubtensorUnstakeSetupFragment : BaseFragment<SubtensorUnstakeSetupViewModel, FragmentSubtensorUnstakeSetupBinding>() {
+
+    companion object {
+        private const val ARG_NETUID = "unstake_netuid"
+        private const val ARG_HOTKEY = "unstake_hotkey"
+        private const val ARG_AMOUNT = "unstake_amount"
+
+        fun bundle(netuid: Int, hotkeyAddress: String, positionPlanks: BigInteger): Bundle = Bundle().apply {
+            putInt(ARG_NETUID, netuid)
+            putString(ARG_HOTKEY, hotkeyAddress)
+            putString(ARG_AMOUNT, positionPlanks.toString())
+        }
+    }
+
+    override fun createBinding() = FragmentSubtensorUnstakeSetupBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+        binder.subtensorUnstakeSetupToolbar.setHomeButtonListener { viewModel.backClicked() }
+        binder.subtensorUnstakeSetupAmount.doAfterTextChanged { viewModel.amountChanged(it?.toString().orEmpty()) }
+        binder.subtensorUnstakeSetupMax.setOnClickListener { viewModel.maxClicked() }
+        binder.subtensorUnstakeSetupContinue.prepareForProgress(viewLifecycleOwner)
+        binder.subtensorUnstakeSetupContinue.setOnClickListener { viewModel.continueClicked() }
+    }
+
+    override fun inject() {
+        val netuid = arguments?.getInt(ARG_NETUID) ?: 0
+        val hotkey = arguments?.getString(ARG_HOTKEY).orEmpty()
+        val planks = arguments?.getString(ARG_AMOUNT)?.let { runCatching { BigInteger(it) }.getOrNull() } ?: BigInteger.ZERO
+        FeatureUtils.getFeature<StakingFeatureComponent>(
+            requireContext(),
+            StakingFeatureApi::class.java,
+        )
+            .subtensorUnstakeSetupFactory()
+            .create(this, netuid, hotkey, planks)
+            .inject(this)
+    }
+
+    override fun subscribe(viewModel: SubtensorUnstakeSetupViewModel) {
+        viewModel.titleText.observe { binder.subtensorUnstakeSetupToolbar.setTitle(it) }
+        viewModel.validatorLabel.observe { binder.subtensorUnstakeSetupValidator.text = it }
+        viewModel.positionLabel.observe { binder.subtensorUnstakeSetupPosition.text = it }
+        viewModel.amount.observe { current ->
+            // Only push back into the EditText when programmatic — Max button.
+            // Avoid loops when the user is typing.
+            val edt = binder.subtensorUnstakeSetupAmount
+            if (edt.text?.toString().orEmpty() != current) {
+                edt.setText(current)
+                edt.setSelection(current.length)
+            }
+        }
+        viewModel.canContinue.observe { binder.subtensorUnstakeSetupContinue.isEnabled = it }
+        viewModel.submitting.observe { binder.subtensorUnstakeSetupContinue.setProgressState(it) }
+        viewModel.toastEvents.observeEvent { msg ->
+            android.widget.Toast.makeText(requireContext(), msg, android.widget.Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.core.widget.doAfterTextChanged
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
+import io.novafoundation.nova.common.utils.setVisible
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
 import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorUnstakeSetupBinding
 import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
@@ -39,6 +40,16 @@ class SubtensorUnstakeSetupFragment : BaseFragment<SubtensorUnstakeSetupViewMode
             MaxActionAvailability.Available { viewModel.maxClicked() }
         )
         binder.subtensorUnstakeSetupContinue.setOnClickListener { viewModel.continueClicked() }
+
+        // Nova-fee disclosure — visible only when the fee applies (subnet +
+        // recipient set). Inert today (recipient null → hidden). The caption is
+        // static; the fee row's value is observed in subscribe().
+        binder.subtensorUnstakeSetupNovaFee.setVisible(viewModel.novaFeeApplies)
+        binder.subtensorUnstakeSetupNovaFeeDisclaimer.setVisible(viewModel.novaFeeApplies)
+        binder.subtensorUnstakeSetupNovaFeeDisclaimer.text = getString(
+            io.novafoundation.nova.feature_staking_impl.R.string.subtensor_setup_nova_fee_disclaimer,
+            io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants.NOVA_FEE_PERCENT_DISPLAY,
+        )
     }
 
     override fun inject() {
@@ -58,6 +69,10 @@ class SubtensorUnstakeSetupFragment : BaseFragment<SubtensorUnstakeSetupViewMode
         // Canonical Nova fee row — same wire-up as bond_more / parachain
         // start. The mixin owns shimmer / loaded / error states.
         setupFeeLoading(viewModel.feeMixin, binder.subtensorUnstakeSetupFee)
+
+        // Nova-fee row — observed independently of the network-fee mixin. Reuses
+        // the standard FeeView.setFeeStatus binding; NoFee hides the row.
+        viewModel.novaFeeStatusFlow.observe(binder.subtensorUnstakeSetupNovaFee::setFeeStatus)
 
         viewModel.titleText.observe { binder.subtensorUnstakeSetupToolbar.setTitle(it) }
         viewModel.validatorTargetModel.observe { binder.subtensorUnstakeSetupValidator.setModel(it) }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupFragment.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupFragment.kt
@@ -4,10 +4,11 @@ import android.os.Bundle
 import androidx.core.widget.doAfterTextChanged
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
-import io.novafoundation.nova.common.view.setProgressState
 import io.novafoundation.nova.feature_staking_api.di.StakingFeatureApi
 import io.novafoundation.nova.feature_staking_impl.databinding.FragmentSubtensorUnstakeSetupBinding
 import io.novafoundation.nova.feature_staking_impl.di.StakingFeatureComponent
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.amountChooser.MaxActionAvailability
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.setupFeeLoading
 import java.math.BigInteger
 
 class SubtensorUnstakeSetupFragment : BaseFragment<SubtensorUnstakeSetupViewModel, FragmentSubtensorUnstakeSetupBinding>() {
@@ -28,9 +29,15 @@ class SubtensorUnstakeSetupFragment : BaseFragment<SubtensorUnstakeSetupViewMode
 
     override fun initViews() {
         binder.subtensorUnstakeSetupToolbar.setHomeButtonListener { viewModel.backClicked() }
-        binder.subtensorUnstakeSetupAmount.doAfterTextChanged { viewModel.amountChanged(it?.toString().orEmpty()) }
-        binder.subtensorUnstakeSetupMax.setOnClickListener { viewModel.maxClicked() }
-        binder.subtensorUnstakeSetupContinue.prepareForProgress(viewLifecycleOwner)
+        binder.subtensorUnstakeSetupAmountInput.amountInput.doAfterTextChanged {
+            viewModel.amountChanged(it?.toString().orEmpty())
+        }
+        // MaxAmountView wires the click via setMaxActionAvailability — set
+        // it once with our handler. The widget colours itself based on
+        // availability (blue when clickable, grey otherwise).
+        binder.subtensorUnstakeSetupMax.setMaxActionAvailability(
+            MaxActionAvailability.Available { viewModel.maxClicked() }
+        )
         binder.subtensorUnstakeSetupContinue.setOnClickListener { viewModel.continueClicked() }
     }
 
@@ -48,22 +55,50 @@ class SubtensorUnstakeSetupFragment : BaseFragment<SubtensorUnstakeSetupViewMode
     }
 
     override fun subscribe(viewModel: SubtensorUnstakeSetupViewModel) {
+        // Canonical Nova fee row — same wire-up as bond_more / parachain
+        // start. The mixin owns shimmer / loaded / error states.
+        setupFeeLoading(viewModel.feeMixin, binder.subtensorUnstakeSetupFee)
+
         viewModel.titleText.observe { binder.subtensorUnstakeSetupToolbar.setTitle(it) }
-        viewModel.validatorLabel.observe { binder.subtensorUnstakeSetupValidator.text = it }
-        viewModel.positionLabel.observe { binder.subtensorUnstakeSetupPosition.text = it }
+        viewModel.validatorTargetModel.observe { binder.subtensorUnstakeSetupValidator.setModel(it) }
+        viewModel.positionLabel.observe { binder.subtensorUnstakeSetupPosition.showValue(it) }
+        viewModel.maxLabel.observe { binder.subtensorUnstakeSetupMax.setMaxAmountDisplay(it) }
+
+        // Static chip — the ticker ("SN56" / "TAO") doesn't change after
+        // construction. Set once instead of plumbing a Flow.
+        binder.subtensorUnstakeSetupAmountInput.setAssetName(viewModel.ticker)
+        viewModel.tokenIcon.observe { icon ->
+            icon?.let { binder.subtensorUnstakeSetupAmountInput.loadAssetImage(it) }
+        }
+        viewModel.fiatAmount.observe { fiat ->
+            binder.subtensorUnstakeSetupAmountInput.setFiatAmount(fiat)
+        }
+
         viewModel.amount.observe { current ->
-            // Only push back into the EditText when programmatic — Max button.
-            // Avoid loops when the user is typing.
-            val edt = binder.subtensorUnstakeSetupAmount
+            val edt = binder.subtensorUnstakeSetupAmountInput.amountInput
             if (edt.text?.toString().orEmpty() != current) {
                 edt.setText(current)
                 edt.setSelection(current.length)
             }
         }
         viewModel.canContinue.observe { binder.subtensorUnstakeSetupContinue.isEnabled = it }
-        viewModel.submitting.observe { binder.subtensorUnstakeSetupContinue.setProgressState(it) }
         viewModel.toastEvents.observeEvent { msg ->
             android.widget.Toast.makeText(requireContext(), msg, android.widget.Toast.LENGTH_LONG).show()
         }
+        viewModel.unstakeAllPromptEvent.observeEvent { showUnstakeAllPrompt() }
+    }
+
+    private fun showUnstakeAllPrompt() {
+        // Mirrors the iOS relaychain "min stake not crossed" affordance:
+        // user is about to leave dust under the chain minimum, offer to
+        // unstake everything as a single action instead.
+        androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setTitle(io.novafoundation.nova.feature_staking_impl.R.string.subtensor_unstake_remainder_title)
+            .setMessage(io.novafoundation.nova.feature_staking_impl.R.string.subtensor_unstake_remainder_message)
+            .setPositiveButton(io.novafoundation.nova.feature_staking_impl.R.string.subtensor_unstake_all) { _, _ ->
+                viewModel.confirmUnstakeAll()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupViewModel.kt
@@ -1,0 +1,135 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup
+
+import androidx.lifecycle.viewModelScope
+import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.common.utils.Event
+import io.novafoundation.nova.feature_staking_impl.R
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.runtime.state.chainAsset
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+import java.math.BigInteger
+
+class SubtensorUnstakeSetupViewModel(
+    private val router: StakingRouter,
+    private val dashboardRouter: StakingDashboardRouter,
+    private val resourceManager: ResourceManager,
+    private val stakingSharedState: StakingSharedState,
+    private val submitInteractor: SubtensorStakeSubmitInteractor,
+    val netuid: Int,
+    val hotkeyAddress: String,
+    val positionPlanks: BigInteger,
+) : BaseViewModel() {
+
+    val isRoot: Boolean = netuid == SubtensorStakingConstants.ROOT_NETUID
+
+    val titleText: StateFlow<String> = MutableStateFlow(resourceManager.getString(R.string.subtensor_unstake)).asStateFlow()
+
+    val validatorLabel: StateFlow<String> = MutableStateFlow(formatValidatorLabel()).asStateFlow()
+
+    /** Resolved once chainAsset() returns. Default 9 (Bittensor mainnet TAO). */
+    private val precision = MutableStateFlow(9)
+
+    val positionLabel: StateFlow<String> = precision
+        .map { formatPosition(it) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, formatPosition(9))
+
+    private val _amount = MutableStateFlow("")
+    val amount: StateFlow<String> = _amount.asStateFlow()
+
+    private val _submitting = MutableStateFlow(false)
+    val submitting: StateFlow<Boolean> = _submitting.asStateFlow()
+
+    val toastEvents = androidx.lifecycle.MutableLiveData<Event<String>>()
+
+    val canContinue: StateFlow<Boolean> = combine(_amount, _submitting) { amt, submitting ->
+        !submitting && amt.isNotBlank() && (amt.toBigDecimalOrNull()?.signum() ?: 0) > 0
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    init {
+        viewModelScope.launch {
+            precision.value = runCatching {
+                stakingSharedState.chainAsset().precision.value.toInt()
+            }.getOrDefault(9)
+        }
+    }
+
+    fun amountChanged(text: String) {
+        _amount.value = text
+    }
+
+    fun maxClicked() {
+        // Mirrors iOS UnstakeSetupPresenter.availableForMax — full position
+        // amount as a decimal so the input shows the user's complete stake.
+        val tao = positionPlanks.toBigDecimal().movePointLeft(precision.value).stripTrailingZeros().toPlainString()
+        _amount.value = tao
+    }
+
+    fun continueClicked() {
+        if (_submitting.value) return
+        val amt = _amount.value.toBigDecimalOrNull() ?: return
+        if (amt <= BigDecimal.ZERO) return
+        submit(amt)
+    }
+
+    fun backClicked() {
+        if (_submitting.value) return
+        router.back()
+    }
+
+    private fun submit(amountInUnits: BigDecimal) {
+        _submitting.value = true
+        viewModelScope.launch {
+            val planks = amountInUnits.multiply(BigDecimal.TEN.pow(precision.value)).toBigInteger()
+            if (planks > positionPlanks) {
+                _submitting.value = false
+                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_unstake_amount_exceeds))
+                return@launch
+            }
+
+            val hotkeyBytes: ByteArray? = runCatching { hotkeyAddress.toAccountId() }.getOrNull()
+            if (hotkeyBytes == null) {
+                _submitting.value = false
+                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_setup_invalid_validator))
+                return@launch
+            }
+
+            val result = submitInteractor.submitUnstake(
+                netuid = netuid,
+                hotkey = hotkeyBytes,
+                amountInPlanks = planks,
+            )
+            _submitting.value = false
+            result.fold(
+                onSuccess = { dashboardRouter.returnToStakingDashboard() },
+                onFailure = { error ->
+                    val message = error.localizedMessage
+                        ?: resourceManager.getString(R.string.subtensor_setup_submit_failed)
+                    toastEvents.value = Event(message)
+                },
+            )
+        }
+    }
+
+    private fun formatValidatorLabel(): String =
+        if (hotkeyAddress.length <= 10) hotkeyAddress else "${hotkeyAddress.take(6)}…${hotkeyAddress.takeLast(4)}"
+
+    private fun formatPosition(precision: Int): String {
+        val tao = positionPlanks.toBigDecimal().movePointLeft(precision)
+        val symbol = if (isRoot) "TAO" else "α"
+        return "%.4f %s".format(tao, symbol)
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupViewModel.kt
@@ -26,9 +26,12 @@ import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.Subten
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.common.SubtensorNovaFee
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmPayload
 import io.novafoundation.nova.feature_staking_impl.presentation.view.stakingTarget.StakingTargetModel
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeDisplay
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.model.FeeStatus
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.awaitOptionalFee
 import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.connectWith
@@ -129,6 +132,29 @@ class SubtensorUnstakeSetupViewModel(
         scope = this,
         selectedChainAssetFlow = selectedChainAsset.filterNotNull().shareInBackground(),
     )
+
+    /** True only when the Nova fee applies (subnet + recipient set). Drives the
+     *  fee row + caption visibility. Inert (false) today since the recipient is null. */
+    val novaFeeApplies: Boolean = SubtensorNovaFee.feeApplies(netuid)
+
+    /**
+     * Nova service-fee row — live 0.3% of the entered amount, shown in the
+     * screen's (alpha) asset units (e.g. "SN56"), mirroring iOS which shows the
+     * unstake-setup fee in the subnet token. Sits beside [feeMixin]'s
+     * network-fee row. Emits [FeeStatus.NoFee] (hidden) when the fee doesn't
+     * apply. Isolated from the network-fee mixin.
+     */
+    val novaFeeStatusFlow: StateFlow<FeeStatus<*, FeeDisplay>> = combine(
+        _amountInPlanks,
+        precision,
+    ) { amountPlanks, precision ->
+        SubtensorNovaFee.alphaFeeStatus(
+            netuid = netuid,
+            grossPlanks = amountPlanks,
+            precision = precision,
+            ticker = ticker,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, FeeStatus.NoFee)
 
     val canContinue: StateFlow<Boolean> = combine(_amount, _submitting) { amt, submitting ->
         !submitting && amt.isNotBlank() && (amt.toBigDecimalOrNull()?.signum() ?: 0) > 0

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/SubtensorUnstakeSetupViewModel.kt
@@ -1,34 +1,69 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup
 
+import android.graphics.drawable.Drawable
 import androidx.lifecycle.viewModelScope
+import io.novafoundation.nova.common.address.AddressIconGenerator
+import io.novafoundation.nova.common.address.createSubstrateAddressIcon
 import io.novafoundation.nova.common.base.BaseViewModel
+import io.novafoundation.nova.common.presentation.AssetIconProvider
+import io.novafoundation.nova.common.presentation.getAssetIconOrFallback
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.common.utils.Event
+import io.novafoundation.nova.common.utils.images.Icon as CommonIcon
+import io.novafoundation.nova.common.utils.images.asIcon
+import io.novafoundation.nova.common.utils.shareInBackground
+import io.novafoundation.nova.feature_account_api.data.ethereum.transaction.TransactionOrigin
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
+import io.novafoundation.nova.feature_currency_api.presentation.formatters.formatAsCurrency
+import io.novafoundation.nova.feature_wallet_api.domain.ArbitraryTokenUseCase
+import io.novafoundation.nova.feature_wallet_api.domain.model.HistoricalToken
+import kotlin.time.Duration.Companion.milliseconds
 import io.novafoundation.nova.feature_staking_impl.R
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
-import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.extrinsic.removeStakeLimit
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.BittensorDelegatesClient
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
 import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.confirm.SubtensorUnstakeConfirmPayload
+import io.novafoundation.nova.feature_staking_impl.presentation.view.stakingTarget.StakingTargetModel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.mapFeeToParcel
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.awaitOptionalFee
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.connectWith
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.createDefault
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.state.chain
 import io.novafoundation.nova.runtime.state.chainAsset
 import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAccountId
+import io.novasama.substrate_sdk_android.ss58.SS58Encoder.toAddress
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.math.BigInteger
 
 class SubtensorUnstakeSetupViewModel(
     private val router: StakingRouter,
-    private val dashboardRouter: StakingDashboardRouter,
+    @Suppress("UnusedPrivateMember") private val dashboardRouter: StakingDashboardRouter,
     private val resourceManager: ResourceManager,
     private val stakingSharedState: StakingSharedState,
-    private val submitInteractor: SubtensorStakeSubmitInteractor,
+    private val extrinsicService: ExtrinsicService,
+    private val delegatesClient: BittensorDelegatesClient,
+    private val validatorProvider: SubtensorValidatorProvider,
+    private val addressIconGenerator: AddressIconGenerator,
+    private val assetIconProvider: AssetIconProvider,
+    private val arbitraryTokenUseCase: ArbitraryTokenUseCase,
+    feeLoaderMixinFactory: FeeLoaderMixinV2.Factory,
     val netuid: Int,
     val hotkeyAddress: String,
     val positionPlanks: BigInteger,
@@ -36,53 +71,187 @@ class SubtensorUnstakeSetupViewModel(
 
     val isRoot: Boolean = netuid == SubtensorStakingConstants.ROOT_NETUID
 
-    val titleText: StateFlow<String> = MutableStateFlow(resourceManager.getString(R.string.subtensor_unstake)).asStateFlow()
+    /** "TAO" for root, "SN56" for subnets — used as the position/fee/max ticker. */
+    val ticker: String = if (isRoot) "TAO" else "SN$netuid"
 
-    val validatorLabel: StateFlow<String> = MutableStateFlow(formatValidatorLabel()).asStateFlow()
+    /** Chain-asset icon (TAO logo) — populated once chainAsset() resolves and
+     *  the relative filename ("TAO_bittensor.svg") is rebased through the
+     *  AssetIconProvider to a full URL. iOS uses the TAO logo for subnet
+     *  positions too; mirroring that here. */
+    private val _tokenIcon = MutableStateFlow<CommonIcon?>(null)
+    val tokenIcon: StateFlow<CommonIcon?> = _tokenIcon.asStateFlow()
+
+    /** Validator hotkey identicon (the polkadot-style multi-coloured circle).
+     *  Generated once on init, regardless of whether identity resolves. */
+    private val _identicon = MutableStateFlow<Drawable?>(null)
+
+    val titleText: StateFlow<String> = MutableStateFlow(
+        // Mirrors iOS `SubtensorUnstakeSetupViewLayout.title`: "Unstake — SN56"
+        // (or "Unstake — TAO"). The em-dash matches iOS exactly.
+        resourceManager.getString(R.string.subtensor_unstake) + " — " + ticker
+    ).asStateFlow()
 
     /** Resolved once chainAsset() returns. Default 9 (Bittensor mainnet TAO). */
     private val precision = MutableStateFlow(9)
+
+    /** Resolved from delegates registry on init; null while loading or if unknown. */
+    private val _identity = MutableStateFlow<String?>(null)
+    val identity: StateFlow<String?> = _identity.asStateFlow()
+
+    val validatorTargetModel: StateFlow<StakingTargetModel> = combine(_identity, _identicon) { identity, identicon ->
+        buildTargetModel(identity, identicon)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, buildTargetModel(null, null))
 
     val positionLabel: StateFlow<String> = precision
         .map { formatPosition(it) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, formatPosition(9))
 
+    val maxLabel: StateFlow<String> = precision
+        .map { formatMaxLabel(it) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, formatMaxLabel(9))
+
     private val _amount = MutableStateFlow("")
     val amount: StateFlow<String> = _amount.asStateFlow()
+
+    private val _amountInPlanks = MutableStateFlow(BigInteger.ZERO)
 
     private val _submitting = MutableStateFlow(false)
     val submitting: StateFlow<Boolean> = _submitting.asStateFlow()
 
     val toastEvents = androidx.lifecycle.MutableLiveData<Event<String>>()
 
+    val unstakeAllPromptEvent = androidx.lifecycle.MutableLiveData<Event<Unit>>()
+
+    private val selectedChainAsset = MutableStateFlow<Chain.Asset?>(null)
+
+    /** Fee row mixin — wired to amount via [connectWith] in init. */
+    val feeMixin = feeLoaderMixinFactory.createDefault(
+        scope = this,
+        selectedChainAssetFlow = selectedChainAsset.filterNotNull().shareInBackground(),
+    )
+
     val canContinue: StateFlow<Boolean> = combine(_amount, _submitting) { amt, submitting ->
         !submitting && amt.isNotBlank() && (amt.toBigDecimalOrNull()?.signum() ?: 0) > 0
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
+    /** HistoricalToken built off the priceId directly (skips the symbol-keyed
+     *  `tokens` table that conflates Fusotao and Bittensor under the symbol
+     *  "TAO" — last write wins, so the cached rate may be Fusotao's). */
+    private val _historicalToken = MutableStateFlow<HistoricalToken?>(null)
+
+    /** "$X.XX" string for the typed amount. Subnet-alpha positions have no
+     *  priceId of their own — iOS suppresses the fiat row for them rather
+     *  than mis-pricing alpha at TAO's rate. Mirroring that here: only show
+     *  fiat for root (where the typed amount is TAO and the price is TAO's). */
+    val fiatAmount: StateFlow<CharSequence?> = combine(_historicalToken, _amount) { token, raw ->
+        if (!isRoot) return@combine null
+        val amount = raw.toBigDecimalOrNull() ?: return@combine null
+        if (token == null) return@combine null
+        token.amountToFiat(amount).formatAsCurrency(token.currency)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
     init {
         viewModelScope.launch {
-            precision.value = runCatching {
-                stakingSharedState.chainAsset().precision.value.toInt()
-            }.getOrDefault(9)
+            val asset = runCatching { stakingSharedState.chainAsset() }.getOrNull()
+            precision.value = asset?.precision?.value?.toInt() ?: 9
+            selectedChainAsset.value = asset
+            // Resolve the relative filename ("TAO_bittensor.svg") to a full
+            // URL via AssetIconProvider — mirrors how Nova wallet rows and
+            // ChooseAmountView load asset icons everywhere else.
+            _tokenIcon.value = assetIconProvider.getAssetIconOrFallback(asset?.icon)
         }
+        // Fiat source: ArbitraryTokenUseCase.historicalToken(asset, now) —
+        // fetches CoinPrice by the asset's *priceId* (e.g. "bittensor")
+        // directly, bypassing the symbol-keyed `tokens` cache that conflates
+        // Fusotao and Bittensor under symbol "TAO". The returned
+        // HistoricalToken carries currency + rate together, so we can format
+        // fiat with the same one-liner the rest of Nova uses.
+        viewModelScope.launch {
+            val asset = runCatching { stakingSharedState.chainAsset() }.getOrNull() ?: return@launch
+            val now = System.currentTimeMillis().milliseconds
+            _historicalToken.value = runCatching {
+                withContext(Dispatchers.IO) { arbitraryTokenUseCase.historicalToken(asset, now) }
+            }.getOrNull()
+        }
+        // Identicon — generated locally from the SS58 hotkey. Doesn't need a
+        // network round-trip and works even when identity resolution fails,
+        // matching iOS where the picker, confirm, and unstake screens all
+        // show the same identicon for a given hotkey.
+        viewModelScope.launch {
+            _identicon.value = runCatching {
+                addressIconGenerator.createSubstrateAddressIcon(hotkeyAddress, AddressIconGenerator.SIZE_MEDIUM)
+            }.getOrNull()
+        }
+        // Identity lookup — go through the same provider the validator picker
+        // uses so we get TaoStats names (which include "P2P.org" and other
+        // operators not in the bittensor-delegates GitHub registry) merged
+        // with the delegates registry. Falls back to delegates-only on
+        // TaoStats failure. Mirrors iOS — picker and unstake share one
+        // identity source.
+        viewModelScope.launch {
+            val prefix: Short = runCatching {
+                stakingSharedState.chain().addressPrefix.toShort()
+            }.getOrDefault(42)
+            val resolved = runCatching {
+                withContext(Dispatchers.IO) { validatorProvider.fetchValidators(netuid) }
+                    .firstOrNull { row ->
+                        runCatching { row.hotkey.toAddress(prefix) }.getOrNull() == hotkeyAddress
+                    }?.identity?.takeIf { it.isNotBlank() }
+            }.getOrNull()
+                ?: runCatching {
+                    withContext(Dispatchers.IO) { delegatesClient.fetchDelegates() }
+                }.getOrElse { delegatesClient.cachedDelegates() }
+                    .get(hotkeyAddress)?.name
+                    ?.takeIf { it.isNotBlank() }
+            _identity.value = resolved
+        }
+
+        listenFee()
     }
 
     fun amountChanged(text: String) {
         _amount.value = text
+        _amountInPlanks.value = text.toBigDecimalOrNull()
+            ?.multiply(BigDecimal.TEN.pow(precision.value))
+            ?.toBigInteger()
+            ?: BigInteger.ZERO
     }
 
     fun maxClicked() {
-        // Mirrors iOS UnstakeSetupPresenter.availableForMax — full position
-        // amount as a decimal so the input shows the user's complete stake.
         val tao = positionPlanks.toBigDecimal().movePointLeft(precision.value).stripTrailingZeros().toPlainString()
         _amount.value = tao
+        _amountInPlanks.value = positionPlanks
     }
 
     fun continueClicked() {
         if (_submitting.value) return
         val amt = _amount.value.toBigDecimalOrNull() ?: return
         if (amt <= BigDecimal.ZERO) return
-        submit(amt)
+
+        val planks = amt.multiply(BigDecimal.TEN.pow(precision.value)).toBigInteger()
+        if (planks > positionPlanks) {
+            toastEvents.value = Event(resourceManager.getString(R.string.subtensor_unstake_amount_exceeds))
+            return
+        }
+
+        // Mirror iOS dust-remainder UX: prompt to unstake all when the
+        // partial unstake would leave less than the chain minimum.
+        val remainder = positionPlanks - planks
+        val belowMin = remainder.signum() > 0 &&
+            remainder < SubtensorStakingConstants.MIN_NOMINATOR_STAKE_RAO
+        if (belowMin) {
+            unstakeAllPromptEvent.value = Event(Unit)
+            return
+        }
+
+        openConfirm(planks)
+    }
+
+    fun confirmUnstakeAll() {
+        if (_submitting.value) return
+        val tao = positionPlanks.toBigDecimal().movePointLeft(precision.value)
+        _amount.value = tao.stripTrailingZeros().toPlainString()
+        openConfirm(positionPlanks)
     }
 
     fun backClicked() {
@@ -90,46 +259,68 @@ class SubtensorUnstakeSetupViewModel(
         router.back()
     }
 
-    private fun submit(amountInUnits: BigDecimal) {
+    private fun listenFee() {
+        feeMixin.connectWith(
+            inputSource1 = _amountInPlanks,
+        ) { _, planks ->
+            val realAmount = planks.takeIf { it > BigInteger.ZERO } ?: BigInteger.valueOf(1_000_000_000L)
+            val hotkeyBytes = runCatching { hotkeyAddress.toAccountId() }.getOrNull() ?: ByteArray(32)
+            extrinsicService.estimateFee(
+                chain = stakingSharedState.chain(),
+                origin = TransactionOrigin.SelectedWallet,
+            ) {
+                removeStakeLimit(hotkey = hotkeyBytes, netuid = netuid, amount = realAmount)
+            }
+        }
+    }
+
+    private fun openConfirm(planks: BigInteger) {
         _submitting.value = true
         viewModelScope.launch {
-            val planks = amountInUnits.multiply(BigDecimal.TEN.pow(precision.value)).toBigInteger()
-            if (planks > positionPlanks) {
+            val fee = feeMixin.awaitOptionalFee()
+            if (fee == null) {
                 _submitting.value = false
-                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_unstake_amount_exceeds))
+                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_setup_submit_failed))
                 return@launch
             }
-
-            val hotkeyBytes: ByteArray? = runCatching { hotkeyAddress.toAccountId() }.getOrNull()
-            if (hotkeyBytes == null) {
-                _submitting.value = false
-                toastEvents.value = Event(resourceManager.getString(R.string.subtensor_setup_invalid_validator))
-                return@launch
-            }
-
-            val result = submitInteractor.submitUnstake(
-                netuid = netuid,
-                hotkey = hotkeyBytes,
-                amountInPlanks = planks,
-            )
             _submitting.value = false
-            result.fold(
-                onSuccess = { dashboardRouter.returnToStakingDashboard() },
-                onFailure = { error ->
-                    val message = error.localizedMessage
-                        ?: resourceManager.getString(R.string.subtensor_setup_submit_failed)
-                    toastEvents.value = Event(message)
-                },
+            router.openSubtensorUnstakeConfirm(
+                SubtensorUnstakeConfirmPayload(
+                    netuid = netuid,
+                    hotkeyAddress = hotkeyAddress,
+                    validatorIdentity = _identity.value,
+                    amountInPlanks = planks,
+                    positionPlanks = positionPlanks,
+                    fee = mapFeeToParcel(fee),
+                )
             )
         }
     }
 
-    private fun formatValidatorLabel(): String =
-        if (hotkeyAddress.length <= 10) hotkeyAddress else "${hotkeyAddress.take(6)}…${hotkeyAddress.takeLast(4)}"
+    private fun buildTargetModel(identity: String?, identicon: Drawable?): StakingTargetModel {
+        val short = if (hotkeyAddress.length <= 10) hotkeyAddress
+        else "${hotkeyAddress.take(6)}...${hotkeyAddress.takeLast(4)}"
+        val name = identity?.takeIf { it.isNotBlank() }
+        // iOS: when identity resolves, the subtitle drops away — only the
+        // name + identicon remain. The hotkey is still discoverable via the
+        // chevron tap on the row. Match that here.
+        val title = name ?: short
+        val iconModel = identicon?.let { StakingTargetModel.TargetIcon.Icon(it.asIcon()) }
+        return StakingTargetModel(title = title, subtitle = null, icon = iconModel)
+    }
 
     private fun formatPosition(precision: Int): String {
         val tao = positionPlanks.toBigDecimal().movePointLeft(precision)
-        val symbol = if (isRoot) "TAO" else "α"
-        return "%.4f %s".format(tao, symbol)
+        // iOS uses the subnet identifier ("SN56") as the alpha-token ticker,
+        // not the alpha glyph (α). Switching here aligns Position / Max
+        // labels with the chip in the amount input.
+        return "%.4f %s".format(tao, ticker)
+    }
+
+    private fun formatMaxLabel(precision: Int): String {
+        // Returns just the value ("0.4659 SN56") — MaxAmountView prepends a
+        // blue "Max:" label of its own, matching the canonical Nova flows.
+        val tao = positionPlanks.toBigDecimal().movePointLeft(precision)
+        return "%.4f %s".format(tao, ticker)
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/di/SubtensorUnstakeSetupComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/di/SubtensorUnstakeSetupComponent.kt
@@ -1,0 +1,29 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.di
+
+import androidx.fragment.app.Fragment
+import dagger.BindsInstance
+import dagger.Subcomponent
+import io.novafoundation.nova.common.di.scope.ScreenScope
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.SubtensorUnstakeSetupFragment
+import java.math.BigInteger
+
+@Subcomponent(
+    modules = [
+        SubtensorUnstakeSetupModule::class,
+    ],
+)
+@ScreenScope
+interface SubtensorUnstakeSetupComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance fragment: Fragment,
+            @BindsInstance netuid: Int,
+            @BindsInstance hotkeyAddress: String,
+            @BindsInstance positionPlanks: BigInteger,
+        ): SubtensorUnstakeSetupComponent
+    }
+
+    fun inject(fragment: SubtensorUnstakeSetupFragment)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/di/SubtensorUnstakeSetupModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/di/SubtensorUnstakeSetupModule.kt
@@ -1,0 +1,70 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.di
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
+import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.common.resources.ResourceManager
+import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
+import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
+import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
+import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.SubtensorUnstakeSetupViewModel
+import java.math.BigInteger
+
+@Module(includes = [ViewModelModule::class])
+class SubtensorUnstakeSetupModule {
+
+    @Provides
+    fun provideUnstakeSubmitInteractor(
+        extrinsicService: ExtrinsicService,
+        stakingSharedState: StakingSharedState,
+        accountRepository: AccountRepository,
+        subnetFetcher: SubtensorSubnetFetcher,
+        positionCache: SubtensorPositionCache,
+    ): SubtensorStakeSubmitInteractor = SubtensorStakeSubmitInteractor(
+        extrinsicService = extrinsicService,
+        stakingSharedState = stakingSharedState,
+        accountRepository = accountRepository,
+        subnetFetcher = subnetFetcher,
+        positionCache = positionCache,
+    )
+
+    @Provides
+    @IntoMap
+    @ViewModelKey(SubtensorUnstakeSetupViewModel::class)
+    fun provideViewModel(
+        router: StakingRouter,
+        dashboardRouter: StakingDashboardRouter,
+        resourceManager: ResourceManager,
+        stakingSharedState: StakingSharedState,
+        submitInteractor: SubtensorStakeSubmitInteractor,
+        netuid: Int,
+        hotkeyAddress: String,
+        positionPlanks: BigInteger,
+    ): ViewModel = SubtensorUnstakeSetupViewModel(
+        router = router,
+        dashboardRouter = dashboardRouter,
+        resourceManager = resourceManager,
+        stakingSharedState = stakingSharedState,
+        submitInteractor = submitInteractor,
+        netuid = netuid,
+        hotkeyAddress = hotkeyAddress,
+        positionPlanks = positionPlanks,
+    )
+
+    @Provides
+    fun provideViewModelInstance(
+        fragment: Fragment,
+        viewModelFactory: ViewModelProvider.Factory,
+    ): SubtensorUnstakeSetupViewModel =
+        ViewModelProvider(fragment, viewModelFactory).get(SubtensorUnstakeSetupViewModel::class.java)
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/di/SubtensorUnstakeSetupModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/subtensor/unstake/setup/di/SubtensorUnstakeSetupModule.kt
@@ -6,37 +6,24 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import io.novafoundation.nova.common.address.AddressIconGenerator
 import io.novafoundation.nova.common.di.viewmodel.ViewModelKey
 import io.novafoundation.nova.common.di.viewmodel.ViewModelModule
+import io.novafoundation.nova.common.presentation.AssetIconProvider
 import io.novafoundation.nova.common.resources.ResourceManager
 import io.novafoundation.nova.feature_account_api.data.extrinsic.ExtrinsicService
-import io.novafoundation.nova.feature_account_api.domain.interfaces.AccountRepository
 import io.novafoundation.nova.feature_staking_impl.data.StakingSharedState
-import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorPositionCache
-import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorSubnetFetcher
-import io.novafoundation.nova.feature_staking_impl.domain.subtensor.SubtensorStakeSubmitInteractor
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.BittensorDelegatesClient
+import io.novafoundation.nova.feature_staking_impl.data.subtensor.network.SubtensorValidatorProvider
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingDashboardRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.StakingRouter
 import io.novafoundation.nova.feature_staking_impl.presentation.subtensor.unstake.setup.SubtensorUnstakeSetupViewModel
+import io.novafoundation.nova.feature_wallet_api.domain.ArbitraryTokenUseCase
+import io.novafoundation.nova.feature_wallet_api.presentation.mixin.fee.v2.FeeLoaderMixinV2
 import java.math.BigInteger
 
 @Module(includes = [ViewModelModule::class])
 class SubtensorUnstakeSetupModule {
-
-    @Provides
-    fun provideUnstakeSubmitInteractor(
-        extrinsicService: ExtrinsicService,
-        stakingSharedState: StakingSharedState,
-        accountRepository: AccountRepository,
-        subnetFetcher: SubtensorSubnetFetcher,
-        positionCache: SubtensorPositionCache,
-    ): SubtensorStakeSubmitInteractor = SubtensorStakeSubmitInteractor(
-        extrinsicService = extrinsicService,
-        stakingSharedState = stakingSharedState,
-        accountRepository = accountRepository,
-        subnetFetcher = subnetFetcher,
-        positionCache = positionCache,
-    )
 
     @Provides
     @IntoMap
@@ -46,7 +33,13 @@ class SubtensorUnstakeSetupModule {
         dashboardRouter: StakingDashboardRouter,
         resourceManager: ResourceManager,
         stakingSharedState: StakingSharedState,
-        submitInteractor: SubtensorStakeSubmitInteractor,
+        extrinsicService: ExtrinsicService,
+        delegatesClient: BittensorDelegatesClient,
+        validatorProvider: SubtensorValidatorProvider,
+        addressIconGenerator: AddressIconGenerator,
+        assetIconProvider: AssetIconProvider,
+        arbitraryTokenUseCase: ArbitraryTokenUseCase,
+        feeLoaderMixinFactory: FeeLoaderMixinV2.Factory,
         netuid: Int,
         hotkeyAddress: String,
         positionPlanks: BigInteger,
@@ -55,7 +48,13 @@ class SubtensorUnstakeSetupModule {
         dashboardRouter = dashboardRouter,
         resourceManager = resourceManager,
         stakingSharedState = stakingSharedState,
-        submitInteractor = submitInteractor,
+        extrinsicService = extrinsicService,
+        delegatesClient = delegatesClient,
+        validatorProvider = validatorProvider,
+        addressIconGenerator = addressIconGenerator,
+        assetIconProvider = assetIconProvider,
+        arbitraryTokenUseCase = arbitraryTokenUseCase,
+        feeLoaderMixinFactory = feeLoaderMixinFactory,
         netuid = netuid,
         hotkeyAddress = hotkeyAddress,
         positionPlanks = positionPlanks,

--- a/feature-staking-impl/src/main/res/drawable/bg_subtensor_stake_type_card.xml
+++ b/feature-staking-impl/src/main/res/drawable/bg_subtensor_stake_type_card.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/block_background" />
+            <stroke android:width="1dp" android:color="@color/button_text_accent" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/block_background" />
+        </shape>
+    </item>
+</selector>

--- a/feature-staking-impl/src/main/res/layout/bottom_sheet_subtensor_subnet_filter.xml
+++ b/feature-staking-impl/src/main/res/layout/bottom_sheet_subtensor_subnet_filter.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Mirrors iOS SubtensorSubnetFilterViewController: only the "Sort by:"
+     section, no "Show" toggles (iOS subnet picker has no per-subnet show
+     filters in v1). Two radios + Apply + Reset. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="16dp"
+    android:paddingTop="20dp"
+    android:paddingBottom="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/subtensor_validator_filter_title"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Body" />
+
+        <TextView
+            android:id="@+id/subtensorSubnetFilterReset"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="@string/common_reset"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Footnote"
+            android:textColor="@color/button_text_accent" />
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/subtensor_validator_filter_sort_by"
+        android:textAllCaps="true"
+        android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Caps2"
+        android:textColor="@color/text_secondary" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/bg_block_12"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="4dp">
+
+        <LinearLayout
+            android:id="@+id/subtensorSubnetFilterSortStakeRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:gravity="center_vertical"
+            android:minHeight="48dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/subtensor_subnet_filter_sort_total_stake"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body" />
+
+            <RadioButton
+                android:id="@+id/subtensorSubnetFilterSortStakeRadio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:focusable="false" />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/container_border" />
+
+        <LinearLayout
+            android:id="@+id/subtensorSubnetFilterSortNetuidRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:gravity="center_vertical"
+            android:minHeight="48dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/subtensor_subnet_filter_sort_netuid"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body" />
+
+            <RadioButton
+                android:id="@+id/subtensorSubnetFilterSortNetuidRadio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:focusable="false" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <io.novafoundation.nova.common.view.PrimaryButton
+        android:id="@+id/subtensorSubnetFilterApply"
+        style="@style/Widget.Nova.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/common_apply" />
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/bottom_sheet_subtensor_validator_filter.xml
+++ b/feature-staking-impl/src/main/res/layout/bottom_sheet_subtensor_validator_filter.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Mirrors iOS SubtensorValidatorFilterViewController:
+     "Show" section with two switches, "Sort by:" section with two radios,
+     Apply button at the bottom. Reset action lives in the toolbar. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="16dp"
+    android:paddingTop="20dp"
+    android:paddingBottom="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/subtensor_validator_filter_title"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Body" />
+
+        <TextView
+            android:id="@+id/subtensorValidatorFilterReset"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="@string/common_reset"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Footnote"
+            android:textColor="@color/button_text_accent" />
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/subtensor_validator_filter_show"
+        android:textAllCaps="true"
+        android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Caps2"
+        android:textColor="@color/text_secondary" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/bg_block_12"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="4dp">
+
+        <LinearLayout
+            android:id="@+id/subtensorValidatorFilterIdentityRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:gravity="center_vertical"
+            android:minHeight="48dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/subtensor_validator_filter_identity"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/subtensorValidatorFilterIdentitySwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:focusable="false" />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/container_border" />
+
+        <LinearLayout
+            android:id="@+id/subtensorValidatorFilterCommissionRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:gravity="center_vertical"
+            android:minHeight="48dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/subtensor_validator_filter_hide_max_commission"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/subtensorValidatorFilterCommissionSwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:focusable="false" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:text="@string/subtensor_validator_filter_sort_by"
+        android:textAllCaps="true"
+        android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Caps2"
+        android:textColor="@color/text_secondary" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/bg_block_12"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="4dp">
+
+        <LinearLayout
+            android:id="@+id/subtensorValidatorFilterSortAprRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:gravity="center_vertical"
+            android:minHeight="48dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/subtensor_validator_filter_sort_apr"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body" />
+
+            <RadioButton
+                android:id="@+id/subtensorValidatorFilterSortAprRadio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:focusable="false" />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/container_border" />
+
+        <LinearLayout
+            android:id="@+id/subtensorValidatorFilterSortStakeRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:gravity="center_vertical"
+            android:minHeight="48dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/subtensor_validator_filter_sort_total_stake"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body" />
+
+            <RadioButton
+                android:id="@+id/subtensorValidatorFilterSortStakeRadio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:focusable="false" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <io.novafoundation.nova.common.view.PrimaryButton
+        android:id="@+id/subtensorValidatorFilterApply"
+        style="@style/Widget.Nova.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/common_apply" />
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_confirm.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_confirm.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:background="@color/secondary_screen_background">
+
+    <io.novafoundation.nova.common.view.Toolbar
+        android:id="@+id/subtensorStakeConfirmToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:dividerVisible="false"
+        app:titleText="@string/common_confirm_title" />
+
+    <io.novafoundation.nova.feature_wallet_api.presentation.view.amount.PrimaryAmountView
+        android:id="@+id/subtensorStakeConfirmAmount"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="16dp" />
+
+    <io.novafoundation.nova.feature_wallet_api.presentation.view.extrinsic.GenericExtrinsicInformationView
+        android:id="@+id/subtensorStakeConfirmExtrinsicInformation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="24dp" />
+
+    <io.novafoundation.nova.common.view.TableView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp">
+
+        <io.novafoundation.nova.common.view.TableCellView
+            android:id="@+id/subtensorStakeConfirmValidator"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="@string/subtensor_setup_validator_label" />
+    </io.novafoundation.nova.common.view.TableView>
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <io.novafoundation.nova.common.view.PrimaryButton
+        android:id="@+id/subtensorStakeConfirmConfirm"
+        style="@style/Widget.Nova.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/common_confirm" />
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_confirm.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_confirm.xml
@@ -26,7 +26,32 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="24dp" />
+        android:layout_marginTop="24dp">
+
+        <!-- Nova Wallet service-fee row, added as a cell INSIDE the extrinsic-info
+             table so it sits in the same card directly beneath the network-fee row.
+             TableView lays out + dividers all its children uniformly, so no margins
+             or own divider here. Subnet only + recipient set; hidden today
+             (NOVA_FEE_RECIPIENT == null). -->
+        <io.novafoundation.nova.feature_wallet_api.presentation.view.FeeView
+            android:id="@+id/subtensorStakeConfirmNovaFee"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:title="@string/subtensor_setup_nova_fee_label" />
+
+    </io.novafoundation.nova.feature_wallet_api.presentation.view.extrinsic.GenericExtrinsicInformationView>
+
+    <TextView
+        android:id="@+id/subtensorStakeConfirmNovaFeeDisclaimer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1"
+        android:textColor="@color/text_secondary"
+        android:visibility="gone" />
 
     <io.novafoundation.nova.common.view.TableView
         android:layout_width="match_parent"

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_setup.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_setup.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/secondary_screen_background">
+
+    <io.novafoundation.nova.common.view.Toolbar
+        android:id="@+id/subtensorStakeSetupToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        app:contentBackground="@android:color/transparent"
+        app:dividerVisible="false"
+        app:layout_constraintTop_toTopOf="parent"
+        app:titleText="@string/subtensor_staking_title" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/subtensorStakeSetupToolbar"
+        app:layout_constraintBottom_toTopOf="@id/subtensorStakeSetupContinue">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/subtensor_setup_validator_label"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                android:textColor="@color/text_secondary" />
+
+            <LinearLayout
+                android:id="@+id/subtensorStakeSetupValidator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:padding="16dp"
+                android:background="@drawable/bg_block_12"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/subtensorStakeSetupValidatorLabel"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/subtensor_setup_select_validator"
+                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
+                    android:textColor="@color/text_secondary" />
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_chevron_right"
+                    app:tint="@color/text_secondary"
+                    android:contentDescription="@null" />
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="@string/subtensor_setup_amount_label"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                android:textColor="@color/text_secondary" />
+
+            <EditText
+                android:id="@+id/subtensorStakeSetupAmount"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:padding="16dp"
+                android:background="@drawable/bg_block_12"
+                android:hint="@string/subtensor_setup_amount_placeholder"
+                android:inputType="numberDecimal"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
+                android:textColor="@color/text_primary"
+                android:textColorHint="@color/text_secondary"
+                android:textCursorDrawable="@null"
+                tools:hint="0.00" />
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <io.novafoundation.nova.common.view.PrimaryButton
+        android:id="@+id/subtensorStakeSetupContinue"
+        style="@style/Widget.Nova.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="16dp"
+        android:enabled="false"
+        android:text="@string/common_continue"
+        app:layout_constraintBottom_toBottomOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_setup.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_setup.xml
@@ -1,29 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/secondary_screen_background">
+    android:orientation="vertical"
+    tools:background="@color/secondary_screen_background">
 
     <io.novafoundation.nova.common.view.Toolbar
         android:id="@+id/subtensorStakeSetupToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@android:color/transparent"
-        app:contentBackground="@android:color/transparent"
         app:dividerVisible="false"
-        app:layout_constraintTop_toTopOf="parent"
-        app:titleText="@string/subtensor_staking_title" />
+        app:titleText="@string/subtensor_stake_more" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:fillViewport="true"
-        android:paddingHorizontal="16dp"
-        android:paddingTop="8dp"
-        app:layout_constraintTop_toBottomOf="@id/subtensorStakeSetupToolbar"
-        app:layout_constraintBottom_toTopOf="@id/subtensorStakeSetupContinue">
+        android:layout_weight="1"
+        android:fillViewport="true">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -33,60 +28,45 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
                 android:text="@string/subtensor_setup_validator_label"
                 android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
                 android:textColor="@color/text_secondary" />
 
-            <LinearLayout
+            <io.novafoundation.nova.feature_staking_impl.presentation.view.stakingTarget.StakingTargetView
                 android:id="@+id/subtensorStakeSetupValidator"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
                 android:layout_marginTop="8dp"
-                android:padding="16dp"
-                android:background="@drawable/bg_block_12"
-                android:clickable="true"
-                android:focusable="true"
-                android:gravity="center_vertical">
+                android:layout_marginEnd="16dp" />
 
-                <TextView
-                    android:id="@+id/subtensorStakeSetupValidatorLabel"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/subtensor_setup_select_validator"
-                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
-                    android:textColor="@color/text_secondary" />
-
-                <ImageView
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:src="@drawable/ic_chevron_right"
-                    app:tint="@color/text_secondary"
-                    android:contentDescription="@null" />
-            </LinearLayout>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="@string/subtensor_setup_amount_label"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
-                android:textColor="@color/text_secondary" />
-
-            <EditText
+            <io.novafoundation.nova.feature_wallet_api.presentation.view.amount.ChooseAmountView
                 android:id="@+id/subtensorStakeSetupAmount"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:padding="16dp"
-                android:background="@drawable/bg_block_12"
-                android:hint="@string/subtensor_setup_amount_placeholder"
-                android:inputType="numberDecimal"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
-                android:textColor="@color/text_primary"
-                android:textColorHint="@color/text_secondary"
-                android:textCursorDrawable="@null"
-                tools:hint="0.00" />
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp" />
+
+            <io.novafoundation.nova.common.view.TableCellView
+                android:id="@+id/subtensorStakeSetupMinStake"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="16dp"
+                app:dividerVisible="false"
+                app:title="@string/subtensor_setup_min_stake_label" />
+
+            <io.novafoundation.nova.feature_wallet_api.presentation.view.FeeView
+                android:id="@+id/subtensorStakeSetupFee"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                app:dividerVisible="false" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 
@@ -98,6 +78,5 @@
         android:layout_marginHorizontal="16dp"
         android:layout_marginBottom="16dp"
         android:enabled="false"
-        android:text="@string/common_continue"
-        app:layout_constraintBottom_toBottomOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:text="@string/common_continue" />
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_setup.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_setup.xml
@@ -67,6 +67,29 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 app:dividerVisible="false" />
+
+            <!-- Nova Wallet service-fee disclosure (subnet only, recipient set).
+                 Hidden today since NOVA_FEE_RECIPIENT == null. -->
+            <io.novafoundation.nova.feature_wallet_api.presentation.view.FeeView
+                android:id="@+id/subtensorStakeSetupNovaFee"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:visibility="gone"
+                app:dividerVisible="false"
+                app:title="@string/subtensor_setup_nova_fee_label" />
+
+            <TextView
+                android:id="@+id/subtensorStakeSetupNovaFeeDisclaimer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1"
+                android:textColor="@color/text_secondary"
+                android:visibility="gone" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_type.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_stake_type.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/secondary_screen_background">
+
+    <io.novafoundation.nova.common.view.Toolbar
+        android:id="@+id/subtensorStakeTypeToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        app:contentBackground="@android:color/transparent"
+        app:dividerVisible="false"
+        app:layout_constraintTop_toTopOf="parent"
+        app:titleText="@string/subtensor_stake_type_title" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/subtensorStakeTypeToolbar"
+        app:layout_constraintBottom_toTopOf="@id/subtensorStakeTypeContinue">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:id="@+id/subtensorStakeTypeRootCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_subtensor_stake_type_card"
+                android:clickable="true"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="140dp"
+                    android:layout_height="107dp"
+                    android:layout_gravity="end|top"
+                    android:src="@drawable/ic_direct_staking_banner_picture"
+                    android:scaleType="fitCenter"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="16dp">
+
+                    <RadioButton
+                        android:id="@+id/subtensorStakeTypeRootRadio"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:clickable="false"
+                        android:focusable="false"
+                        android:checked="true"
+                        android:buttonTint="@color/button_text_accent" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:layout_weight="1"
+                        android:layout_marginStart="12dp"
+                        android:layout_marginEnd="96dp">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/subtensor_stake_type_root_title"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Bold.Title3"
+                            android:textColor="@color/text_primary" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:text="@string/subtensor_stake_type_root_details"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                            android:textColor="@color/text_secondary"
+                            android:lineSpacingExtra="2dp" />
+                    </LinearLayout>
+                </LinearLayout>
+            </FrameLayout>
+
+            <FrameLayout
+                android:id="@+id/subtensorStakeTypeSubnetCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:background="@drawable/bg_subtensor_stake_type_card"
+                android:clickable="true"
+                android:focusable="true">
+
+                <ImageView
+                    android:layout_width="140dp"
+                    android:layout_height="107dp"
+                    android:layout_gravity="end|top"
+                    android:src="@drawable/ic_pool_staking_banner_picture"
+                    android:scaleType="fitCenter"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="16dp">
+
+                    <RadioButton
+                        android:id="@+id/subtensorStakeTypeSubnetRadio"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:clickable="false"
+                        android:focusable="false"
+                        android:buttonTint="@color/button_text_accent" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:layout_weight="1"
+                        android:layout_marginStart="12dp"
+                        android:layout_marginEnd="96dp">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/subtensor_stake_type_subnet_title"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Bold.Title3"
+                            android:textColor="@color/text_primary" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:text="@string/subtensor_stake_type_subnet_details"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                            android:textColor="@color/text_secondary"
+                            android:lineSpacingExtra="2dp" />
+                    </LinearLayout>
+                </LinearLayout>
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/subtensorStakeTypeWikiFooter"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                android:textColor="@color/text_secondary"
+                tools:text="Find out more about Root and Subnet staking over at the Nova Wiki >" />
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <io.novafoundation.nova.common.view.PrimaryButton
+        android:id="@+id/subtensorStakeTypeContinue"
+        style="@style/Widget.Nova.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/common_continue"
+        app:layout_constraintBottom_toBottomOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_staking.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_staking.xml
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Background gets swapped dynamically in SubtensorStakingFragment.renderState:
+     gradient for the populated detail state (matches the rest of Nova),
+     solid black for the empty/landing state (matches AZERO landing). -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/subtensorRoot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/drawable_background_image">
 
+    <!-- Toolbar matches the canonical StartStakingLanding (close icon, no
+         title) so the empty/landing state visually mirrors the AZERO etc.
+         landings. The detail content (when there's an active stake) wires
+         the title text dynamically in the Fragment. -->
     <io.novafoundation.nova.common.view.Toolbar
         android:id="@+id/subtensorStakingToolbar"
         android:layout_width="match_parent"
@@ -13,8 +21,8 @@
         android:background="@android:color/transparent"
         app:contentBackground="@android:color/transparent"
         app:dividerVisible="false"
-        app:layout_constraintTop_toTopOf="parent"
-        app:titleText="@string/subtensor_staking_title" />
+        app:homeButtonIcon="@drawable/ic_close"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/subtensorScroll"
@@ -22,7 +30,7 @@
         android:layout_height="0dp"
         android:fillViewport="true"
         app:layout_constraintTop_toBottomOf="@id/subtensorStakingToolbar"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintBottom_toTopOf="@id/subtensorLandingBottomContainer">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -40,30 +48,117 @@
                 android:layout_marginTop="48dp"
                 android:visibility="gone" />
 
+            <!-- iOS-parity gold landing. Replaces the prior "No active stakes"
+                 empty card. Mirrors the bullets, copy and accent colour of
+                 `StartStakingInfoSubtensorPresenter`. The Start CTA + balance
+                 are pinned to the bottom of the screen via a sibling
+                 container outside the scroll view (see below). -->
             <LinearLayout
                 android:id="@+id/subtensorEmptyState"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:gravity="center_horizontal"
-                android:paddingTop="64dp"
+                android:paddingTop="24dp"
                 android:visibility="gone"
                 tools:visibility="visible">
 
                 <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/subtensor_no_active_stakes"
-                    android:textAppearance="@style/TextAppearance.NovaFoundation.Bold.Title3" />
-
-                <TextView
+                    android:id="@+id/subtensorLandingTitle"
+                    style="@style/TextAppearance.NovaFoundation.Bold.Title1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:gravity="center_horizontal"
-                    android:text="@string/subtensor_no_active_stakes_message"
-                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline"
-                    android:textColor="@color/text_secondary" />
+                    android:gravity="center"
+                    android:textColor="@color/text_primary"
+                    tools:text="Earn up to 20.01%\non your TAO tokens\nper year" />
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp">
+
+                    <ImageView
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:src="@drawable/ic_stake_anytime" />
+
+                    <TextView
+                        android:id="@+id/subtensorLandingBulletStake"
+                        style="@style/TextAppearance.NovaFoundation.SemiBold.Title3"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="48dp"
+                        android:textColor="@color/text_primary"
+                        tools:text="Stake anytime with as little as 0.01 TAO. Your stake will actively earn rewards in 1 minute" />
+                </FrameLayout>
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp">
+
+                    <ImageView
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:src="@drawable/ic_unstake_anytime" />
+
+                    <TextView
+                        style="@style/TextAppearance.NovaFoundation.SemiBold.Title3"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="48dp"
+                        android:text="@string/subtensor_landing_unstake_condition"
+                        android:textColor="@color/text_primary" />
+                </FrameLayout>
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp">
+
+                    <ImageView
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:src="@drawable/ic_rewards" />
+
+                    <TextView
+                        android:id="@+id/subtensorLandingBulletRewards"
+                        style="@style/TextAppearance.NovaFoundation.SemiBold.Title3"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="48dp"
+                        android:textColor="@color/text_primary"
+                        tools:text="Rewards accrue every 1 hour and added back to the stake" />
+                </FrameLayout>
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp">
+
+                    <ImageView
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:src="@drawable/ic_monitor_your_stake" />
+
+                    <TextView
+                        android:id="@+id/subtensorLandingBulletMonitor"
+                        style="@style/TextAppearance.NovaFoundation.SemiBold.Title3"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="48dp"
+                        android:textColor="@color/text_primary"
+                        tools:text="Rewards and staking status vary over time. Monitor your stake from time to time" />
+                </FrameLayout>
+
+                <TextView
+                    android:id="@+id/subtensorLandingMoreInfo"
+                    style="@style/TextAppearance.NovaFoundation.Regular.SubHeadline"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="32dp"
+                    android:gravity="center"
+                    android:textColor="@color/text_secondary"
+                    tools:text="Find out more information about Bittensor staking over at the Nova Wiki ›" />
             </LinearLayout>
 
             <LinearLayout
@@ -287,5 +382,41 @@
             </LinearLayout>
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
+
+    <!-- Bottom container for the landing CTA. Only visible while the empty
+         state is on screen — once a position loads, the scroll view takes
+         the full height again. Mirrors fragment_start_staking_landing.xml. -->
+    <LinearLayout
+        android:id="@+id/subtensorLandingBottomContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_bottom_button_container"
+        android:orientation="vertical"
+        android:paddingHorizontal="17dp"
+        android:paddingTop="16dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible">
+
+        <io.novafoundation.nova.common.view.PrimaryButton
+            android:id="@+id/subtensorLandingStartButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/subtensor_landing_start_staking" />
+
+        <TextView
+            android:id="@+id/subtensorLandingAvailableBalance"
+            style="@style/TextAppearance.NovaFoundation.Regular.SubHeadline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="24dp"
+            android:gravity="center"
+            android:textColor="@color/text_secondary"
+            tools:text="Available balance: 0.0373 TAO" />
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_staking.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_staking.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/drawable_background_image">
+
+    <io.novafoundation.nova.common.view.Toolbar
+        android:id="@+id/subtensorStakingToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        app:contentBackground="@android:color/transparent"
+        app:dividerVisible="false"
+        app:layout_constraintTop_toTopOf="parent"
+        app:titleText="@string/subtensor_staking_title" />
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/subtensorScroll"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@id/subtensorStakingToolbar"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="16dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="32dp">
+
+            <ProgressBar
+                android:id="@+id/subtensorLoading"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginTop="48dp"
+                android:visibility="gone" />
+
+            <LinearLayout
+                android:id="@+id/subtensorEmptyState"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center_horizontal"
+                android:paddingTop="64dp"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/subtensor_no_active_stakes"
+                    android:textAppearance="@style/TextAppearance.NovaFoundation.Bold.Title3" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_horizontal"
+                    android:text="@string/subtensor_no_active_stakes_message"
+                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline"
+                    android:textColor="@color/text_secondary" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/subtensorContent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <!-- Your stake card — amount + SN# badge on the same line, mirrors iOS SubtensorStakeAmountsView -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:gravity="center_horizontal"
+                    android:padding="20dp"
+                    android:background="@drawable/bg_block_12">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/subtensor_your_stake"
+                        android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline"
+                        android:textColor="@color/text_secondary" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:id="@+id/subtensorTotalStakeAmount"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Bold.Title3"
+                            tools:text="0.3031 α" />
+
+                        <TextView
+                            android:id="@+id/subtensorTotalStakeBadge"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+                            android:visibility="gone"
+                            tools:text="SN8"
+                            tools:visibility="visible" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <!-- Stake more / Unstake action card — mirrors iOS actionsTable -->
+                <LinearLayout
+                    android:id="@+id/subtensorActionsCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginTop="12dp"
+                    android:background="@drawable/bg_block_12">
+
+                    <LinearLayout
+                        android:id="@+id/subtensorStakeMore"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingHorizontal="16dp"
+                        android:paddingVertical="14dp"
+                        android:background="?attr/selectableItemBackground"
+                        android:clickable="true"
+                        android:focusable="true">
+
+                        <ImageView
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:src="@drawable/ic_add_circle_outline"
+                            app:tint="@color/icon_secondary" />
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_marginStart="12dp"
+                            android:text="@string/subtensor_stake_more"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline" />
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            android:src="@drawable/ic_chevron_right"
+                            app:tint="@color/icon_secondary" />
+                    </LinearLayout>
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="0.5dp"
+                        android:layout_marginHorizontal="16dp"
+                        android:background="@color/divider" />
+
+                    <LinearLayout
+                        android:id="@+id/subtensorUnstake"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingHorizontal="16dp"
+                        android:paddingVertical="14dp"
+                        android:background="?attr/selectableItemBackground"
+                        android:clickable="true"
+                        android:focusable="true">
+
+                        <ImageView
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:src="@drawable/ic_minus_circle_outline"
+                            app:tint="@color/icon_secondary" />
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_marginStart="12dp"
+                            android:text="@string/subtensor_unstake"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline" />
+
+                        <ImageView
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            android:src="@drawable/ic_chevron_right"
+                            app:tint="@color/icon_secondary" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <!-- Your validator(s) card -->
+                <LinearLayout
+                    android:id="@+id/subtensorValidatorCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginTop="12dp"
+                    android:padding="14dp"
+                    android:background="@drawable/bg_block_12"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <TextView
+                        android:id="@+id/subtensorValidatorTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline"
+                        android:textColor="@color/text_secondary"
+                        tools:text="Your validator" />
+
+                    <LinearLayout
+                        android:id="@+id/subtensorValidatorRows"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:layout_marginTop="4dp" />
+                </LinearLayout>
+
+                <!-- Staking info -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginTop="12dp"
+                    android:padding="16dp"
+                    android:background="@drawable/bg_block_12">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/subtensor_staking_info"
+                        android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline"
+                        android:textColor="@color/text_secondary" />
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginTop="12dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/subtensor_minimum_stake"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline" />
+
+                        <TextView
+                            android:id="@+id/subtensorMinStake"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
+                            tools:text="0.01 TAO" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginTop="8dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/subtensor_unstaking_period"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline" />
+
+                        <TextView
+                            android:id="@+id/subtensorUnstakingPeriod"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/subtensor_unstaking_period_instant"
+                            android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline" />
+                    </LinearLayout>
+                </LinearLayout>
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_subnet_picker.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_subnet_picker.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/secondary_screen_background">
+
+    <io.novafoundation.nova.common.view.Toolbar
+        android:id="@+id/subtensorSubnetPickerToolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:dividerVisible="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:titleText="@string/subtensor_subnet_picker_title" />
+
+    <ProgressBar
+        android:id="@+id/subtensorSubnetPickerProgress"
+        style="@style/Widget.Nova.ProgressBar.Indeterminate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerToolbar"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/subtensorSubnetPickerEmpty"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:gravity="center"
+        android:paddingHorizontal="32dp"
+        android:text="@string/subtensor_subnet_picker_empty"
+        android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline.Secondary"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerToolbar" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerToolbar">
+
+        <LinearLayout
+            android:id="@+id/subtensorSubnetPickerList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_block_12"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_subnet_picker.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_subnet_picker.xml
@@ -16,6 +16,19 @@
         app:layout_constraintTop_toTopOf="parent"
         app:titleText="@string/subtensor_subnet_picker_title" />
 
+    <io.novafoundation.nova.common.view.SearchView
+        android:id="@+id/subtensorSubnetPickerSearch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:hint="@string/common_search"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerToolbar"
+        tools:visibility="visible" />
+
     <ProgressBar
         android:id="@+id/subtensorSubnetPickerProgress"
         style="@style/Widget.Nova.ProgressBar.Indeterminate"
@@ -25,7 +38,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerToolbar"
+        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerSearch"
         tools:visibility="visible" />
 
     <TextView
@@ -40,7 +53,7 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerToolbar" />
+        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerSearch" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
@@ -52,13 +65,12 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerToolbar">
+        app:layout_constraintTop_toBottomOf="@id/subtensorSubnetPickerSearch">
 
         <LinearLayout
             android:id="@+id/subtensorSubnetPickerList"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/bg_block_12"
             android:orientation="vertical"
             android:visibility="gone"
             tools:visibility="visible" />

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_confirm.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_confirm.xml
@@ -26,7 +26,32 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="24dp" />
+        android:layout_marginTop="24dp">
+
+        <!-- Nova Wallet service-fee row, added as a cell INSIDE the extrinsic-info
+             table so it sits in the same card directly beneath the network-fee row.
+             TableView lays out + dividers all its children uniformly, so no margins
+             or own divider here. Subnet only + recipient set; hidden today
+             (NOVA_FEE_RECIPIENT == null). -->
+        <io.novafoundation.nova.feature_wallet_api.presentation.view.FeeView
+            android:id="@+id/subtensorUnstakeConfirmNovaFee"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:title="@string/subtensor_setup_nova_fee_label" />
+
+    </io.novafoundation.nova.feature_wallet_api.presentation.view.extrinsic.GenericExtrinsicInformationView>
+
+    <TextView
+        android:id="@+id/subtensorUnstakeConfirmNovaFeeDisclaimer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1"
+        android:textColor="@color/text_secondary"
+        android:visibility="gone" />
 
     <io.novafoundation.nova.common.view.TableView
         android:layout_width="match_parent"

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_confirm.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_confirm.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:background="@color/secondary_screen_background">
+
+    <io.novafoundation.nova.common.view.Toolbar
+        android:id="@+id/subtensorUnstakeConfirmToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:dividerVisible="false"
+        app:titleText="@string/subtensor_unstake" />
+
+    <io.novafoundation.nova.feature_wallet_api.presentation.view.amount.PrimaryAmountView
+        android:id="@+id/subtensorUnstakeConfirmAmount"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="16dp" />
+
+    <io.novafoundation.nova.feature_wallet_api.presentation.view.extrinsic.GenericExtrinsicInformationView
+        android:id="@+id/subtensorUnstakeConfirmExtrinsicInformation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="24dp" />
+
+    <io.novafoundation.nova.common.view.TableView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp">
+
+        <io.novafoundation.nova.common.view.TableCellView
+            android:id="@+id/subtensorUnstakeConfirmValidator"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="@string/subtensor_setup_validator_label" />
+
+        <io.novafoundation.nova.common.view.TableCellView
+            android:id="@+id/subtensorUnstakeConfirmReceive"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:title="@string/subtensor_unstake_youll_receive"
+            tools:visibility="visible" />
+    </io.novafoundation.nova.common.view.TableView>
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <io.novafoundation.nova.common.view.PrimaryButton
+        android:id="@+id/subtensorUnstakeConfirmConfirm"
+        style="@style/Widget.Nova.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/common_confirm" />
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_setup.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_setup.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/secondary_screen_background">
+
+    <io.novafoundation.nova.common.view.Toolbar
+        android:id="@+id/subtensorUnstakeSetupToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        app:contentBackground="@android:color/transparent"
+        app:dividerVisible="false"
+        app:layout_constraintTop_toTopOf="parent"
+        app:titleText="@string/subtensor_unstake" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/subtensorUnstakeSetupToolbar"
+        app:layout_constraintBottom_toTopOf="@id/subtensorUnstakeSetupContinue">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/subtensor_setup_validator_label"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                android:textColor="@color/text_secondary" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:padding="16dp"
+                android:background="@drawable/bg_block_12"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/subtensorUnstakeSetupValidator"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
+                    android:textColor="@color/text_primary"
+                    tools:text="5GgYg…XEm9zT" />
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="@string/subtensor_unstake_position_label"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                android:textColor="@color/text_secondary" />
+
+            <TextView
+                android:id="@+id/subtensorUnstakeSetupPosition"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:padding="16dp"
+                android:background="@drawable/bg_block_12"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
+                android:textColor="@color/text_primary"
+                tools:text="10.0000 TAO" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="@string/subtensor_setup_amount_label"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                android:textColor="@color/text_secondary" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:background="@drawable/bg_block_12"
+                android:orientation="horizontal"
+                android:paddingHorizontal="16dp"
+                android:gravity="center_vertical">
+
+                <EditText
+                    android:id="@+id/subtensorUnstakeSetupAmount"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="@android:color/transparent"
+                    android:hint="@string/subtensor_setup_amount_placeholder"
+                    android:inputType="numberDecimal"
+                    android:paddingVertical="16dp"
+                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
+                    android:textColor="@color/text_primary"
+                    android:textColorHint="@color/text_secondary"
+                    android:textCursorDrawable="@null"
+                    tools:hint="0.00" />
+
+                <TextView
+                    android:id="@+id/subtensorUnstakeSetupMax"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackground"
+                    android:padding="8dp"
+                    android:text="@string/subtensor_unstake_max"
+                    android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Caption1"
+                    android:textColor="@color/button_text_accent" />
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <io.novafoundation.nova.common.view.PrimaryButton
+        android:id="@+id/subtensorUnstakeSetupContinue"
+        style="@style/Widget.Nova.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="16dp"
+        android:enabled="false"
+        android:text="@string/common_continue"
+        app:layout_constraintBottom_toBottomOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_setup.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_setup.xml
@@ -104,6 +104,29 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 app:dividerVisible="false" />
+
+            <!-- Nova Wallet service-fee disclosure (subnet only, recipient set).
+                 Hidden today since NOVA_FEE_RECIPIENT == null. -->
+            <io.novafoundation.nova.feature_wallet_api.presentation.view.FeeView
+                android:id="@+id/subtensorUnstakeSetupNovaFee"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:visibility="gone"
+                app:dividerVisible="false"
+                app:title="@string/subtensor_setup_nova_fee_label" />
+
+            <TextView
+                android:id="@+id/subtensorUnstakeSetupNovaFeeDisclaimer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1"
+                android:textColor="@color/text_secondary"
+                android:visibility="gone" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_setup.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_unstake_setup.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<!-- Mirrors iOS SubtensorUnstakeSetupViewLayout: validator (read-only,
+     pre-filled from position) + amount header w/ Max + amount input +
+     Position row + NetworkFeeView + Continue. Validator slot uses Nova's
+     StakingTargetView for visual parity with the stake-side flow. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/secondary_screen_background">
+    android:orientation="vertical"
+    tools:background="@color/secondary_screen_background">
 
     <io.novafoundation.nova.common.view.Toolbar
         android:id="@+id/subtensorUnstakeSetupToolbar"
@@ -13,17 +18,13 @@
         android:background="@android:color/transparent"
         app:contentBackground="@android:color/transparent"
         app:dividerVisible="false"
-        app:layout_constraintTop_toTopOf="parent"
         app:titleText="@string/subtensor_unstake" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:fillViewport="true"
-        android:paddingHorizontal="16dp"
-        android:paddingTop="8dp"
-        app:layout_constraintTop_toBottomOf="@id/subtensorUnstakeSetupToolbar"
-        app:layout_constraintBottom_toTopOf="@id/subtensorUnstakeSetupContinue">
+        android:layout_weight="1"
+        android:fillViewport="true">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -33,89 +34,76 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
                 android:text="@string/subtensor_setup_validator_label"
                 android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
                 android:textColor="@color/text_secondary" />
 
+            <io.novafoundation.nova.feature_staking_impl.presentation.view.stakingTarget.StakingTargetView
+                android:id="@+id/subtensorUnstakeSetupValidator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp" />
+
+            <!-- Amount header: title left, "Max: 0.30 SN8" tappable right -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:padding="16dp"
-                android:background="@drawable/bg_block_12"
-                android:gravity="center_vertical">
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="16dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
                 <TextView
-                    android:id="@+id/subtensorUnstakeSetupValidator"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
-                    android:textColor="@color/text_primary"
-                    tools:text="5GgYg…XEm9zT" />
-            </LinearLayout>
+                    android:text="@string/subtensor_setup_amount_label"
+                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                    android:textColor="@color/text_secondary" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="@string/subtensor_unstake_position_label"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
-                android:textColor="@color/text_secondary" />
-
-            <TextView
-                android:id="@+id/subtensorUnstakeSetupPosition"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:padding="16dp"
-                android:background="@drawable/bg_block_12"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
-                android:textColor="@color/text_primary"
-                tools:text="10.0000 TAO" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="@string/subtensor_setup_amount_label"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
-                android:textColor="@color/text_secondary" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:background="@drawable/bg_block_12"
-                android:orientation="horizontal"
-                android:paddingHorizontal="16dp"
-                android:gravity="center_vertical">
-
-                <EditText
-                    android:id="@+id/subtensorUnstakeSetupAmount"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:background="@android:color/transparent"
-                    android:hint="@string/subtensor_setup_amount_placeholder"
-                    android:inputType="numberDecimal"
-                    android:paddingVertical="16dp"
-                    android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Body"
-                    android:textColor="@color/text_primary"
-                    android:textColorHint="@color/text_secondary"
-                    android:textCursorDrawable="@null"
-                    tools:hint="0.00" />
-
-                <TextView
+                <!-- Canonical Nova widget: "Max" stays blue, the amount goes
+                     white — matches the AVAIL/USDT/etc. unstake screens. -->
+                <io.novafoundation.nova.feature_wallet_api.presentation.view.amount.MaxAmountView
                     android:id="@+id/subtensorUnstakeSetupMax"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="?selectableItemBackground"
-                    android:padding="8dp"
-                    android:text="@string/subtensor_unstake_max"
-                    android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.Caption1"
-                    android:textColor="@color/button_text_accent" />
+                    android:padding="4dp" />
             </LinearLayout>
+
+            <!-- Token chip (TAO icon + "SN56"/"TAO" ticker on left) + amount
+                 input (right-aligned) — same widget the canonical Nova
+                 stake/transfer flows use. Mirrors iOS amount field. -->
+            <io.novafoundation.nova.feature_wallet_api.presentation.view.amount.ChooseAmountInputView
+                android:id="@+id/subtensorUnstakeSetupAmountInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp" />
+
+            <io.novafoundation.nova.common.view.TableCellView
+                android:id="@+id/subtensorUnstakeSetupPosition"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="16dp"
+                app:dividerVisible="false"
+                app:title="@string/subtensor_unstake_position_label" />
+
+            <io.novafoundation.nova.feature_wallet_api.presentation.view.FeeView
+                android:id="@+id/subtensorUnstakeSetupFee"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                app:dividerVisible="false" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 
@@ -127,6 +115,5 @@
         android:layout_marginHorizontal="16dp"
         android:layout_marginBottom="16dp"
         android:enabled="false"
-        android:text="@string/common_continue"
-        app:layout_constraintBottom_toBottomOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:text="@string/common_continue" />
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_validator_picker.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_validator_picker.xml
@@ -16,6 +16,19 @@
         app:layout_constraintTop_toTopOf="parent"
         app:titleText="@string/subtensor_validator_picker_title" />
 
+    <io.novafoundation.nova.common.view.SearchView
+        android:id="@+id/subtensorValidatorPickerSearch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:hint="@string/common_search"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar"
+        tools:visibility="visible" />
+
     <ProgressBar
         android:id="@+id/subtensorValidatorPickerProgress"
         style="@style/Widget.Nova.ProgressBar.Indeterminate"
@@ -25,7 +38,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar"
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerSearch"
         tools:visibility="visible" />
 
     <TextView
@@ -40,7 +53,7 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar" />
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerSearch" />
 
     <TextView
         android:id="@+id/subtensorValidatorPickerError"
@@ -54,25 +67,22 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar" />
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerSearch" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:clipToPadding="false"
-        android:paddingHorizontal="16dp"
-        android:paddingTop="12dp"
         android:paddingBottom="32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar">
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerSearch">
 
         <LinearLayout
             android:id="@+id/subtensorValidatorPickerList"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/bg_block_12"
             android:orientation="vertical"
             android:visibility="gone"
             tools:visibility="visible" />

--- a/feature-staking-impl/src/main/res/layout/fragment_subtensor_validator_picker.xml
+++ b/feature-staking-impl/src/main/res/layout/fragment_subtensor_validator_picker.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/secondary_screen_background">
+
+    <io.novafoundation.nova.common.view.Toolbar
+        android:id="@+id/subtensorValidatorPickerToolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:dividerVisible="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:titleText="@string/subtensor_validator_picker_title" />
+
+    <ProgressBar
+        android:id="@+id/subtensorValidatorPickerProgress"
+        style="@style/Widget.Nova.ProgressBar.Indeterminate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/subtensorValidatorPickerEmpty"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:gravity="center"
+        android:paddingHorizontal="32dp"
+        android:text="@string/subtensor_validator_picker_empty"
+        android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline.Secondary"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar" />
+
+    <TextView
+        android:id="@+id/subtensorValidatorPickerError"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:gravity="center"
+        android:paddingHorizontal="32dp"
+        android:text="@string/subtensor_validator_picker_loading_failed"
+        android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.SubHeadline.Secondary"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtensorValidatorPickerToolbar">
+
+        <LinearLayout
+            android:id="@+id/subtensorValidatorPickerList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_block_12"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature-staking-impl/src/main/res/layout/item_subtensor_subnet_picker.xml
+++ b/feature-staking-impl/src/main/res/layout/item_subtensor_subnet_picker.xml
@@ -1,80 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Mirrors iOS SubtensorSubnetCell density:
+     [name (semibold subheadline)]              [TAO reserve]
+     [SN# (caption secondary)]                  [spot price (caption secondary)]
+     Each cell is its own rounded block_background card with 4dp gap above and below;
+     the picker container layers them vertically with no extra dividers. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?selectableItemBackground"
-    android:orientation="vertical">
+    android:layout_marginTop="4dp"
+    android:layout_marginBottom="4dp"
+    android:background="@drawable/bg_block_12"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="12dp">
 
     <LinearLayout
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical"
-        android:paddingHorizontal="16dp"
-        android:paddingVertical="14dp">
+        android:layout_weight="1"
+        android:orientation="vertical">
 
-        <LinearLayout
-            android:layout_width="0dp"
+        <TextView
+            android:id="@+id/subtensorSubnetPickerRowName"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
+            android:textColor="@color/text_primary"
+            tools:text="Apex" />
 
-            <TextView
-                android:id="@+id/subtensorSubnetPickerRowName"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
-                tools:text="Apex" />
-
-            <TextView
-                android:id="@+id/subtensorSubnetPickerRowNetuid"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
-                tools:text="SN1" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="wrap_content"
+        <TextView
+            android:id="@+id/subtensorSubnetPickerRowNetuid"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
-            android:gravity="end"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/subtensorSubnetPickerRowReserve"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
-                tools:text="42,103 TAO" />
-
-            <TextView
-                android:id="@+id/subtensorSubnetPickerRowPrice"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
-                tools:text="0.0182 TAO/α" />
-        </LinearLayout>
-
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:src="@drawable/ic_arrow_right"
-            app:tint="@color/icon_secondary" />
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+            tools:text="SN1" />
     </LinearLayout>
 
-    <View
-        android:id="@+id/subtensorSubnetPickerRowDivider"
-        android:layout_width="match_parent"
-        android:layout_height="0.5dp"
-        android:layout_marginStart="16dp"
-        android:background="@color/divider" />
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:gravity="end"
+        android:orientation="vertical">
 
+        <TextView
+            android:id="@+id/subtensorSubnetPickerRowReserve"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+            tools:text="42,103 TAO" />
+
+        <TextView
+            android:id="@+id/subtensorSubnetPickerRowPrice"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+            tools:text="0.0182 TAO/α" />
+    </LinearLayout>
+
+    <ImageView
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_marginStart="8dp"
+        android:src="@drawable/ic_arrow_right"
+        app:tint="@color/icon_secondary" />
 </LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/item_subtensor_subnet_picker.xml
+++ b/feature-staking-impl/src/main/res/layout/item_subtensor_subnet_picker.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="14dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/subtensorSubnetPickerRowName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
+                tools:text="Apex" />
+
+            <TextView
+                android:id="@+id/subtensorSubnetPickerRowNetuid"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+                tools:text="SN1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:gravity="end"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/subtensorSubnetPickerRowReserve"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+                tools:text="42,103 TAO" />
+
+            <TextView
+                android:id="@+id/subtensorSubnetPickerRowPrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+                tools:text="0.0182 TAO/α" />
+        </LinearLayout>
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:src="@drawable/ic_arrow_right"
+            app:tint="@color/icon_secondary" />
+    </LinearLayout>
+
+    <View
+        android:id="@+id/subtensorSubnetPickerRowDivider"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:layout_marginStart="16dp"
+        android:background="@color/divider" />
+
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/item_subtensor_validator_picker.xml
+++ b/feature-staking-impl/src/main/res/layout/item_subtensor_validator_picker.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Mirrors iOS SubtensorValidatorTableViewCell + SubtensorValidatorPickerViewLayout
+     (UITableView style: .plain, separator: .singleLine, color: container_border).
+     Row height ~56dp; flat against the screen background; thin separator inset
+     16dp from the leading edge to align under the title text, not under the icon. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -9,72 +12,57 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
+        android:layout_height="56dp"
         android:gravity="center_vertical"
-        android:paddingHorizontal="16dp"
-        android:paddingVertical="14dp">
+        android:orientation="horizontal"
+        android:paddingHorizontal="16dp">
 
-        <LinearLayout
+        <ImageView
+            android:id="@+id/subtensorValidatorPickerRowIcon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="12dp"
+            tools:src="@drawable/ic_identicon_placeholder_with_background" />
+
+        <TextView
+            android:id="@+id/subtensorValidatorPickerRowName"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/subtensorValidatorPickerRowName"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
-                tools:text="Opentensor Foundation" />
-
-            <TextView
-                android:id="@+id/subtensorValidatorPickerRowHotkey"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
-                tools:text="5GgYg…XEm9zT" />
-        </LinearLayout>
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+            android:textColor="@color/text_primary"
+            tools:text="Opentensor Foundation" />
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
+            android:layout_marginStart="8dp"
             android:gravity="end"
             android:orientation="vertical">
 
             <TextView
-                android:id="@+id/subtensorValidatorPickerRowStake"
+                android:id="@+id/subtensorValidatorPickerRowApr"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
-                tools:text="42,103.50 TAO" />
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+                android:textColor="@color/text_positive"
+                tools:text="14.32%" />
 
             <TextView
-                android:id="@+id/subtensorValidatorPickerRowMeta"
+                android:id="@+id/subtensorValidatorPickerRowCommission"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"
                 android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
-                tools:text="12.30% APR · 18.0% fee" />
+                tools:text="18% commission" />
         </LinearLayout>
-
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:src="@drawable/ic_arrow_right"
-            app:tint="@color/icon_secondary" />
     </LinearLayout>
 
     <View
-        android:id="@+id/subtensorValidatorPickerRowDivider"
         android:layout_width="match_parent"
         android:layout_height="0.5dp"
         android:layout_marginStart="16dp"
-        android:background="@color/divider" />
-
+        android:background="@color/container_border" />
 </LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/item_subtensor_validator_picker.xml
+++ b/feature-staking-impl/src/main/res/layout/item_subtensor_validator_picker.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="14dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/subtensorValidatorPickerRowName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
+                tools:text="Opentensor Foundation" />
+
+            <TextView
+                android:id="@+id/subtensorValidatorPickerRowHotkey"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+                tools:text="5GgYg…XEm9zT" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:gravity="end"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/subtensorValidatorPickerRowStake"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
+                tools:text="42,103.50 TAO" />
+
+            <TextView
+                android:id="@+id/subtensorValidatorPickerRowMeta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+                tools:text="12.30% APR · 18.0% fee" />
+        </LinearLayout>
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:src="@drawable/ic_arrow_right"
+            app:tint="@color/icon_secondary" />
+    </LinearLayout>
+
+    <View
+        android:id="@+id/subtensorValidatorPickerRowDivider"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:layout_marginStart="16dp"
+        android:background="@color/divider" />
+
+</LinearLayout>

--- a/feature-staking-impl/src/main/res/layout/item_subtensor_validator_row.xml
+++ b/feature-staking-impl/src/main/res/layout/item_subtensor_validator_row.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingVertical="12dp"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/subtensorValidatorRowIcon"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:layout_marginEnd="10dp"
+            tools:src="@drawable/ic_identicon_placeholder_with_background" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/subtensorValidatorRowName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
+                tools:text="tao.bot" />
+
+            <TextView
+                android:id="@+id/subtensorValidatorRowHotkey"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textAppearance="@style/TextAppearance.NovaFoundation.Regular.Caption1.Secondary"
+                tools:text="5GgYg…XEm9zT"
+                tools:visibility="visible" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/subtensorValidatorRowAmount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textAppearance="@style/TextAppearance.NovaFoundation.SemiBold.SubHeadline"
+            tools:text="10.0000 TAO" />
+    </LinearLayout>
+
+    <View
+        android:id="@+id/subtensorValidatorRowDivider"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:background="@color/divider" />
+
+</LinearLayout>

--- a/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/SubtensorStakingConstantsTest.kt
+++ b/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/domain/subtensor/SubtensorStakingConstantsTest.kt
@@ -1,0 +1,27 @@
+package io.novafoundation.nova.feature_staking_impl.domain.subtensor
+
+import io.novafoundation.nova.feature_staking_impl.domain.subtensor.model.SubtensorStakingConstants
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigInteger
+
+class SubtensorStakingConstantsTest {
+
+    @Test
+    fun `fee is 0,3 percent of one TAO`() {
+        // 0.3% of 1 TAO (1e9 planks) = 3_000_000
+        assertEquals(3_000_000.toBigInteger(), SubtensorStakingConstants.novaFeeAmount(1_000_000_000.toBigInteger()))
+    }
+
+    @Test
+    fun `dust below threshold floors to zero`() {
+        // 333 * 30 / 10_000 = 0.999 -> floors to 0
+        assertEquals(BigInteger.ZERO, SubtensorStakingConstants.novaFeeAmount(333.toBigInteger()))
+    }
+
+    @Test
+    fun `smallest non-zero fee is one plank`() {
+        // 334 * 30 / 10_000 = 1.002 -> floors to 1
+        assertEquals(BigInteger.ONE, SubtensorStakingConstants.novaFeeAmount(334.toBigInteger()))
+    }
+}

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/TypeBasedAssetSourceRegistry.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/TypeBasedAssetSourceRegistry.kt
@@ -45,6 +45,10 @@ class TypeBasedAssetSourceRegistry(
             is Chain.Asset.Type.EvmErc20 -> evmErc20Source.get()
             is Chain.Asset.Type.EvmNative -> evmNativeSource.get()
             is Chain.Asset.Type.Equilibrium -> equilibriumAssetSource.get()
+            // Subtensor alpha balances live in pallet runtime API state, not
+            // any of the standard balance sources — fall back to unsupported
+            // here. The dashboard updater handles position fetching directly.
+            is Chain.Asset.Type.SubtensorAlpha -> unsupportedBalanceSource
             Chain.Asset.Type.Unsupported -> unsupportedBalanceSource
         }
     }
@@ -64,6 +68,9 @@ class TypeBasedAssetSourceRegistry(
         return when (chainAsset.type) {
             is Chain.Asset.Type.Equilibrium,
             Chain.Asset.Type.EvmNative,
+            // Subtensor alpha emissions are tracked via runtime API, not the
+            // standard event-detector pipeline.
+            is Chain.Asset.Type.SubtensorAlpha,
 
             Chain.Asset.Type.Unsupported -> UnsupportedEventDetector()
 

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/validations/Common.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/transfers/validations/Common.kt
@@ -121,5 +121,8 @@ private fun Chain.Asset.existentialDepositError(amount: BigDecimal): WillRemoveA
     is Type.Statemine -> WillRemoveAccount.WillTransferDust(amount)
     is Type.EvmErc20, is Type.EvmNative -> WillRemoveAccount.WillBurnDust
     is Type.Equilibrium -> WillRemoveAccount.WillBurnDust
+    // Subtensor alpha assets are not transferable in the standard sense; ED
+    // doesn't apply. Throwing matches the unsupported-asset semantics.
+    is Type.SubtensorAlpha -> throw IllegalArgumentException("Subtensor alpha not transferable")
     Type.Unsupported -> throw IllegalArgumentException("Unsupported")
 }

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/model/request/SubqueryHistoryRequest.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/model/request/SubqueryHistoryRequest.kt
@@ -139,6 +139,8 @@ class SubqueryHistoryRequest(
             StakingTypeGroup.MYTHOS -> "reward"
 
             StakingTypeGroup.NOMINATION_POOL -> "poolReward"
+            // Subtensor rewards aren't surfaced via the SubQuery indexer yet.
+            StakingTypeGroup.SUBTENSOR -> null
             StakingTypeGroup.UNSUPPORTED -> null
         }
     }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
 
-        
+
 
         buildConfigField "String", "CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/refs/heads/master/chains/v22/chains_dev.json\""
         buildConfigField "String", "EVM_ASSETS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/master/assets/evm/v3/assets_dev.json\""
@@ -20,7 +20,15 @@ android {
 
     buildTypes {
         debug {
-
+            // [TEMP] Point dev builds at the nova-utils branch shipping the Bittensor
+            // `staking: ["subtensor"]` config + 128 subnet alpha assets. Master
+            // nova-utils doesn't have these yet — drop this override once the
+            // iOS-side `feature/staking-tao-type` is merged into nova-utils master.
+            // Mirrors the iOS dev override in `Common/Configs/ApplicationConfigs.swift`.
+            buildConfigField "String", "CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/feature/staking-tao-type/chains/v22/chains_dev.json\""
+            buildConfigField "String", "EVM_ASSETS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/feature/staking-tao-type/assets/evm/v3/assets_dev.json\""
+            buildConfigField "String", "PRE_CONFIGURED_CHAINS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/feature/staking-tao-type/chains/v22/preConfigured/chains_dev.json\""
+            buildConfigField "String", "PRE_CONFIGURED_CHAIN_DETAILS_URL", "\"https://raw.githubusercontent.com/novasamatech/nova-utils/feature/staking-tao-type/chains/v22/preConfigured/detailsDev\""
         }
 
         release {

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
@@ -23,6 +23,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.SUBTENSOR
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.UNSUPPORTED
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Type
@@ -172,7 +173,7 @@ fun ChainId.chainIdHexPrefix16(): String {
 
 enum class StakingTypeGroup {
 
-    RELAYCHAIN, PARACHAIN, NOMINATION_POOL, MYTHOS, UNSUPPORTED
+    RELAYCHAIN, PARACHAIN, NOMINATION_POOL, MYTHOS, SUBTENSOR, UNSUPPORTED
 }
 
 fun Chain.Asset.StakingType.group(): StakingTypeGroup {
@@ -182,6 +183,7 @@ fun Chain.Asset.StakingType.group(): StakingTypeGroup {
         PARACHAIN, TURING -> StakingTypeGroup.PARACHAIN
         MYTHOS -> StakingTypeGroup.MYTHOS
         NOMINATION_POOLS -> StakingTypeGroup.NOMINATION_POOL
+        SUBTENSOR -> StakingTypeGroup.SUBTENSOR
     }
 }
 
@@ -581,6 +583,9 @@ val Chain.Asset.onChainAssetId: String?
         is Type.EvmErc20 -> this.type.contractAddress
         is Type.Native -> null
         is Type.EvmNative -> null
+        // Subtensor alpha assets are addressed by netuid, not an on-chain
+        // assetId — they live entirely in pallet runtime API state.
+        is Type.SubtensorAlpha -> null
         Type.Unsupported -> error("Unsupported assetId type: ${this.type::class.simpleName}")
     }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/ChainMappersConstants.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/ChainMappersConstants.kt
@@ -26,3 +26,6 @@ const val ORML_EXTRAS_TRANSFERS_ENABLED = "transfersEnabled"
 const val EVM_EXTRAS_CONTRACT_ADDRESS = "contractAddress"
 
 const val ORML_TRANSFERS_ENABLED_DEFAULT = true
+
+const val ASSET_SUBTENSOR_ALPHA = "subtensor-alpha"
+const val SUBTENSOR_ALPHA_EXTRAS_NETUID = "netuid"

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/DomainToLocalChainMapper.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/DomainToLocalChainMapper.kt
@@ -63,6 +63,10 @@ fun mapChainAssetTypeToRaw(type: Chain.Asset.Type): Pair<String, Map<String, Any
         ASSET_EQUILIBRIUM_ON_CHAIN_ID to type.id.toString()
     )
 
+    is Chain.Asset.Type.SubtensorAlpha -> ASSET_SUBTENSOR_ALPHA to mapOf(
+        SUBTENSOR_ALPHA_EXTRAS_NETUID to type.netuid
+    )
+
     Chain.Asset.Type.Unsupported -> ASSET_UNSUPPORTED to null
 }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/LocalToDomainChainMapper.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/LocalToDomainChainMapper.kt
@@ -87,6 +87,14 @@ private fun mapChainAssetTypeFromRaw(type: String?, typeExtras: Map<String, Any?
 
         ASSET_EQUILIBRIUM -> Chain.Asset.Type.Equilibrium((typeExtras!![ASSET_EQUILIBRIUM_ON_CHAIN_ID] as String).toBigInteger())
 
+        ASSET_SUBTENSOR_ALPHA -> {
+            // typeExtras.netuid arrives as a JSON Number → Double after Gson
+            // round-trip — coerce safely to Int. Missing extras → root (0)
+            // so a malformed asset still maps to a usable type.
+            val netuid = (typeExtras?.get(SUBTENSOR_ALPHA_EXTRAS_NETUID) as? Number)?.toInt() ?: 0
+            Chain.Asset.Type.SubtensorAlpha(netuid = netuid)
+        }
+
         else -> Chain.Asset.Type.Unsupported
     }
 }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
@@ -252,6 +252,7 @@ fun mapStakingStringToStakingType(stakingString: String?): Chain.Asset.StakingTy
         "turing" -> Chain.Asset.StakingType.TURING
         "aleph-zero" -> Chain.Asset.StakingType.ALEPH_ZERO
         "mythos" -> Chain.Asset.StakingType.MYTHOS
+        "subtensor" -> Chain.Asset.StakingType.SUBTENSOR
         else -> Chain.Asset.StakingType.UNSUPPORTED
     }
 }
@@ -266,6 +267,7 @@ fun mapStakingTypeToStakingString(stakingType: Chain.Asset.StakingType): String?
         Chain.Asset.StakingType.ALEPH_ZERO -> "aleph-zero"
         Chain.Asset.StakingType.NOMINATION_POOLS -> "nomination-pools"
         Chain.Asset.StakingType.MYTHOS -> "mythos"
+        Chain.Asset.StakingType.SUBTENSOR -> "subtensor"
     }
 }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
@@ -124,6 +124,14 @@ data class Chain(
                 val id: BigInteger
             ) : Type()
 
+            /**
+             * Bittensor subnet alpha asset. `netuid` distinguishes between
+             * subnets (1..128) — root TAO uses `Native` instead. Sourced
+             * from nova-utils chain config: `type: "subtensor-alpha"` with
+             * `typeExtras: {netuid: N}`.
+             */
+            data class SubtensorAlpha(val netuid: Int) : Type()
+
             object Unsupported : Type()
         }
 
@@ -132,7 +140,8 @@ data class Chain(
             RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO, // relaychain like
             PARACHAIN, TURING, // parachain-staking like
             NOMINATION_POOLS,
-            MYTHOS
+            MYTHOS,
+            SUBTENSOR // bittensor (TAO root + dTAO subnet alpha)
         }
 
         override val identifier = "$chainId:$id"


### PR DESCRIPTION
## Summary

Android counterpart of novasamatech/nova-wallet-ios#1831. First-class Subtensor staking on Android for Bittensor mainnet — root TAO and per-subnet (alpha) positions via the standard Nova staking flow, with positions sourced from a single runtime API call and refreshed on every confirmed extrinsic.

**What ships:**
- Per-subnet rows on the multistaking dashboard — TAO root + one row per subnet where the user holds stake. Rows without stake are filtered from "Available to stake".
- Stake details screen scoped to the entry netuid, with the standard Nova staking layout.
- Full stake / unstake submit lifecycle (`add_stake_limit` / `remove_stake_limit`). Slippage protection on the subnet path enforces a 0.5% cushion against the AMM spot price.
- Subnet picker (sort by total TAO staked / subnet number) + validator picker (on-chain identity from the GitHub delegate registry, sort by total stake / APR).
- Smart-pick unstake UX: 0 positions → toast, 1 → skip picker, N → AlertDialog → unstake setup with hotkey + amount prefilled.

## Architecture

- Mirrors the iOS architecture file-for-file under `feature-staking-impl/.../data/subtensor/`: SCALE decoder, position fetcher, position cache (Mutex + 15s TTL + dedup, generation counter), `BittensorDelegatesClient`, extrinsic builders (`addStakeLimit` / `removeStakeLimit` / `moveStake`).
- **Position fetch** uses `state_call("StakeInfoRuntimeApi_get_stake_info_for_coldkey", coldkey)` — same canonical runtime API as the iOS port and the reference wallets. Storage-map walking was discarded for the same reasons (root not always in `StakingHotkeys`; V1→V2 lazy migration of alpha shares).
- **`StakingType.SUBTENSOR`** + **`Chain.Asset.Type.SubtensorAlpha(netuid)`** integrate into the existing chain / staking pipeline. Dashboard rows are written by a thin per-netuid sync service that filters the shared position cache.
- **Display addresses** use `SS58Encoder.UNIFIED_ADDRESS_PREFIX = 0` (Polkadot prefix, matches the multichain display convention); identity registry lookup uses the chain's own prefix (Bittensor 42).
- **Subnet picker** resolves data via `SubtensorSubnetFetcher` — direct JSON-RPC batch over `SubtensorModule.{SubnetTAO, SubnetAlphaIn, SubnetIdentitiesV3}` for netuids 1…128, SCALE-decoded names + reserves + spot price. **Validator picker** merges GitHub delegate registry identity with a numeric data source.
- **Stake / unstake selection round-trip** uses `previousBackStackEntry.savedStateHandle` — same idiom as `customBonusFlow` in `Navigator.kt`. `StakingRouter` exposes `subtensorSelectedValidatorFlow` and `respondAndPopValidatorPicker`.
- **Subnet extrinsic encoding:** `limit_price` is `TaoBalance` (u64, RAO-per-Alpha) with `× ONE_TAO_IN_RAO.toDouble()` + `ceil` on stake / `floor` on unstake — matches the iOS rounding semantics. An earlier prototype multiplied by `2^32` (treating `limit_price` as I96F32 raw bits), which would have silently relaxed stake slippage by ~4.29× and rejected every subnet unstake.
- **Cache invalidation** on `inBlock` propagates back to the dashboard via the position cache; the dashboard refreshes on resume.

## Notes

- Companion chain config: novasamatech/nova-utils#4335 — adds 128 subnet-alpha assets (`assetId = 10000 + netuid`, `type = "subtensor-alpha"`, `typeExtras = {netuid: N}`, `staking = ["subtensor"]`, gold theme colour on the Bittensor chain).
- iOS counterpart: novasamatech/nova-wallet-ios#1831.
- Subnet names ship as placeholders (`SN1` … `SN128`). Replacing them requires a runtime override layered on top — separate follow-up.
- Subnet-alpha icons reuse `TAO_bittensor.svg` — per-subnet icons are a design follow-up.
- USD/fiat price for subnet alpha is not surfaced. Surfacing it requires a chain-local price provider reading AMM spot × TAO external price — separate follow-up.
- Public Finney RPC rate-limits aggressively — the shared position cache is what makes 129 parallel sync services viable on the public endpoint.

### Indexer dependency

The `[TEMP-TAOSTATS]` scaffolding fills in everything Nova's Bittensor indexer is intended to provide. To remove the scaffolding cleanly, the indexer needs to expose:

- **Per-validator (hotkey) yield estimate** (APR / APY) — consumed by the validator picker rows and by the Start Staking Info "Earn up to %" headline. TaoStats publishes a 7-day rolling figure today.
- **Per-validator commission / take** — shown on each validator row and drives the "hide 100% commission" filter.
- **Per-validator total stake + nominator count** — sort key on the validator picker and row metadata.
- **Per-subnet aggregate APR** (root + each netuid) — dashboard tile headline yield per row. Without this the dashboard falls back to a placeholder 18% figure.
