### PR TITLE
Staking: EnergyWebX (EWT) — parachain-staking-avn lifecycle

### DIFF
--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -30,6 +30,7 @@
     <color name="critical_update_chip_text">#EBC50A</color>
     <color name="text_negative">#E53450</color>
     <color name="text_positive">#2FC864</color>
+    <color name="color_polkadot_brand">#E6007A</color>
     <color name="progress_bar_text">#2AB0F2</color>
     <color name="major_update_chip_text">#2AB0F2</color>
     <color name="conviction_slider_text_01x">#2AB0F2</color>

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/api/StakingTypeMappers.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/stats/api/StakingTypeMappers.kt
@@ -12,6 +12,7 @@ fun mapStakingTypeToSubQueryId(stakingType: Chain.Asset.StakingType): String? {
         Chain.Asset.StakingType.ALEPH_ZERO -> "aleph-zero"
         Chain.Asset.StakingType.NOMINATION_POOLS -> "nomination-pool"
         Chain.Asset.StakingType.MYTHOS -> "mythos"
+        Chain.Asset.StakingType.PARACHAIN_AVN -> null
     }
 }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardParachainStakingUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/dashboard/network/updaters/chain/StakingDashboardParachainStakingUpdater.kt
@@ -2,6 +2,7 @@ package io.novafoundation.nova.feature_staking_impl.data.dashboard.network.updat
 
 import io.novafoundation.nova.common.address.get
 import io.novafoundation.nova.common.address.intoKey
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.isZero
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.core.updater.SharedRequestsBuilder
@@ -62,7 +63,10 @@ class StakingDashboardParachainStakingUpdater(
     private suspend fun StorageQueryContext.subscribeToStakingState(): Flow<ParachainStakingBaseInfo?> {
         val accountId = metaAccount.accountIdIn(chain) ?: return flowOf(null)
 
-        val delegatorStateFlow = runtime.metadata.parachainStaking().storage("DelegatorState").observe(
+        val parachainStaking = runtime.metadata.parachainStaking()
+        val delegatorStorageName = if (parachainStaking.hasStorage("NominatorState")) "NominatorState" else "DelegatorState"
+
+        val delegatorStateFlow = parachainStaking.storage(delegatorStorageName).observe(
             accountId,
             binding = { bindDelegatorState(it, accountId, chain, chainAsset) }
         )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/StakingUpdaters.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/network/blockhain/updaters/StakingUpdaters.kt
@@ -10,6 +10,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.MYTHOS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN_AVN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
@@ -57,6 +58,7 @@ class StakingUpdaters(
             RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO -> relaychainUpdaters.updaters
             PARACHAIN -> parachainUpdaters.updaters
             TURING -> parachainUpdaters.updaters + turingExtraUpdaters.updaters
+            PARACHAIN_AVN -> parachainUpdaters.updaters
             NOMINATION_POOLS -> nominationPoolsUpdaters.updaters
             MYTHOS -> mythosUpdaters.updaters
             UNSUPPORTED -> emptyList()

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/network/bindings/AvnGrowthInfo.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/network/bindings/AvnGrowthInfo.kt
@@ -1,0 +1,47 @@
+package io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.network.bindings
+
+import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
+import io.novafoundation.nova.common.data.network.runtime.binding.castToStruct
+import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
+import java.math.BigInteger
+
+class GrowthPeriodInfo(
+    val index: BigInteger,
+)
+
+class GrowthInfo(
+    val numberOfAccumulations: BigInteger,
+    val totalStakeAccumulated: Balance,
+    val totalStakerReward: Balance,
+)
+
+fun bindGrowthPeriod(dynamic: Any?): GrowthPeriodInfo {
+    val struct = dynamic.castToStruct()
+    val index: Any? = struct.mapping["index"]
+    return GrowthPeriodInfo(index = bindNumber(index))
+}
+
+fun bindGrowthInfo(dynamic: Any?): GrowthInfo {
+    val struct = dynamic.castToStruct()
+
+    return GrowthInfo(
+        numberOfAccumulations = bindNumber(struct["numberOfAccumulations"]),
+        totalStakeAccumulated = bindNumber(struct["totalStakeAccumulated"]),
+        totalStakerReward = bindNumber(struct["totalStakerReward"])
+    )
+}
+
+class CommissionSetting(
+    val current: BigInteger,
+    val scheduled: BigInteger?,
+)
+
+fun bindCommissionSetting(dynamic: Any?): CommissionSetting {
+    val struct = dynamic.castToStruct()
+    val scheduledRaw: Any? = struct.mapping["scheduled"]
+
+    return CommissionSetting(
+        current = bindNumber(struct["current"]),
+        scheduled = scheduledRaw?.let(::bindNumber)
+    )
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/repository/AvnRewardsRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/repository/AvnRewardsRepository.kt
@@ -1,0 +1,67 @@
+package io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.repository
+
+import io.novafoundation.nova.common.data.network.runtime.binding.Perbill
+import io.novafoundation.nova.common.data.network.runtime.binding.bindPerbillNumber
+import io.novafoundation.nova.common.utils.parachainStaking
+import io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.network.bindings.bindCommissionSetting
+import io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.network.bindings.bindGrowthInfo
+import io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.network.bindings.bindGrowthPeriod
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.storage.source.StorageDataSource
+import io.novasama.substrate_sdk_android.runtime.metadata.storage
+import kotlinx.coroutines.withTimeoutOrNull
+import java.math.BigDecimal
+import java.math.BigInteger
+
+class AvnGrowthSnapshot(
+    val totalStakerReward: BigInteger,
+    val totalStakeAccumulated: BigInteger,
+    val numberOfAccumulations: BigInteger,
+)
+
+interface AvnRewardsRepository {
+    suspend fun getCommission(chainId: ChainId): Perbill
+    suspend fun getGrowthSnapshot(chainId: ChainId): AvnGrowthSnapshot?
+}
+
+class RealAvnRewardsRepository(
+    private val storageDataSource: StorageDataSource,
+) : AvnRewardsRepository {
+
+    override suspend fun getCommission(chainId: ChainId): Perbill {
+        val commission = withTimeoutOrNull(3_000) {
+            runCatching {
+                storageDataSource.query(chainId) {
+                    runtime.metadata.parachainStaking().storage("DefaultCollatorCommission").query(binding = ::bindCommissionSetting)
+                }
+            }.getOrNull()
+        }
+        return commission?.let { bindPerbillNumber(it.current) } ?: BigDecimal.ZERO
+    }
+
+    override suspend fun getGrowthSnapshot(chainId: ChainId): AvnGrowthSnapshot? {
+        // Bounded to avoid blocking the staking info screen forever when
+        // the growth indexer hasn't seen its first period yet.
+        return withTimeoutOrNull(3_000) {
+            runCatching {
+                storageDataSource.query(chainId) {
+                    val period = runtime.metadata.parachainStaking().storage("GrowthPeriod")
+                        .query(binding = ::bindGrowthPeriod)
+                    val periodIndex = period?.index ?: return@query null
+
+                    if (periodIndex <= BigInteger.ZERO) return@query null
+                    val prevIndex = periodIndex - BigInteger.ONE
+
+                    val growth = runtime.metadata.parachainStaking().storage("Growth")
+                        .query(prevIndex, binding = ::bindGrowthInfo) ?: return@query null
+
+                    AvnGrowthSnapshot(
+                        totalStakerReward = growth.totalStakerReward,
+                        totalStakeAccumulated = growth.totalStakeAccumulated,
+                        numberOfAccumulations = growth.numberOfAccumulations
+                    )
+                }
+            }.getOrNull()
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/repository/scheduledRequests/AvnLegacyNominationScheduledRequestExecutor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/repository/scheduledRequests/AvnLegacyNominationScheduledRequestExecutor.kt
@@ -1,0 +1,92 @@
+package io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.repository.scheduledRequests
+
+import io.novafoundation.nova.common.data.network.runtime.binding.bindAccountId
+import io.novafoundation.nova.common.data.network.runtime.binding.bindList
+import io.novafoundation.nova.common.data.network.runtime.binding.castToStruct
+import io.novafoundation.nova.common.data.network.runtime.binding.getTyped
+import io.novafoundation.nova.common.utils.filterNotNull
+import io.novafoundation.nova.common.utils.mapValuesNotNull
+import io.novafoundation.nova.common.utils.parachainStaking
+import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
+import io.novafoundation.nova.feature_staking_api.domain.model.parachain.ScheduledDelegationRequest
+import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.bindings.bindDelegationAction
+import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.bindings.bindRoundIndex
+import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.scheduledRequests.DelegationScheduledRequestExecutor
+import io.novafoundation.nova.runtime.storage.source.StorageEntries
+import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
+import io.novafoundation.nova.runtime.storage.source.query.wrapSingleArgumentKeys
+import io.novasama.substrate_sdk_android.extensions.fromHex
+import io.novasama.substrate_sdk_android.extensions.toHexString
+import io.novasama.substrate_sdk_android.runtime.AccountId
+import io.novasama.substrate_sdk_android.runtime.metadata.storage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AvnLegacyNominationScheduledRequestExecutor : DelegationScheduledRequestExecutor {
+
+    context(StorageQueryContext)
+    override suspend fun entries(delegatorState: DelegatorState.Delegator): Map<String, ScheduledDelegationRequest> {
+        val keyArguments = delegatorState.delegations.map { listOf(it.owner) }
+
+        return runtime.metadata.parachainStaking().storage("NominationScheduledRequests").entries(
+            keyArguments,
+            keyExtractor = { (collatorId: AccountId) -> collatorId.toHexString() },
+            binding = { dynamicInstance, collatorId -> bindNominationRequests(dynamicInstance, collatorId.fromHex()) }
+        ).byNominator(delegatorState.accountId)
+    }
+
+    context(StorageQueryContext)
+    override suspend fun observe(delegatorState: DelegatorState.Delegator): Flow<Collection<ScheduledDelegationRequest>> {
+        val keyArguments = delegatorState.delegations.map { listOf(it.owner) }
+
+        return runtime.metadata.parachainStaking().storage("NominationScheduledRequests").observe(
+            keyArguments,
+            keyExtractor = { (collatorId: AccountId) -> collatorId.toHexString() },
+            binding = { dynamicInstance, collatorId -> bindNominationRequests(dynamicInstance, collatorId.fromHex()) }
+        ).map { it.filterNotNull().byNominator(delegatorState.accountId).values }
+    }
+
+    context(StorageQueryContext)
+    override suspend fun query(
+        delegatorState: DelegatorState.Delegator,
+        collatorId: AccountId
+    ): ScheduledDelegationRequest? {
+        val allCollatorRequests = runtime.metadata.parachainStaking().storage("NominationScheduledRequests").query(
+            collatorId,
+            binding = { bindNominationRequests(it, collatorId) }
+        )
+
+        return allCollatorRequests.find { it.delegator.contentEquals(delegatorState.accountId) }
+    }
+
+    context(StorageQueryContext)
+    override suspend fun entriesRaw(delegatorState: DelegatorState.Delegator): StorageEntries {
+        val nominatorIdsArgs = delegatorState.delegations.map { it.owner }.wrapSingleArgumentKeys()
+
+        return runtime.metadata.parachainStaking().storage("NominationScheduledRequests").entriesRaw(nominatorIdsArgs)
+    }
+
+    private fun bindNominationRequests(instance: Any?, collatorId: AccountId) = instance?.let {
+        bindList(instance) { listElement -> bindNominationRequest(collatorId, listElement) }
+    }.orEmpty()
+
+    private fun bindNominationRequest(
+        collatorId: AccountId,
+        instance: Any?,
+    ): ScheduledDelegationRequest {
+        val struct = instance.castToStruct()
+        val nominatorField: Any? = struct.mapping["nominator"] ?: struct.mapping["delegator"]
+
+        return ScheduledDelegationRequest(
+            delegator = bindAccountId(nominatorField),
+            whenExecutable = bindRoundIndex(struct["whenExecutable"]),
+            action = bindDelegationAction(struct.getTyped("action")),
+            collator = collatorId
+        )
+    }
+
+    private fun Map<String, List<ScheduledDelegationRequest>>.byNominator(nominator: AccountId) =
+        mapValuesNotNull { (_, pendingRequests) ->
+            pendingRequests.find { it.delegator.contentEquals(nominator) }
+        }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/repository/scheduledRequests/AvnNewNominationScheduledRequestExecutor.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/repository/scheduledRequests/AvnNewNominationScheduledRequestExecutor.kt
@@ -1,0 +1,103 @@
+package io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.repository.scheduledRequests
+
+import io.novafoundation.nova.common.data.network.runtime.binding.bindList
+import io.novafoundation.nova.common.data.network.runtime.binding.castToStruct
+import io.novafoundation.nova.common.data.network.runtime.binding.getTyped
+import io.novafoundation.nova.common.utils.mapValuesNotNull
+import io.novafoundation.nova.common.utils.parachainStaking
+import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
+import io.novafoundation.nova.feature_staking_api.domain.model.parachain.ScheduledDelegationRequest
+import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.bindings.bindDelegationAction
+import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.bindings.bindRoundIndex
+import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.scheduledRequests.DelegationScheduledRequestExecutor
+import io.novafoundation.nova.runtime.storage.source.StorageEntries
+import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
+import io.novasama.substrate_sdk_android.extensions.fromHex
+import io.novasama.substrate_sdk_android.extensions.toHexString
+import io.novasama.substrate_sdk_android.runtime.AccountId
+import io.novasama.substrate_sdk_android.runtime.metadata.storage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
+
+private class RequestKey(val collatorId: String, val nominatorId: String)
+
+class AvnNewNominationScheduledRequestExecutor : DelegationScheduledRequestExecutor {
+
+    context(StorageQueryContext)
+    override suspend fun entries(delegatorState: DelegatorState.Delegator): Map<String, ScheduledDelegationRequest> {
+        val keyArguments = delegatorState.delegations.map { listOf(it.owner, delegatorState.accountId) }
+
+        return runtime.metadata.parachainStaking().storage("NominationScheduledRequests").entries(
+            keyArguments,
+            keyExtractor = { (collatorId: AccountId, nominatorId: AccountId) ->
+                RequestKey(collatorId.toHexString(), nominatorId.toHexString())
+            },
+            binding = { dynamicInstance, key ->
+                bindNominationRequests(
+                    instance = dynamicInstance,
+                    collatorId = key.collatorId.fromHex(),
+                    nominatorId = key.nominatorId.fromHex()
+                )
+            }
+        ).mapKeys { (key, _) -> key.collatorId }
+            .mapValuesNotNull { it.value.firstOrNull() }
+    }
+
+    context(StorageQueryContext)
+    override suspend fun observe(delegatorState: DelegatorState.Delegator): Flow<Collection<ScheduledDelegationRequest>> {
+        val keyArguments = delegatorState.delegations.map { listOf(it.owner, delegatorState.accountId) }
+
+        return runtime.metadata.parachainStaking().storage("NominationScheduledRequests").observe(
+            keyArguments,
+            keyExtractor = { (collatorId: AccountId, nominatorId: AccountId) ->
+                RequestKey(collatorId.toHexString(), nominatorId.toHexString())
+            },
+            binding = { dynamicInstance, key ->
+                bindNominationRequests(
+                    dynamicInstance,
+                    collatorId = key.collatorId.fromHex(),
+                    nominatorId = key.nominatorId.fromHex()
+                )
+            }
+        ).mapNotNull { instances -> instances.values.flatMap { it.orEmpty() } }
+    }
+
+    context(StorageQueryContext)
+    override suspend fun query(delegatorState: DelegatorState.Delegator, collatorId: AccountId): ScheduledDelegationRequest? {
+        return runtime.metadata.parachainStaking().storage("NominationScheduledRequests").query(
+            collatorId,
+            delegatorState.accountId,
+            binding = { bindNominationRequests(it, collatorId, delegatorState.accountId) }
+        ).firstOrNull()
+    }
+
+    context(StorageQueryContext)
+    override suspend fun entriesRaw(delegatorState: DelegatorState.Delegator): StorageEntries {
+        val nominatorIdsArgs = delegatorState.delegations.map { listOf(it.owner, delegatorState.accountId) }
+
+        return runtime.metadata.parachainStaking().storage("NominationScheduledRequests").entriesRaw(nominatorIdsArgs)
+    }
+
+    private fun bindNominationRequests(
+        instance: Any?,
+        collatorId: AccountId,
+        nominatorId: AccountId,
+    ) = instance?.let {
+        bindList(instance) { listElement -> bindNominationRequest(collatorId, nominatorId, listElement) }
+    }.orEmpty()
+
+    private fun bindNominationRequest(
+        collatorId: AccountId,
+        nominatorId: AccountId,
+        instance: Any?,
+    ): ScheduledDelegationRequest {
+        val struct = instance.castToStruct()
+
+        return ScheduledDelegationRequest(
+            delegator = nominatorId,
+            whenExecutable = bindRoundIndex(struct["whenExecutable"]),
+            action = bindDelegationAction(struct.getTyped("action")),
+            collator = collatorId
+        )
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/repository/scheduledRequests/AvnNominationScheduledRequestFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainAvnStaking/repository/scheduledRequests/AvnNominationScheduledRequestFactory.kt
@@ -1,0 +1,25 @@
+package io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.repository.scheduledRequests
+
+import io.novafoundation.nova.common.utils.parachainStaking
+import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.scheduledRequests.DelegationScheduledRequestExecutor
+import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Alias
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Struct
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Vec
+import io.novasama.substrate_sdk_android.runtime.metadata.storage
+
+class AvnNominationScheduledRequestFactory {
+    context(StorageQueryContext)
+    fun create(): DelegationScheduledRequestExecutor {
+        val storage = runtime.metadata.parachainStaking().storage("NominationScheduledRequests")
+        val vec = storage.type.value as Vec
+        val alias = vec.typeReference.value as Alias
+        val struct = alias.aliasedReference.value as Struct
+
+        return when {
+            struct.mapping.contains("nominator") || struct.mapping.contains("delegator") ->
+                AvnLegacyNominationScheduledRequestExecutor()
+            else -> AvnNewNominationScheduledRequestExecutor()
+        }
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/bindings/CandidateMetadata.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/bindings/CandidateMetadata.kt
@@ -57,12 +57,17 @@ fun CandidateMetadata.minimumStakeToGetRewards(techMinimumStake: Balance): Balan
 
 fun bindCandidateMetadata(decoded: Any?): CandidateMetadata {
     return decoded.castToStruct().let { struct ->
+        val nominationCount: Any? = struct.mapping["delegationCount"] ?: struct.mapping["nominationCount"]
+        val lowestBottom: Any? = struct.mapping["lowestBottomDelegationAmount"] ?: struct.mapping["lowestBottomNominationAmount"]
+        val lowestTop: Any? = struct.mapping["lowestTopDelegationAmount"] ?: struct.mapping["lowestTopNominationAmount"]
+        val highestBottom: Any? = struct.mapping["highestBottomDelegationAmount"] ?: struct.mapping["highestBottomNominationAmount"]
+
         CandidateMetadata(
             totalCounted = bindNumber(struct["totalCounted"]),
-            delegationCount = bindNumber(struct["delegationCount"]),
-            lowestBottomDelegationAmount = bindNumber(struct["lowestBottomDelegationAmount"]),
-            lowestTopDelegationAmount = bindNumber(struct["lowestTopDelegationAmount"]),
-            highestBottomDelegationAmount = bindNumber(struct["highestBottomDelegationAmount"]),
+            delegationCount = bindNumber(nominationCount),
+            lowestBottomDelegationAmount = bindNumber(lowestBottom),
+            lowestTopDelegationAmount = bindNumber(lowestTop),
+            highestBottomDelegationAmount = bindNumber(highestBottom),
             topCapacity = bindCollectionEnum(struct["topCapacity"]),
             bottomCapacity = bindCollectionEnum(struct["bottomCapacity"]),
             status = bindCollectionEnum(struct["status"])

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/bindings/CollatorSnapshot.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/bindings/CollatorSnapshot.kt
@@ -14,10 +14,11 @@ class CollatorSnapshot(
 
 fun bindCollatorSnapshot(instance: Any?): CollatorSnapshot {
     val asStruct = instance.castToStruct()
+    val bonds: Any? = asStruct.mapping["delegations"] ?: asStruct.mapping["nominations"]
 
     return CollatorSnapshot(
         bond = bindNumber(asStruct["bond"]),
-        delegations = bindList(asStruct["delegations"], ::bindBond),
+        delegations = bindList(bonds, ::bindBond),
         total = bindNumber(asStruct["total"])
     )
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/bindings/DelegatorState.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/bindings/DelegatorState.kt
@@ -30,11 +30,13 @@ private fun bindDelegator(
     chain: Chain,
     chainAsset: Chain.Asset,
 ): DelegatorState.Delegator {
+    val bonds: Any? = struct.mapping["delegations"] ?: struct.mapping["nominations"]
+
     return DelegatorState.Delegator(
         accountId = accountId,
         chain = chain,
         chainAsset = chainAsset,
-        delegations = bindList(struct["delegations"], ::bindBond),
+        delegations = bindList(bonds, ::bindBond),
         total = bindNumber(struct["total"]),
         lessTotal = bindNumber(struct["lessTotal"])
     )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/CollatorCommissionUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/CollatorCommissionUpdater.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.blockhain.updaters
 
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.core.updater.GlobalScope
@@ -18,6 +19,8 @@ class CollatorCommissionUpdater(
 ) : SingleStorageKeyUpdater<Unit>(GlobalScope, stakingSharedState, chainRegistry, storageCache), SharedStateBasedUpdater<Unit> {
 
     override suspend fun storageKey(runtime: RuntimeSnapshot, scopeValue: Unit): String {
-        return runtime.metadata.parachainStaking().storage("CollatorCommission").storageKey()
+        val parachainStaking = runtime.metadata.parachainStaking()
+        val storageName = if (parachainStaking.hasStorage("DefaultCollatorCommission")) "DefaultCollatorCommission" else "CollatorCommission"
+        return parachainStaking.storage(storageName).storageKey()
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/CurrentRoundUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/CurrentRoundUpdater.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.blockhain.updaters
 
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.core.updater.GlobalScope
@@ -18,6 +19,8 @@ class CurrentRoundUpdater(
 ) : SingleStorageKeyUpdater<Unit>(GlobalScope, stakingSharedState, chainRegistry, storageCache), SharedStateBasedUpdater<Unit> {
 
     override suspend fun storageKey(runtime: RuntimeSnapshot, scopeValue: Unit): String {
-        return runtime.metadata.parachainStaking().storage("Round").storageKey()
+        val parachainStaking = runtime.metadata.parachainStaking()
+        val storageName = if (parachainStaking.hasStorage("Era")) "Era" else "Round"
+        return parachainStaking.storage(storageName).storageKey()
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/DelegatorStateUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/DelegatorStateUpdater.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.blockhain.updaters
 
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.feature_account_api.domain.model.MetaAccount
@@ -26,6 +27,8 @@ class DelegatorStateUpdater(
 
         val accountId = account.accountIdIn(chain) ?: return null
 
-        return runtime.metadata.parachainStaking().storage("DelegatorState").storageKey(runtime, accountId)
+        val parachainStaking = runtime.metadata.parachainStaking()
+        val storageName = if (parachainStaking.hasStorage("NominatorState")) "NominatorState" else "DelegatorState"
+        return parachainStaking.storage(storageName).storageKey(runtime, accountId)
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/InflationConfigUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/InflationConfigUpdater.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.blockhain.updaters
 
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.core.updater.GlobalScope
@@ -17,7 +18,9 @@ class InflationConfigUpdater(
     storageCache: StorageCache
 ) : SingleStorageKeyUpdater<Unit>(GlobalScope, stakingSharedState, chainRegistry, storageCache), SharedStateBasedUpdater<Unit> {
 
-    override suspend fun storageKey(runtime: RuntimeSnapshot, scopeValue: Unit): String {
-        return runtime.metadata.parachainStaking().storage("InflationConfig").storageKey()
+    override suspend fun storageKey(runtime: RuntimeSnapshot, scopeValue: Unit): String? {
+        val parachainStaking = runtime.metadata.parachainStaking()
+        if (!parachainStaking.hasStorage("InflationConfig")) return null
+        return parachainStaking.storage("InflationConfig").storageKey()
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/ScheduledDelegationRequestsUpdater.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/blockhain/updaters/ScheduledDelegationRequestsUpdater.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.blockhain.updaters
 
 import io.novafoundation.nova.common.utils.decodeValue
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.core.storage.StorageCache
 import io.novafoundation.nova.core.storage.insert
@@ -42,7 +43,9 @@ class ScheduledDelegationRequestsUpdater(
 
         val accountId = account.accountIdIn(chain) ?: return emptyFlow()
 
-        val storage = runtime.metadata.parachainStaking().storage("DelegatorState")
+        val parachainStaking = runtime.metadata.parachainStaking()
+        val storageName = if (parachainStaking.hasStorage("NominatorState")) "NominatorState" else "DelegatorState"
+        val storage = parachainStaking.storage(storageName)
         val key = storage.storageKey(runtime, accountId)
 
         return storageSubscriptionBuilder.subscribe(key).map {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/calls/ExtrinsicBuilderExt.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/network/calls/ExtrinsicBuilderExt.kt
@@ -1,14 +1,17 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.calls
 
 import io.novafoundation.nova.common.utils.Modules
-import io.novafoundation.nova.common.utils.hasCall
+import io.novafoundation.nova.common.utils.firstExistingCallName
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
 import io.novasama.substrate_sdk_android.runtime.AccountId
 import io.novasama.substrate_sdk_android.runtime.extrinsic.builder.ExtrinsicBuilder
 import io.novasama.substrate_sdk_android.runtime.extrinsic.call
-import io.novasama.substrate_sdk_android.runtime.metadata.RuntimeMetadata
 import java.math.BigInteger
+
+// Each helper probes runtime metadata for an EWX (AvN-renamed) call name
+// first, then falls back to the Moonbeam name. The argument map is built
+// for whichever call shape the chain actually exposes.
 
 fun ExtrinsicBuilder.delegate(
     candidate: AccountId,
@@ -16,44 +19,49 @@ fun ExtrinsicBuilder.delegate(
     candidateDelegationCount: BigInteger,
     delegationCount: BigInteger
 ): ExtrinsicBuilder {
-    return if (runtime.metadata.hasDelegateAutoCompoundCall()) {
-        call(
-            moduleName = Modules.PARACHAIN_STAKING,
-            callName = "delegate_with_auto_compound",
-            arguments = mapOf(
-                "candidate" to candidate,
-                "amount" to amount,
-                "auto_compound" to BigInteger.ZERO,
-                "candidate_delegation_count" to candidateDelegationCount,
-                "candidate_auto_compounding_delegation_count" to BigInteger.ZERO,
-                "delegation_count" to delegationCount
-            )
+    val parachainStaking = runtime.metadata.parachainStaking()
+    val callName = parachainStaking.firstExistingCallName(
+        "nominate",
+        "delegate_with_auto_compound",
+        "delegate"
+    )
+
+    val arguments: Map<String, Any?> = when (callName) {
+        "nominate" -> mapOf(
+            "candidate" to candidate,
+            "amount" to amount,
+            "candidate_nomination_count" to candidateDelegationCount,
+            "nomination_count" to delegationCount
         )
-    } else {
-        call(
-            moduleName = Modules.PARACHAIN_STAKING,
-            callName = "delegate",
-            arguments = mapOf(
-                "candidate" to candidate,
-                "amount" to amount,
-                "candidate_delegation_count" to candidateDelegationCount,
-                "delegation_count" to delegationCount
-            )
+        "delegate_with_auto_compound" -> mapOf(
+            "candidate" to candidate,
+            "amount" to amount,
+            "auto_compound" to BigInteger.ZERO,
+            "candidate_delegation_count" to candidateDelegationCount,
+            "candidate_auto_compounding_delegation_count" to BigInteger.ZERO,
+            "delegation_count" to delegationCount
+        )
+        else -> mapOf(
+            "candidate" to candidate,
+            "amount" to amount,
+            "candidate_delegation_count" to candidateDelegationCount,
+            "delegation_count" to delegationCount
         )
     }
-}
 
-private fun RuntimeMetadata.hasDelegateAutoCompoundCall(): Boolean {
-    return parachainStaking().hasCall("delegate_with_auto_compound")
+    return call(moduleName = Modules.PARACHAIN_STAKING, callName = callName, arguments = arguments)
 }
 
 fun ExtrinsicBuilder.delegatorBondMore(
     candidate: AccountId,
     amount: Balance,
 ): ExtrinsicBuilder {
+    val callName = runtime.metadata.parachainStaking()
+        .firstExistingCallName("bond_extra", "delegator_bond_more")
+
     return call(
         moduleName = Modules.PARACHAIN_STAKING,
-        callName = "delegator_bond_more",
+        callName = callName,
         arguments = mapOf(
             "candidate" to candidate,
             "more" to amount
@@ -64,12 +72,13 @@ fun ExtrinsicBuilder.delegatorBondMore(
 fun ExtrinsicBuilder.scheduleRevokeDelegation(
     collatorId: AccountId
 ): ExtrinsicBuilder {
+    val callName = runtime.metadata.parachainStaking()
+        .firstExistingCallName("schedule_revoke_nomination", "schedule_revoke_delegation")
+
     return call(
         moduleName = Modules.PARACHAIN_STAKING,
-        callName = "schedule_revoke_delegation",
-        arguments = mapOf(
-            "collator" to collatorId,
-        )
+        callName = callName,
+        arguments = mapOf("collator" to collatorId)
     )
 }
 
@@ -77,9 +86,12 @@ fun ExtrinsicBuilder.scheduleBondLess(
     collatorId: AccountId,
     amount: Balance,
 ): ExtrinsicBuilder {
+    val callName = runtime.metadata.parachainStaking()
+        .firstExistingCallName("schedule_nominator_unbond", "schedule_delegator_bond_less")
+
     return call(
         moduleName = Modules.PARACHAIN_STAKING,
-        callName = "schedule_delegator_bond_less",
+        callName = callName,
         arguments = mapOf(
             "candidate" to collatorId,
             "less" to amount
@@ -91,11 +103,16 @@ fun ExtrinsicBuilder.executeDelegationRequest(
     delegator: AccountId,
     collatorId: AccountId
 ): ExtrinsicBuilder {
+    val callName = runtime.metadata.parachainStaking()
+        .firstExistingCallName("execute_nomination_request", "execute_delegation_request")
+
+    val delegatorKey = if (callName == "execute_nomination_request") "nominator" else "delegator"
+
     return call(
         moduleName = Modules.PARACHAIN_STAKING,
-        callName = "execute_delegation_request",
+        callName = callName,
         arguments = mapOf(
-            "delegator" to delegator,
+            delegatorKey to delegator,
             "candidate" to collatorId
         )
     )
@@ -104,11 +121,12 @@ fun ExtrinsicBuilder.executeDelegationRequest(
 fun ExtrinsicBuilder.cancelDelegationRequest(
     collatorId: AccountId
 ): ExtrinsicBuilder {
+    val callName = runtime.metadata.parachainStaking()
+        .firstExistingCallName("cancel_nomination_request", "cancel_delegation_request")
+
     return call(
         moduleName = Modules.PARACHAIN_STAKING,
-        callName = "cancel_delegation_request",
-        arguments = mapOf(
-            "candidate" to collatorId,
-        )
+        callName = callName,
+        arguments = mapOf("candidate" to collatorId)
     )
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/CurrentRoundRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/CurrentRoundRepository.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository
 
 import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.feature_account_api.data.model.AccountIdMap
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.RoundIndex
@@ -52,13 +53,17 @@ class RealCurrentRoundRepository(
 
     override fun currentRoundInfoFlow(chainId: ChainId): Flow<RoundInfo> {
         return storageDataSource.subscribe(chainId) {
-            runtime.metadata.parachainStaking().storage("Round").observe(binding = ::bindRoundInfo)
+            val parachainStaking = runtime.metadata.parachainStaking()
+            val roundStorageName = if (parachainStaking.hasStorage("Era")) "Era" else "Round"
+            parachainStaking.storage(roundStorageName).observe(binding = ::bindRoundInfo)
         }
     }
 
     override suspend fun currentRoundInfo(chainId: ChainId): RoundInfo {
         return storageDataSource.query(chainId) {
-            runtime.metadata.parachainStaking().storage("Round").query(binding = ::bindRoundInfo)
+            val parachainStaking = runtime.metadata.parachainStaking()
+            val roundStorageName = if (parachainStaking.hasStorage("Era")) "Era" else "Round"
+            parachainStaking.storage(roundStorageName).query(binding = ::bindRoundInfo)
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/DelegatorStateRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/DelegatorStateRepository.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository
 
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.feature_account_api.data.model.AccountIdMap
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
@@ -68,7 +69,9 @@ class RealDelegatorStateRepository(
 
     override fun observeDelegatorState(chain: Chain, chainAsset: Chain.Asset, accountId: AccountId): Flow<DelegatorState> {
         return localStorage.subscribe(chain.id) {
-            runtime.metadata.parachainStaking().storage("DelegatorState").observe(
+            val parachainStaking = runtime.metadata.parachainStaking()
+            val storageName = if (parachainStaking.hasStorage("NominatorState")) "NominatorState" else "DelegatorState"
+            parachainStaking.storage(storageName).observe(
                 accountId,
                 binding = { bindDelegatorState(it, accountId, chain, chainAsset) }
             )
@@ -77,7 +80,9 @@ class RealDelegatorStateRepository(
 
     override suspend fun getDelegationState(chain: Chain, chainAsset: Chain.Asset, accountId: AccountId): DelegatorState {
         return localStorage.query(chain.id) {
-            runtime.metadata.parachainStaking().storage("DelegatorState").query(
+            val parachainStaking = runtime.metadata.parachainStaking()
+            val storageName = if (parachainStaking.hasStorage("NominatorState")) "NominatorState" else "DelegatorState"
+            parachainStaking.storage(storageName).query(
                 accountId,
                 binding = { bindDelegatorState(it, accountId, chain, chainAsset) }
             )

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/ParachainStakingConstantsRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/ParachainStakingConstantsRepository.kt
@@ -30,25 +30,37 @@ class RuntimeParachainStakingConstantsRepository(
 ) : ParachainStakingConstantsRepository {
 
     override suspend fun maxRewardedDelegatorsPerCollator(chainId: ChainId): BigInteger {
-        return numberConstant(chainId, "MaxTopDelegationsPerCandidate")
+        // EWX (AvN) renames to MaxTopNominationsPerCandidate.
+        return numberConstantOrNull(chainId, "MaxTopNominationsPerCandidate")
+            ?: numberConstant(chainId, "MaxTopDelegationsPerCandidate")
     }
 
     override suspend fun minimumDelegation(chainId: ChainId): BigInteger {
-        return numberConstant(chainId, "MinDelegation")
+        // EWX (AvN) renames to MinNominationPerCollator.
+        return numberConstantOrNull(chainId, "MinNominationPerCollator")
+            ?: numberConstant(chainId, "MinDelegation")
     }
 
     override suspend fun minimumDelegatorStake(chainId: ChainId): BigInteger {
-        return numberConstantOrNull(chainId, "MinDelegatorStk")
+        return numberConstantOrNull(chainId, "MinNominationPerCollator")
+            ?: numberConstantOrNull(chainId, "MinDelegatorStk")
             // Starting from runtime 2500, MinDelegatorStk was removed and only MinDelegation remained
             ?: minimumDelegation(chainId)
     }
 
     override suspend fun delegationBondLessDelay(chainId: ChainId): BigInteger {
-        return numberConstant(chainId, "DelegationBondLessDelay")
+        // EWX (AvN) has no equivalent constant — the unbond delay is the
+        // `Delay` storage value (~2 eras). The reward calculator uses this
+        // delay for display only, so fall back to 2 if the constant is
+        // absent. A precise on-chain read would require storage access
+        // outside this repository's surface.
+        return numberConstantOrNull(chainId, "DelegationBondLessDelay") ?: BigInteger.TWO
     }
 
     override suspend fun maxDelegationsPerDelegator(chainId: ChainId): BigInteger {
-        return numberConstant(chainId, "MaxDelegationsPerDelegator")
+        // EWX (AvN) renames to MaxNominationsPerNominator.
+        return numberConstantOrNull(chainId, "MaxNominationsPerNominator")
+            ?: numberConstant(chainId, "MaxDelegationsPerDelegator")
     }
 
     private suspend fun numberConstant(chainId: ChainId, name: String): BigInteger {

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/RewardsRepository.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/RewardsRepository.kt
@@ -2,8 +2,10 @@ package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.reposi
 
 import io.novafoundation.nova.common.data.network.runtime.binding.Perbill
 import io.novafoundation.nova.common.data.network.runtime.binding.bindPerbill
+import io.novafoundation.nova.common.data.network.runtime.binding.bindPerbillNumber
 import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
+import io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.network.bindings.bindCommissionSetting
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.bindings.InflationDistributionConfig
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.bindings.InflationInfo
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.bindings.bindInflationDistributionConfig
@@ -12,6 +14,7 @@ import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import io.novasama.substrate_sdk_android.runtime.metadata.storage
+import java.math.BigDecimal
 
 interface RewardsRepository {
 
@@ -46,7 +49,14 @@ class RealRewardsRepository(
 
     override suspend fun getCollatorCommission(chainId: ChainId): Perbill {
         return storageDataSource.query(chainId) {
-            runtime.metadata.parachainStaking().storage("CollatorCommission").query(binding = ::bindPerbill)
+            val parachainStaking = runtime.metadata.parachainStaking()
+
+            if (parachainStaking.hasStorage("DefaultCollatorCommission")) {
+                val setting = parachainStaking.storage("DefaultCollatorCommission").query(binding = ::bindCommissionSetting)
+                setting?.let { bindPerbillNumber(it.current) } ?: BigDecimal.ZERO
+            } else {
+                parachainStaking.storage("CollatorCommission").query(binding = ::bindPerbill)
+            }
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/scheduledRequests/DelegationScheduledRequestFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/parachainStaking/repository/scheduledRequests/DelegationScheduledRequestFactory.kt
@@ -1,8 +1,10 @@
 package io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.scheduledRequests
 
+import io.novafoundation.nova.common.utils.hasStorage
 import io.novafoundation.nova.common.utils.parachainStaking
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.DelegatorState
 import io.novafoundation.nova.feature_staking_api.domain.model.parachain.ScheduledDelegationRequest
+import io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.repository.scheduledRequests.AvnNominationScheduledRequestFactory
 import io.novafoundation.nova.runtime.storage.source.StorageEntries
 import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -12,10 +14,18 @@ import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Vec
 import io.novasama.substrate_sdk_android.runtime.metadata.storage
 import kotlinx.coroutines.flow.Flow
 
-class DelegationScheduledRequestFactory {
+class DelegationScheduledRequestFactory(
+    private val avnFactory: AvnNominationScheduledRequestFactory = AvnNominationScheduledRequestFactory(),
+) {
     context(StorageQueryContext)
     fun create(): DelegationScheduledRequestExecutor {
-        val storage = runtime.metadata.parachainStaking().storage("DelegationScheduledRequests")
+        val parachainStaking = runtime.metadata.parachainStaking()
+
+        if (parachainStaking.hasStorage("NominationScheduledRequests")) {
+            return avnFactory.create()
+        }
+
+        val storage = parachainStaking.storage("DelegationScheduledRequests")
         val vec = storage.type.value as Vec
         val alias = vec.typeReference.value as Alias
         val struct = alias.aliasedReference.value as Struct

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/datasource/StakingRewardPeriodDataSource.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/data/repository/datasource/StakingRewardPeriodDataSource.kt
@@ -119,6 +119,7 @@ class RealStakingRewardPeriodDataSource(
             Chain.Asset.StakingType.TURING -> "TURING"
             Chain.Asset.StakingType.NOMINATION_POOLS -> "NOMINATION_POOLS"
             Chain.Asset.StakingType.MYTHOS -> "MYTHOS"
+            Chain.Asset.StakingType.PARACHAIN_AVN -> "PARACHAIN_AVN"
         }
     }
 }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/parachain/ParachainStakingModule.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/di/staking/parachain/ParachainStakingModule.kt
@@ -18,6 +18,8 @@ import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.reposit
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.RealCandidatesRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.RealCurrentRoundRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.RealDelegatorStateRepository
+import io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.repository.AvnRewardsRepository
+import io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.repository.RealAvnRewardsRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.RealRewardsRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.RewardsRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.RuntimeParachainStakingConstantsRepository
@@ -83,6 +85,12 @@ class ParachainStakingModule {
 
     @Provides
     @FeatureScope
+    fun provideAvnRewardsRepository(
+        @Named(LOCAL_STORAGE_SOURCE) storageDataSource: StorageDataSource
+    ): AvnRewardsRepository = RealAvnRewardsRepository(storageDataSource)
+
+    @Provides
+    @FeatureScope
     fun provideCandidatesRepository(
         @Named(REMOTE_STORAGE_SOURCE) storageDataSource: StorageDataSource
     ): CandidatesRepository = RealCandidatesRepository(storageDataSource)
@@ -106,10 +114,11 @@ class ParachainStakingModule {
     @FeatureScope
     fun provideRewardCalculatorFactory(
         rewardsRepository: RewardsRepository,
+        avnRewardsRepository: AvnRewardsRepository,
         commonStakingRepository: TotalIssuanceRepository,
         currentRoundRepository: CurrentRoundRepository,
         turingStakingRewardsRepository: TuringStakingRewardsRepository,
-    ) = ParachainStakingRewardCalculatorFactory(rewardsRepository, currentRoundRepository, commonStakingRepository, turingStakingRewardsRepository)
+    ) = ParachainStakingRewardCalculatorFactory(rewardsRepository, avnRewardsRepository, currentRoundRepository, commonStakingRepository, turingStakingRewardsRepository)
 
     @Provides
     @FeatureScope

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rewards/AvnParachainStakingRewardCalculator.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rewards/AvnParachainStakingRewardCalculator.kt
@@ -1,0 +1,69 @@
+package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.rewards
+
+import io.novafoundation.nova.common.data.network.runtime.binding.Perbill
+import io.novafoundation.nova.feature_staking_impl.domain.rewards.PeriodReturns
+import io.novasama.substrate_sdk_android.extensions.toHexString
+import io.novasama.substrate_sdk_android.runtime.AccountId
+import java.math.BigDecimal
+
+private const val DAYS_IN_YEAR = 365
+
+class AvnParachainStakingRewardCalculator(
+    annualApr: BigDecimal,
+    collators: List<ParachainStakingRewardTarget>,
+    private val collatorCommission: Perbill,
+) : ParachainStakingRewardCalculator {
+
+    private val annualReturn = annualApr.toDouble()
+
+    private val averageStake = collators.map { it.totalStake.toDouble() }
+        .takeIf { it.isNotEmpty() }
+        ?.average()
+        ?: 0.0
+
+    private val aprByCollator = collators.associateBy(
+        keySelector = ParachainStakingRewardTarget::accountIdHex,
+        valueTransform = ::collatorApr
+    )
+
+    private val averageApr = aprFor(collatorStake = averageStake)
+
+    private val maxApr = aprByCollator.values.maxOrNull() ?: 0.0
+
+    override fun maximumGain(days: Int): BigDecimal {
+        return (maxApr * days / DAYS_IN_YEAR).toBigDecimal()
+    }
+
+    override fun collatorApr(collatorIdHex: String): BigDecimal? {
+        return aprByCollator[collatorIdHex]?.toBigDecimal()
+    }
+
+    override fun calculateCollatorAnnualReturns(collatorId: AccountId, amount: BigDecimal): PeriodReturns {
+        val collatorApr = collatorApr(collatorId.toHexString()) ?: averageApr.toBigDecimal()
+
+        return PeriodReturns(
+            gainAmount = amount * collatorApr,
+            gainFraction = collatorApr,
+            isCompound = false
+        )
+    }
+
+    override fun calculateMaxAnnualReturns(amount: BigDecimal): PeriodReturns {
+        val maxAnnual = maximumAnnualApr()
+
+        return PeriodReturns(
+            gainAmount = amount * maxAnnual,
+            gainFraction = maxAnnual,
+            isCompound = false
+        )
+    }
+
+    private fun collatorApr(collator: ParachainStakingRewardTarget): Double {
+        return aprFor(collator.totalStake.toDouble())
+    }
+
+    private fun aprFor(collatorStake: Double): Double {
+        if (collatorStake <= 0.0 || averageStake <= 0.0) return 0.0
+        return annualReturn * (1 - collatorCommission.toDouble()) * (averageStake / collatorStake)
+    }
+}

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rewards/ParachainStakingRewardCalculatorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/parachainStaking/rewards/ParachainStakingRewardCalculatorFactory.kt
@@ -2,14 +2,18 @@ package io.novafoundation.nova.feature_staking_impl.domain.parachainStaking.rewa
 
 import io.novafoundation.nova.feature_account_api.data.model.AccountIdMap
 import io.novafoundation.nova.feature_staking_impl.data.StakingOption
+import io.novafoundation.nova.feature_staking_impl.data.parachainAvnStaking.repository.AvnRewardsRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.network.bindings.CollatorSnapshot
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.CurrentRoundRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.repository.RewardsRepository
 import io.novafoundation.nova.feature_staking_impl.data.parachainStaking.turing.repository.TuringStakingRewardsRepository
+import java.math.BigDecimal
+import java.math.BigInteger
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.ALEPH_ZERO
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.MYTHOS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN_AVN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
@@ -19,6 +23,7 @@ import io.novafoundation.nova.runtime.repository.TotalIssuanceRepository
 
 class ParachainStakingRewardCalculatorFactory(
     private val rewardsRepository: RewardsRepository,
+    private val avnRewardsRepository: AvnRewardsRepository,
     private val currentRoundRepository: CurrentRoundRepository,
     private val commonStakingRepository: TotalIssuanceRepository,
     private val turingStakingRewardsRepository: TuringStakingRewardsRepository,
@@ -33,10 +38,37 @@ class ParachainStakingRewardCalculatorFactory(
         return when (stakingOption.additional.stakingType) {
             PARACHAIN -> defaultCalculator(chainId, snapshots)
             TURING -> turingCalculator(chainId, snapshots)
+            PARACHAIN_AVN -> avnCalculator(chainId, snapshots)
             NOMINATION_POOLS, RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO, UNSUPPORTED, MYTHOS -> {
                 throw IllegalStateException("Unknown staking type in ParachainStakingRewardCalculatorFactory")
             }
         }
+    }
+
+    private suspend fun avnCalculator(
+        chainId: ChainId,
+        snapshots: AccountIdMap<CollatorSnapshot>
+    ): ParachainStakingRewardCalculator {
+        val snapshot = avnRewardsRepository.getGrowthSnapshot(chainId)
+        val totalStaked = currentRoundRepository.totalStaked(chainId)
+        val commission = avnRewardsRepository.getCommission(chainId)
+
+        val annualApr: BigDecimal = if (snapshot != null && snapshot.totalStakeAccumulated > BigInteger.ZERO && snapshot.numberOfAccumulations > BigInteger.ZERO) {
+            val rewardFraction = snapshot.totalStakerReward.toBigDecimal() / snapshot.totalStakeAccumulated.toBigDecimal()
+            val periodsPerYear = BigDecimal(365) / snapshot.numberOfAccumulations.toBigDecimal()
+            rewardFraction * periodsPerYear
+        } else {
+            // Fallback while the first growth period is still accumulating.
+            // 2M EWT / year is the documented Energy Web X validator-reward budget.
+            val fallback = BigDecimal(2_000_000) * BigDecimal.TEN.pow(18)
+            if (totalStaked > BigInteger.ZERO) fallback / totalStaked.toBigDecimal() else BigDecimal.ZERO
+        }
+
+        return AvnParachainStakingRewardCalculator(
+            annualApr = annualApr,
+            collators = snapshots.toCollatorList(),
+            collatorCommission = commission
+        )
     }
 
     private suspend fun turingCalculator(

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/rewards/RewardCalculatorFactory.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/domain/rewards/RewardCalculatorFactory.kt
@@ -22,6 +22,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.MYTHOS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN_AVN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
@@ -89,7 +90,7 @@ class RewardCalculatorFactory(
             }
 
             ALEPH_ZERO -> AlephZeroRewardCalculator(validators, chainAsset = assetWithChain.asset)
-            NOMINATION_POOLS, UNSUPPORTED, PARACHAIN, TURING, MYTHOS -> throw IllegalStateException("Unknown staking type in RelaychainRewardFactory")
+            NOMINATION_POOLS, UNSUPPORTED, PARACHAIN, TURING, MYTHOS, PARACHAIN_AVN -> throw IllegalStateException("Unknown staking type in RelaychainRewardFactory")
         }
     }
 

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/CompoundStatefullComponent.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/staking/main/components/CompoundStatefullComponent.kt
@@ -12,6 +12,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.MYTHOS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN_AVN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
@@ -83,7 +84,7 @@ private class CompoundStakingComponent<S, E, A>(
         return when (stakingOption.additional.stakingType) {
             UNSUPPORTED -> UnsupportedComponent()
             RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO -> relaychainComponentCreator(stakingOption, childHostContext)
-            PARACHAIN -> parachainComponentCreator(stakingOption, childHostContext)
+            PARACHAIN, PARACHAIN_AVN -> parachainComponentCreator(stakingOption, childHostContext)
             TURING -> turingComponentCreator(stakingOption, childHostContext)
             NOMINATION_POOLS -> nominationPoolsCreator(stakingOption, childHostContext)
             MYTHOS -> mythosCreator(stakingOption, childHostContext)

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/ext/ChainExt.kt
@@ -21,6 +21,7 @@ import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.Staki
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.MYTHOS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.NOMINATION_POOLS
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.PARACHAIN_AVN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.RELAYCHAIN_AURA
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain.Asset.StakingType.TURING
@@ -179,7 +180,7 @@ fun Chain.Asset.StakingType.group(): StakingTypeGroup {
     return when (this) {
         UNSUPPORTED -> StakingTypeGroup.UNSUPPORTED
         RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO -> StakingTypeGroup.RELAYCHAIN
-        PARACHAIN, TURING -> StakingTypeGroup.PARACHAIN
+        PARACHAIN, TURING, PARACHAIN_AVN -> StakingTypeGroup.PARACHAIN
         MYTHOS -> StakingTypeGroup.MYTHOS
         NOMINATION_POOLS -> StakingTypeGroup.NOMINATION_POOL
     }

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/LocalToDomainChainMapper.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/LocalToDomainChainMapper.kt
@@ -40,6 +40,33 @@ private fun mapStakingTypeFromLocal(stakingTypesLocal: String): List<Chain.Asset
     return stakingTypesLocal.split(",").mapNotNull { enumValueOfOrNull<Chain.Asset.StakingType>(it) }
 }
 
+// [TEMP-QA-HACK] EWX (Energy Web X) parachain themeColor — iOS dev config
+// uses #A566FF but production nova-utils chains.json doesn't carry it yet.
+// Inject it on read so cached chain rows show the right purple highlight.
+private const val EWX_CHAIN_ID = "5a51e04b88a4784d205091aa7bada002f3e5da3045e5b05655ee4db2589c33b5"
+private const val EWX_THEME_COLOR = "#A566FF"
+
+private fun applyEwxThemeColorOverride(chainId: String, additional: Chain.Additional?): Chain.Additional? {
+    if (chainId != EWX_CHAIN_ID) return additional
+    if (additional?.themeColor != null) return additional
+
+    return (additional ?: Chain.Additional(
+        defaultTip = null,
+        themeColor = null,
+        stakingWiki = null,
+        defaultBlockTimeMillis = null,
+        relaychainAsNative = null,
+        stakingMaxElectingVoters = null,
+        feeViaRuntimeCall = null,
+        supportLedgerGenericApp = null,
+        identityChain = null,
+        disabledCheckMetadataHash = null,
+        sessionLength = null,
+        sessionsPerEra = null,
+        timelineChain = null
+    )).copy(themeColor = EWX_THEME_COLOR)
+}
+
 fun mapAssetSourceFromLocal(source: AssetSourceLocal): Chain.Asset.Source {
     return when (source) {
         AssetSourceLocal.DEFAULT -> Chain.Asset.Source.DEFAULT
@@ -249,9 +276,10 @@ fun mapChainLocalToChain(
         mapExternalApiLocalToExternalApi(it, gson)
     }
 
-    val additional = chainLocal.additional?.let { raw ->
+    val rawAdditional = chainLocal.additional?.let { raw ->
         gson.fromJson<Chain.Additional>(raw)
     }
+    val additional = applyEwxThemeColorOverride(chainLocal.id, rawAdditional)
 
     return with(chainLocal) {
         Chain(

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/mappers/RemoteToLocalChainMappers.kt
@@ -47,6 +47,11 @@ private const val SESSION_LENGTH = "sessionLength"
 private const val SESSIONS_PER_ERA = "sessionsPerEra"
 private const val TIMELINE_CHAIN = "timelineChain"
 
+// [TEMP-QA-HACK] EWX chain id — used to inject the staking theme color and
+// other settings until nova-utils chains.json carries them upstream.
+private const val EWX_CHAIN_ID = "5a51e04b88a4784d205091aa7bada002f3e5da3045e5b05655ee4db2589c33b5"
+private const val EWX_THEME_COLOR = "#A566FF"
+
 fun mapRemoteChainToLocal(
     chainRemote: ChainRemote,
     oldChain: ChainLocal?,
@@ -61,9 +66,11 @@ fun mapRemoteChainToLocal(
     }
 
     val additional = chainRemote.additional?.let {
+        val themeColor = (it[CHAIN_THEME_COLOR] as? String)
+            ?: EWX_THEME_COLOR.takeIf { chainRemote.chainId == EWX_CHAIN_ID }
         Chain.Additional(
             defaultTip = (it[CHAIN_ADDITIONAL_TIP] as? String)?.toBigInteger(),
-            themeColor = (it[CHAIN_THEME_COLOR] as? String),
+            themeColor = themeColor,
             stakingWiki = (it[CHAIN_STAKING_WIKI] as? String),
             defaultBlockTimeMillis = it[DEFAULT_BLOCK_TIME].asGsonParsedLongOrNull(),
             relaychainAsNative = it[RELAYCHAIN_AS_NATIVE] as? Boolean,
@@ -76,6 +83,25 @@ fun mapRemoteChainToLocal(
             sessionsPerEra = it[SESSIONS_PER_ERA].asGsonParsedIntOrNull(),
             timelineChain = it[TIMELINE_CHAIN] as? ChainId
         )
+    } ?: run {
+        // [TEMP-QA-HACK] EWX chain may arrive with no `additional` block at all.
+        if (chainRemote.chainId == EWX_CHAIN_ID) {
+            Chain.Additional(
+                defaultTip = null,
+                themeColor = EWX_THEME_COLOR,
+                stakingWiki = null,
+                defaultBlockTimeMillis = null,
+                relaychainAsNative = null,
+                stakingMaxElectingVoters = null,
+                feeViaRuntimeCall = null,
+                supportLedgerGenericApp = null,
+                identityChain = null,
+                disabledCheckMetadataHash = null,
+                sessionLength = null,
+                sessionsPerEra = null,
+                timelineChain = null
+            )
+        } else null
     }
 
     val chainLocal = with(chainRemote) {
@@ -164,7 +190,7 @@ fun mapRemoteAssetToLocal(
         chainId = chainRemote.chainId,
         name = assetRemote.name ?: chainRemote.name,
         priceId = assetRemote.priceId,
-        staking = mapRemoteStakingTypesToLocal(assetRemote.staking),
+        staking = applyEwtStakingOverride(assetRemote, mapRemoteStakingTypesToLocal(assetRemote.staking)),
         type = assetRemote.type,
         source = AssetSourceLocal.DEFAULT,
         buyProviders = gson.toJson(assetRemote.buyProviders),
@@ -242,6 +268,15 @@ private fun mapRemoteStakingTypesToLocal(stakingTypesRemote: List<String>?): Str
     }
 }
 
+// [TEMP-QA-HACK] EWT staking: inject "parachain-avn" for EWT on EWX
+// until nova-utils PR adds it to chains.json. Remove once the upstream
+// change ships and the app re-fetches the chain registry.
+private fun applyEwtStakingOverride(assetRemote: ChainAssetRemote, localStaking: String): String {
+    if (localStaking.isNotEmpty()) return localStaking
+    if (assetRemote.priceId != "energy-web-token") return localStaking
+    return mapStakingTypeToLocal(Chain.Asset.StakingType.PARACHAIN_AVN)
+}
+
 fun mapStakingStringToStakingType(stakingString: String?): Chain.Asset.StakingType {
     return when (stakingString) {
         null -> Chain.Asset.StakingType.UNSUPPORTED
@@ -252,6 +287,7 @@ fun mapStakingStringToStakingType(stakingString: String?): Chain.Asset.StakingTy
         "turing" -> Chain.Asset.StakingType.TURING
         "aleph-zero" -> Chain.Asset.StakingType.ALEPH_ZERO
         "mythos" -> Chain.Asset.StakingType.MYTHOS
+        "parachain-avn" -> Chain.Asset.StakingType.PARACHAIN_AVN
         else -> Chain.Asset.StakingType.UNSUPPORTED
     }
 }
@@ -266,6 +302,7 @@ fun mapStakingTypeToStakingString(stakingType: Chain.Asset.StakingType): String?
         Chain.Asset.StakingType.ALEPH_ZERO -> "aleph-zero"
         Chain.Asset.StakingType.NOMINATION_POOLS -> "nomination-pools"
         Chain.Asset.StakingType.MYTHOS -> "mythos"
+        Chain.Asset.StakingType.PARACHAIN_AVN -> "parachain-avn"
     }
 }
 

--- a/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
+++ b/runtime/src/main/java/io/novafoundation/nova/runtime/multiNetwork/chain/model/Chain.kt
@@ -130,7 +130,7 @@ data class Chain(
         enum class StakingType {
             UNSUPPORTED,
             RELAYCHAIN, RELAYCHAIN_AURA, ALEPH_ZERO, // relaychain like
-            PARACHAIN, TURING, // parachain-staking like
+            PARACHAIN, TURING, PARACHAIN_AVN, // parachain-staking like
             NOMINATION_POOLS,
             MYTHOS
         }


### PR DESCRIPTION
## Summary

Android counterpart of novasamatech/nova-wallet-ios#1832. Full nominator lifecycle on EnergyWebX (EWX) mainnet: nominate, schedule revoke / partial unbond, cancel scheduled requests, execute on delay. All on-screen data is sourced from live chain queries — no hardcoded values and no external REST data sources.

**What ships:**
- Standard Nova staking surface for EWT: dashboard tile, Start Staking Info screen, stake / Stake more / Unstake / Redeem confirm flow.
- Validator (collator) picker fed by `CandidatePool` + `CandidateInfo` storage with identity overlay where present.
- Commission read from `defaultCollatorCommission` storage; APR computed from `Growth` storage accumulators (week / month / 6-month / year).
- Schedule-revoke / partial-unbond / cancel / execute, dispatched against the runtime call names the chain exposes.

## Architecture

- **Reuse over fork.** Unlike the iOS port, the Android side does not create a parallel `ParachainAvn*` namespace. Instead, runtime probes inside the existing parachain pipeline serve Moonbeam, Turing, and EWX with the same code paths — every probe falls through to the Moonbeam name when the AvN name is absent. New files only appear where EWX adds genuinely new machinery (Growth APR, scheduled-nomination-requests executor pair + factory, AvN reward calculator).
- **`PARACHAIN_AVN` routed into `StakingTypeGroup.PARACHAIN`** so the existing Dagger graph and dashboard plumbing apply unchanged. Only the reward-calculator and call-name dispatch needed new branches.
- **`hasStorage()` probes** for `NominatorState` / `Era` / `DefaultCollatorCommission` / `NominationScheduledRequests` are wired into 7 repositories and updaters. `InflationConfigUpdater` short-circuits when storage is absent (EWX has no `InflationConfig`).
- **Shared binders** (`bindDelegatorState`, `bindCollatorSnapshot`, `bindCandidateMetadata`) dual-decode AvN field names alongside Moonbeam names. Backward-compatible — Moonbeam decoding is unchanged.
- **Extrinsic dispatchers** (`delegate`, `delegatorBondMore`, etc.) use `firstExistingCallName` to pick the right call name at submit time. Argument keys (e.g. `nominator` vs `delegator`) follow the resolved call.
- **AvN reward calculator.** `AvnRewardsRepository.getGrowthSnapshot` is wrapped in `withTimeoutOrNull(3s)` because the `GrowthPeriod` RPC stalls on EWX when no period has accumulated yet — without the timeout the Start Staking Info screen hangs indefinitely. The fallback is 2M EWT / year over live total stake, kept conservative.
- **Constants probes** (`RuntimeParachainStakingConstantsRepository`) try AvN names first (`MinNominationPerCollator`, `MaxTopNominationsPerCandidate`, `MaxNominationsPerNominator`) before Moonbeam fallbacks. `delegationBondLessDelay` falls back to 2 eras when the constant is absent — follow-up should read EWX's `Delay` storage live (interface refactor needed).
- **`[TEMP-QA-HACK]` chain-config overrides** in `RemoteToLocalChainMappers.applyEwtStakingOverride` (injects `parachain-avn` for assets with priceId `energy-web-token`) + `LocalToDomainChainMapper.applyEwxThemeColorOverride` (injects the staking theme colour at read time so cached chain rows don't need a DB clear). Both gated on the EWX chain id and both removed when novasamatech/nova-utils#4336 lands.

## Notes

- iOS counterpart: novasamatech/nova-wallet-ios#1832.
- Companion chain-config change: novasamatech/nova-utils#4336 — adds `staking: ["parachain-avn"]` + theme colour to EWT; once merged, both `[TEMP-QA-HACK]` mapper overrides are removable.
- Follow-up: plumb storage access into the constants repo so `delegationBondLessDelay` reads `Delay` live instead of the 2-era fallback.

### Indexer dependency

`subquery-staking-energywebx-prod` (Nova ops) needs to be deployed so the following code paths in this PR can render against production data:

- **Per-account staking reward history** (round, collator, amount, timestamp) — rewards card on the position screen.
- **Per-collator APR rolling-window estimate** — dashboard tile headline yield. The on-chain `Growth`-derived APR powers the Start Staking Info screen today but isn't suitable for per-collator surfacing on the tile.
- **Round / era metadata** — round number + boundary timestamps, used for charting and "next payout in X" UI.
