### PR TITLE
Pin scaleway/action-scw-secret to last working commit

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: 🔐 Fetch secrets from Scaleway
-      uses: scaleway/action-scw-secret@v0
+      uses: scaleway/action-scw-secret@9f2ead1e62c0b201b34035cd2ae5274f64c58787 # v0 pinned: newer v0 breaks project-scoped keys
       with:
         secret-names: |
           CI_MARKET_KEYSTORE_PASS,/dev/android/GPLAY_KEYSTORE_PASSWORD


### PR DESCRIPTION
## Problem

CI workflows that fetch secrets via `scaleway/action-scw-secret` started failing on 2026-07-02 with:

```
Failed to fetch secret: '...'. Error: PermissionsDeniedError: insufficient permissions: list secret.
```

Nothing changed on our side — GitHub secrets, the Scaleway IAM policy, and the API key are all intact. The trigger is upstream: scaleway/action-scw-secret#145 was merged on 2026-07-02 at 07:13 UTC and the floating `v0` tag picked it up. The new version passes `organization_id` to the `ListSecrets` call, which requires organization-wide list permission. Our CI keys are intentionally scoped to a single project, so every secret fetch now fails.

## Fix

Pin the action to `9f2ead1e62c0b201b34035cd2ae5274f64c58787` — the last release before the regression. Pinning by SHA also protects us from similar surprises in the future.

Reported upstream: scaleway/action-scw-secret#146.
