### PR TITLE
CI: install NDK 29.0.14206865 to match android.ndkVersion. NW-2116

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -63,12 +63,12 @@ runs:
 
     - name: Install NDK
       if: inputs.minimal_mode != 'true'
-      run: echo "y" | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/16.0/bin/sdkmanager --install "ndk;26.1.10909125" --sdk_root=${ANDROID_SDK_ROOT}
+      run: echo "y" | sudo ${ANDROID_SDK_ROOT}/cmdline-tools/16.0/bin/sdkmanager --install "ndk;29.0.14206865" --sdk_root=${ANDROID_SDK_ROOT}
       shell: bash
 
     - name: Set ndk.dir in local.properties
       if: inputs.minimal_mode != 'true'
-      run: echo "ndk.dir=${ANDROID_SDK_ROOT}/ndk/26.1.10909125" >> local.properties
+      run: echo "ndk.dir=${ANDROID_SDK_ROOT}/ndk/29.0.14206865" >> local.properties
       shell: bash
 
     - name: 🦀 Install Rust

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ buildscript {
 
         web3jVersion = '4.9.5'
 
-        substrateSdkVersion = '2.11.9'
+        substrateSdkVersion = '2.12.0'
 
         gifVersion = '1.2.31'
 

--- a/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/application/substrate/newApp/NewSubstrateLedgerApplication.kt
+++ b/feature-ledger-impl/src/main/java/io/novafoundation/nova/feature_ledger_impl/sdk/application/substrate/newApp/NewSubstrateLedgerApplication.kt
@@ -19,10 +19,7 @@ import io.novafoundation.nova.runtime.extrinsic.metadata.MetadataShortenerServic
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
 import io.novasama.substrate_sdk_android.encrypt.SignatureWrapper
-import io.novasama.substrate_sdk_android.extensions.toHexString
-import io.novasama.substrate_sdk_android.runtime.extrinsic.ExtrinsicVersion
 import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.InheritedImplication
-import io.novasama.substrate_sdk_android.runtime.extrinsic.v5.transactionExtension.signingPayload
 
 abstract class NewSubstrateLedgerApplication(
     private val transport: LedgerTransport,


### PR DESCRIPTION
## Why
CI builds have been failing at the Gradle configure phase since #2285 (May 27) bumped `android.ndkVersion` to `29.0.14206865` in `bindings/hydra-dx-math` and `bindings/metadata_shortener` for 16KB page support:

```
[CXX1104] NDK from ndk.dir at .../ndk/26.1.10909125 had version [26.1.10909125] which disagrees with android.ndkVersion [29.0.14206865]
A problem occurred configuring project ':bindings:hydra-dx-math'.
> NDK is not installed
```

The failure was masked until today by an earlier pipeline break (stale Scaleway API key in repo secrets, now rotated and fixed).

## What
Update the `install` composite action to install NDK `29.0.14206865` and point `ndk.dir` at it, matching the version the project requires.