### PR TITLE
feat: remove crowdloan tab from vote screen

### DIFF
--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/vote/VoteNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/vote/VoteNavigator.kt
@@ -2,7 +2,6 @@ package io.novafoundation.nova.app.root.navigation.navigators.vote
 
 import androidx.fragment.app.Fragment
 import io.novafoundation.nova.app.root.navigation.navigators.Navigator
-import io.novafoundation.nova.feature_crowdloan_impl.presentation.main.CrowdloanFragment
 import io.novafoundation.nova.feature_governance_impl.presentation.referenda.list.ReferendaListFragment
 import io.novafoundation.nova.feature_vote.presentation.VoteRouter
 
@@ -11,10 +10,6 @@ class VoteNavigator(
 ) : VoteRouter {
     override fun getDemocracyFragment(): Fragment {
         return ReferendaListFragment()
-    }
-
-    override fun getCrowdloansFragment(): Fragment {
-        return CrowdloanFragment()
     }
 
     override fun openSwitchWallet() {

--- a/feature-vote/src/main/java/io/novafoundation/nova/feature_vote/presentation/VoteRouter.kt
+++ b/feature-vote/src/main/java/io/novafoundation/nova/feature_vote/presentation/VoteRouter.kt
@@ -6,7 +6,5 @@ interface VoteRouter {
 
     fun getDemocracyFragment(): Fragment
 
-    fun getCrowdloansFragment(): Fragment
-
     fun openSwitchWallet()
 }

--- a/feature-vote/src/main/java/io/novafoundation/nova/feature_vote/presentation/vote/VoteFragment.kt
+++ b/feature-vote/src/main/java/io/novafoundation/nova/feature_vote/presentation/vote/VoteFragment.kt
@@ -4,7 +4,6 @@ import android.view.View
 import io.novafoundation.nova.common.base.BaseFragment
 import io.novafoundation.nova.common.di.FeatureUtils
 import io.novafoundation.nova.common.utils.insets.applyStatusBarInsets
-import io.novafoundation.nova.common.utils.setupWithViewPager2
 import io.novafoundation.nova.feature_vote.databinding.FragmentVoteBinding
 import io.novafoundation.nova.feature_vote.di.VoteFeatureApi
 import io.novafoundation.nova.feature_vote.di.VoteFeatureComponent
@@ -24,9 +23,8 @@ class VoteFragment : BaseFragment<VoteViewModel, FragmentVoteBinding>() {
     }
 
     override fun initViews() {
-        val adapter = VotePagerAdapter(this, router)
-        binder.voteViewPager.adapter = adapter
-        binder.voteTabs.setupWithViewPager2(binder.voteViewPager, adapter::getPageTitle)
+        binder.voteViewPager.adapter = VotePagerAdapter(this, router)
+        binder.voteViewPager.isUserInputEnabled = false
 
         binder.voteAvatar.setOnClickListener { viewModel.avatarClicked() }
     }

--- a/feature-vote/src/main/java/io/novafoundation/nova/feature_vote/presentation/vote/VotePagerAdapter.kt
+++ b/feature-vote/src/main/java/io/novafoundation/nova/feature_vote/presentation/vote/VotePagerAdapter.kt
@@ -2,27 +2,17 @@ package io.novafoundation.nova.feature_vote.presentation.vote
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import io.novafoundation.nova.feature_vote.R
 import io.novafoundation.nova.feature_vote.presentation.VoteRouter
 
-class VotePagerAdapter(private val fragment: Fragment, private val router: VoteRouter) : FragmentStateAdapter(fragment) {
+class VotePagerAdapter(fragment: Fragment, private val router: VoteRouter) : FragmentStateAdapter(fragment) {
 
     override fun getItemCount(): Int {
-        return 2
+        return 1
     }
 
     override fun createFragment(position: Int): Fragment {
         return when (position) {
             0 -> router.getDemocracyFragment()
-            1 -> router.getCrowdloansFragment()
-            else -> throw IllegalArgumentException("Invalid position")
-        }
-    }
-
-    fun getPageTitle(position: Int): CharSequence {
-        return when (position) {
-            0 -> fragment.getString(R.string.common_governance)
-            1 -> fragment.getString(R.string.crowdloan_crowdloan)
             else -> throw IllegalArgumentException("Invalid position")
         }
     }

--- a/feature-vote/src/main/res/layout/fragment_vote.xml
+++ b/feature-vote/src/main/res/layout/fragment_vote.xml
@@ -31,18 +31,10 @@
             android:layout_marginEnd="16dp" />
     </LinearLayout>
 
-    <io.novafoundation.nova.common.view.SegmentedTabLayout
-        android:id="@+id/voteTabs"
-        style="@style/SegmentedTab"
-        android:layout_width="match_parent"
-        android:layout_height="40dp"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginBottom="8dp" />
-
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/voteViewPager"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_marginTop="16dp" />
 
 </LinearLayout>


### PR DESCRIPTION
Removes the "Crowdloans" tab from the Vote screen, leaving it governance-only.

<img width="300" height="600" alt="Screenshot_1786454364" src="https://github.com/user-attachments/assets/dfb86873-af11-4907-8f5c-fb45316a9385" />


### Why

Crowdloans are finished on both Polkadot and Kusama, and there is nothing left for
users to do in this screen:

- `Crowdloan.Funds` is empty on both relay chains (92 funds ever created on Polkadot,
  101 on Kusama — all dissolved). Every `py/cfund` sub-account has been reaped, so
  **0 DOT / 0 KSM** remain to be returned.
- The post-migration reclaim path is empty too: `AhOps.RcCrowdloanContribution`,
  `RcCrowdloanReserve` and `RcLeaseReserve` all have **0 entries** on both Polkadot
  and Kusama Asset Hub.
- No new crowdloans are possible — auctions ended with the move to Agile Coretime.

So the tab currently renders nothing for every user.

### What changed

- `VotePagerAdapter` — single page: `getItemCount()` returns 1, the position-1 branch is
  gone, and `getPageTitle()` was removed since the tab layout was its only caller (the
  `R` import and the `fragment` property go with it)
- `VoteFragment` — removed the `voteTabs.setupWithViewPager2(...)` wiring and its import, and
  set `isUserInputEnabled = false` on the pager: with a single page it would otherwise still
  intercept horizontal drags and show the edge-overscroll glow, an affordance iOS no longer has
- `VoteRouter` / `VoteNavigator` — removed `getCrowdloansFragment()` and the
  `CrowdloanFragment` import
- `fragment_vote.xml` — removed `SegmentedTabLayout`; the pager takes a 16dp top margin
  in its place

`@style/SegmentedTab` is still used by seven other layouts and is untouched.

### Deliberately not in this PR

The `feature-crowdloan-api` / `feature-crowdloan-impl` modules are still wired into
`app/build.gradle` — deleting them is a separate follow-up, as is retiring the now-unused
`crowdloan_crowdloan` string and its translations, which belong with the rest of the
`crowdloan_*` family.

Paired with the equivalent iOS change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
