### PR TITLE
Add missing localization for rc/10.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
         // App version
-        versionName = '10.8.6'
-        versionCode = 263
+        versionName = '10.9.0'
+        versionCode = 264
 
         applicationId = "io.novafoundation.nova"
         releaseApplicationSuffix = "market"

--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -2039,4 +2039,20 @@
     <string name="yield_boost_stake_increase_time">Tiempo de aumento de stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost apostará automáticamente %s todos mis tokens transferibles por encima de %s</string>
     <string name="yiled_boost_yield_boosted">Con Yield Boost</string>
+    <string name="common_go_to_staking">Ir a Staking</string>
+    <string name="common_privacy_notice">Aviso de privacidad</string>
+    <string name="common_terms_of_service">Términos del servicio</string>
+    <string name="dapp_staking_banner_message">¿Quieres hacer stake? Nova Wallet cuenta con Staking integrado.</string>
+    <string name="dapp_staking_notice_continue">Continuar al sitio</string>
+    <string name="dapp_staking_notice_message">Los sitios de Staking de terceros suelen quedar obsoletos. Recomendamos utilizar las funciones de Staking integradas de Nova Wallet.</string>
+    <string name="dapp_staking_notice_title">Aviso</string>
+    <string name="legal_consent_accept">Aceptar y continuar</string>
+    <string name="legal_consent_agreement">Acepto los %1$s y reconozco los %2$s.</string>
+    <string name="legal_consent_implicit">Al continuar, aceptas los %1$s y reconoces los %2$s.</string>
+    <string name="legal_consent_subtitle">Hemos actualizado nuestros Términos del servicio y el Aviso de privacidad. Revisa y acepta los documentos actualizados para continuar utilizando Nova Wallet.</string>
+    <string name="legal_consent_title">Términos actualizados</string>
+    <string name="staking_custom_locked_validator_message">Este validador es operado por Nova y siempre forma parte de tu nominación.</string>
+    <string name="swap_network_fees_label">Comisiones de red</string>
+    <string name="swap_nova_fee_disclaimer">Incluye una comisión de Nova del %s%%.</string>
+    <string name="swap_rate_includes_fee_description">La mejor tasa encontrada, incluida una comisión de Nova Wallet del %s%%.</string>
 </resources>

--- a/common/src/main/res/values-fr-rFR/strings.xml
+++ b/common/src/main/res/values-fr-rFR/strings.xml
@@ -2039,4 +2039,20 @@
     <string name="yield_boost_stake_increase_time">La mise augmente avec le temps</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost misera automatiquement %s tous mes actifs transférables au-dessus de %s</string>
     <string name="yiled_boost_yield_boosted">Rendement boosté</string>
+    <string name="common_go_to_staking">Accéder au Staking</string>
+    <string name="common_privacy_notice">Avis de confidentialité</string>
+    <string name="common_terms_of_service">Conditions d’utilisation</string>
+    <string name="dapp_staking_banner_message">Vous souhaitez faire du Staking ? Nova Wallet intègre le Staking.</string>
+    <string name="dapp_staking_notice_continue">Continuer vers le site</string>
+    <string name="dapp_staking_notice_message">Les sites de Staking tiers deviennent souvent obsolètes. Nous vous recommandons d’utiliser les fonctionnalités de Staking intégrées à Nova Wallet.</string>
+    <string name="dapp_staking_notice_title">Avis</string>
+    <string name="legal_consent_accept">Accepter et continuer</string>
+    <string name="legal_consent_agreement">J’accepte les %1$s et reconnais les %2$s.</string>
+    <string name="legal_consent_implicit">En continuant, vous acceptez les %1$s et reconnaissez les %2$s.</string>
+    <string name="legal_consent_subtitle">Nous avons mis à jour nos Conditions d’utilisation et notre Avis de confidentialité. Veuillez consulter et accepter les documents mis à jour pour continuer à utiliser Nova Wallet.</string>
+    <string name="legal_consent_title">Conditions mises à jour</string>
+    <string name="staking_custom_locked_validator_message">Ce validateur est géré par Nova et fait toujours partie de votre nomination.</string>
+    <string name="swap_network_fees_label">Frais du réseau</string>
+    <string name="swap_nova_fee_disclaimer">Inclut des frais Nova de %s%%.</string>
+    <string name="swap_rate_includes_fee_description">Meilleur taux trouvé, incluant des frais de %s%% de Nova Wallet.</string>
 </resources>

--- a/common/src/main/res/values-hu/strings.xml
+++ b/common/src/main/res/values-hu/strings.xml
@@ -2039,4 +2039,20 @@
     <string name="yield_boost_stake_increase_time">Stake növekedési idő</string>
     <string name="yield_boost_terms" formatted="false">A  Yield Boost %s automatikusan stake-elni fogja a %s feletti utalható tokeneket</string>
     <string name="yiled_boost_yield_boosted">Yield Boost-olt</string>
+    <string name="common_go_to_staking">Ugrás a stakinghez</string>
+    <string name="common_privacy_notice">Adatvédelmi nyilatkozat</string>
+    <string name="common_terms_of_service">Szolgáltatási feltételek</string>
+    <string name="dapp_staking_banner_message">Stakelni szeretnél? A Nova Wallet beépített stakinget kínál.</string>
+    <string name="dapp_staking_notice_continue">Tovább az oldalra</string>
+    <string name="dapp_staking_notice_message">A harmadik felek stakingoldalai gyakran elavulnak. Javasoljuk, hogy használd a Nova Wallet beépített stakingfunkcióit.</string>
+    <string name="dapp_staking_notice_title">Figyelem</string>
+    <string name="legal_consent_accept">Elfogadás és folytatás</string>
+    <string name="legal_consent_agreement">Elfogadom a(z) %1$s dokumentumot, és tudomásul veszem a(z) %2$s dokumentumot.</string>
+    <string name="legal_consent_implicit">A folytatással elfogadod a(z) %1$s dokumentumot, és tudomásul veszed a(z) %2$s dokumentumot.</string>
+    <string name="legal_consent_subtitle">Frissítettük a Szolgáltatási feltételeket és az Adatvédelmi nyilatkozatot. A Nova Wallet további használatához tekintsd át és fogadd el a frissített dokumentumokat.</string>
+    <string name="legal_consent_title">Frissített feltételek</string>
+    <string name="staking_custom_locked_validator_message">Ezt a validátort a Nova üzemelteti, és mindig része a jelölésednek.</string>
+    <string name="swap_network_fees_label">Hálózati díjak</string>
+    <string name="swap_nova_fee_disclaimer">%s%% Nova-díjat tartalmaz.</string>
+    <string name="swap_rate_includes_fee_description">A megtalált legjobb árfolyam, amely tartalmazza a Nova Wallet %s%%-os díját.</string>
 </resources>

--- a/common/src/main/res/values-in/strings.xml
+++ b/common/src/main/res/values-in/strings.xml
@@ -2025,4 +2025,20 @@
     <string name="yield_boost_stake_increase_time">Waktu peningkatan staking</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost akan secara otomatis melakukan staking %s semua token yang dapat ditransfer di atas %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="common_go_to_staking">Buka Staking</string>
+    <string name="common_privacy_notice">Pemberitahuan Privasi</string>
+    <string name="common_terms_of_service">Ketentuan Layanan</string>
+    <string name="dapp_staking_banner_message">Ingin melakukan staking? Nova Wallet memiliki fitur staking bawaan.</string>
+    <string name="dapp_staking_notice_continue">Lanjutkan ke situs</string>
+    <string name="dapp_staking_notice_message">Situs staking pihak ketiga sering kali tidak lagi tersedia. Kami menyarankan Anda menggunakan fitur staking bawaan Nova Wallet.</string>
+    <string name="dapp_staking_notice_title">Pemberitahuan</string>
+    <string name="legal_consent_accept">Setujui dan Lanjutkan</string>
+    <string name="legal_consent_agreement">Saya menyetujui %1$s dan mengakui %2$s.</string>
+    <string name="legal_consent_implicit">Dengan melanjutkan, Anda menyetujui %1$s dan mengakui %2$s.</string>
+    <string name="legal_consent_subtitle">Kami telah memperbarui Ketentuan Layanan dan Pemberitahuan Privasi kami. Harap tinjau dan setujui dokumen yang diperbarui untuk terus menggunakan Nova Wallet.</string>
+    <string name="legal_consent_title">Ketentuan yang Diperbarui</string>
+    <string name="staking_custom_locked_validator_message">Validator ini dioperasikan oleh Nova dan selalu menjadi bagian dari nominasi Anda.</string>
+    <string name="swap_network_fees_label">Biaya jaringan</string>
+    <string name="swap_nova_fee_disclaimer">Termasuk biaya Nova sebesar %s%%.</string>
+    <string name="swap_rate_includes_fee_description">Nilai tukar terbaik yang ditemukan, termasuk biaya Nova Wallet sebesar %s%%.</string>
 </resources>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -2039,4 +2039,20 @@
     <string name="yield_boost_stake_increase_time">Tempo di aumento dello stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost stakerà automaticamente %s tutti i miei token trasferibili oltre %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="common_go_to_staking">Vai allo staking</string>
+    <string name="common_privacy_notice">Informativa sulla privacy</string>
+    <string name="common_terms_of_service">Termini di servizio</string>
+    <string name="dapp_staking_banner_message">Vuoi fare staking? Nova Wallet offre lo staking integrato.</string>
+    <string name="dapp_staking_notice_continue">Continua al sito</string>
+    <string name="dapp_staking_notice_message">I siti di staking di terze parti spesso diventano obsoleti. Ti consigliamo di utilizzare le funzionalità di staking integrate di Nova Wallet.</string>
+    <string name="dapp_staking_notice_title">Avviso</string>
+    <string name="legal_consent_accept">Accetta e continua</string>
+    <string name="legal_consent_agreement">Accetto i %1$s e riconosco i %2$s.</string>
+    <string name="legal_consent_implicit">Continuando, accetti i %1$s e riconosci i %2$s.</string>
+    <string name="legal_consent_subtitle">Abbiamo aggiornato i nostri Termini di servizio e l\'Informativa sulla privacy. Esamina e accetta i documenti aggiornati per continuare a utilizzare Nova Wallet.</string>
+    <string name="legal_consent_title">Termini aggiornati</string>
+    <string name="staking_custom_locked_validator_message">Questo validatore è gestito da Nova e fa sempre parte della tua nomina.</string>
+    <string name="swap_network_fees_label">Commissioni di rete</string>
+    <string name="swap_nova_fee_disclaimer">Include una commissione Nova del %s%%.</string>
+    <string name="swap_rate_includes_fee_description">Il miglior tasso trovato, inclusa una commissione Nova Wallet del %s%%.</string>
 </resources>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -2025,4 +2025,20 @@
     <string name="yield_boost_stake_increase_time">Stake増加時間</string>
     <string name="yield_boost_terms" formatted="false">Yield Boostは自動的に%s私の全ての譲渡可能なトークンを%s以上ステークします</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="common_go_to_staking">Stakingへ移動</string>
+    <string name="common_privacy_notice">プライバシーに関する通知</string>
+    <string name="common_terms_of_service">利用規約</string>
+    <string name="dapp_staking_banner_message">Stakeをご希望ですか？Nova WalletにはStaking機能が組み込まれています。</string>
+    <string name="dapp_staking_notice_continue">サイトへ続行</string>
+    <string name="dapp_staking_notice_message">第三者のStakingサイトは、利用できなくなることがよくあります。Nova Walletに組み込まれたStaking機能のご利用をおすすめします。</string>
+    <string name="dapp_staking_notice_title">通知</string>
+    <string name="legal_consent_accept">同意して続行</string>
+    <string name="legal_consent_agreement">%1$sに同意し、%2$sを確認しました。</string>
+    <string name="legal_consent_implicit">続行することで、%1$sに同意し、%2$sを確認したものとみなされます。</string>
+    <string name="legal_consent_subtitle">利用規約とプライバシーに関する通知を更新しました。Nova Walletの利用を続けるには、更新された文書を確認して同意してください。</string>
+    <string name="legal_consent_title">更新された利用規約</string>
+    <string name="staking_custom_locked_validator_message">このバリデーターはNovaが運用しており、常にノミネーションの対象となります。</string>
+    <string name="swap_network_fees_label">ネットワーク手数料</string>
+    <string name="swap_nova_fee_disclaimer">%s%%のNova手数料を含みます。</string>
+    <string name="swap_rate_includes_fee_description">%s%%のNova Wallet手数料を含む、見つかった最良のレートです。</string>
 </resources>

--- a/common/src/main/res/values-ko/strings.xml
+++ b/common/src/main/res/values-ko/strings.xml
@@ -2025,4 +2025,20 @@
     <string name="yield_boost_stake_increase_time">Stake 증가 시간</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost가 %s 모든 양도 가능한 토큰을 %s 이상 자동으로 Stake 합니다</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="common_go_to_staking">Staking으로 이동</string>
+    <string name="common_privacy_notice">개인정보 보호정책</string>
+    <string name="common_terms_of_service">서비스 약관</string>
+    <string name="dapp_staking_banner_message">Stake하려고 하시나요? Nova Wallet에는 Staking 기능이 내장되어 있습니다.</string>
+    <string name="dapp_staking_notice_continue">사이트로 계속하기</string>
+    <string name="dapp_staking_notice_message">타사 Staking 사이트는 자주 지원이 중단됩니다. Nova Wallet의 내장 Staking 기능을 사용하는 것을 권장합니다.</string>
+    <string name="dapp_staking_notice_title">알림</string>
+    <string name="legal_consent_accept">동의하고 계속하기</string>
+    <string name="legal_consent_agreement">%1$s에 동의하고 %2$s을(를) 확인합니다.</string>
+    <string name="legal_consent_implicit">계속하면 %1$s에 동의하고 %2$s을(를) 확인하는 것으로 간주됩니다.</string>
+    <string name="legal_consent_subtitle">서비스 약관 및 개인정보 보호정책이 업데이트되었습니다. Nova Wallet을 계속 사용하려면 업데이트된 문서를 검토하고 동의해 주세요.</string>
+    <string name="legal_consent_title">업데이트된 약관</string>
+    <string name="staking_custom_locked_validator_message">이 검증인은 Nova에서 운영하며 항상 귀하의 지명에 포함됩니다.</string>
+    <string name="swap_network_fees_label">네트워크 수수료</string>
+    <string name="swap_nova_fee_disclaimer">%s%% Nova 수수료가 포함됩니다.</string>
+    <string name="swap_rate_includes_fee_description">%s%% Nova Wallet 수수료를 포함하여 찾은 최적의 환율입니다.</string>
 </resources>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -2067,4 +2067,20 @@
     <string name="yield_boost_stake_increase_time">Czas zwiększenia Stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost automatycznie Stake %s wszystkie moje przenośne tokeny powyżej %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="common_go_to_staking">Przejdź do Staking</string>
+    <string name="common_privacy_notice">Informacja o prywatności</string>
+    <string name="common_terms_of_service">Warunki korzystania z usługi</string>
+    <string name="dapp_staking_banner_message">Chcesz korzystać ze Staking? Nova Wallet ma wbudowany Staking.</string>
+    <string name="dapp_staking_notice_continue">Przejdź do strony</string>
+    <string name="dapp_staking_notice_message">Zewnętrzne strony Staking często stają się niedostępne. Zalecamy korzystanie z wbudowanych funkcji Staking w Nova Wallet.</string>
+    <string name="dapp_staking_notice_title">Uwaga</string>
+    <string name="legal_consent_accept">Akceptuję i kontynuuję</string>
+    <string name="legal_consent_agreement">Akceptuję %1$s i potwierdzam zapoznanie się z %2$s.</string>
+    <string name="legal_consent_implicit">Kontynuując, akceptujesz %1$s i potwierdzasz zapoznanie się z %2$s.</string>
+    <string name="legal_consent_subtitle">Zaktualizowaliśmy nasze Warunki korzystania z usługi i Informację o prywatności. Zapoznaj się ze zaktualizowanymi dokumentami i zaakceptuj je, aby nadal korzystać z Nova Wallet.</string>
+    <string name="legal_consent_title">Zaktualizowane warunki</string>
+    <string name="staking_custom_locked_validator_message">Ten walidator jest obsługiwany przez Nova i zawsze jest częścią Twojej nominacji.</string>
+    <string name="swap_network_fees_label">Opłaty sieciowe</string>
+    <string name="swap_nova_fee_disclaimer">Zawiera opłatę Nova w wysokości %s%%.</string>
+    <string name="swap_rate_includes_fee_description">Najlepszy znaleziony kurs, uwzględniający opłatę Nova Wallet w wysokości %s%%.</string>
 </resources>

--- a/common/src/main/res/values-pt/strings.xml
+++ b/common/src/main/res/values-pt/strings.xml
@@ -2039,4 +2039,20 @@
     <string name="yield_boost_stake_increase_time">Tempo de aumento de stake</string>
     <string name="yield_boost_terms" formatted="false">O Impulso de Rendimento irá automaticamente fazer o stake de %s de todos os meus tokens transferíveis acima de %s</string>
     <string name="yiled_boost_yield_boosted">Com Impulso de Rendimento</string>
+    <string name="common_go_to_staking">Ir para staking</string>
+    <string name="common_privacy_notice">Aviso de privacidade</string>
+    <string name="common_terms_of_service">Termos de serviço</string>
+    <string name="dapp_staking_banner_message">Procurando fazer staking? A Nova Wallet oferece staking integrado.</string>
+    <string name="dapp_staking_notice_continue">Continuar para o site</string>
+    <string name="dapp_staking_notice_message">Sites de staking de terceiros frequentemente ficam desatualizados. Recomendamos usar os recursos de staking integrados da Nova Wallet.</string>
+    <string name="dapp_staking_notice_title">Aviso</string>
+    <string name="legal_consent_accept">Aceitar e continuar</string>
+    <string name="legal_consent_agreement">Concordo com os %1$s e reconheço os %2$s.</string>
+    <string name="legal_consent_implicit">Ao continuar, você concorda com os %1$s e reconhece os %2$s.</string>
+    <string name="legal_consent_subtitle">Atualizamos nossos Termos de serviço e Aviso de privacidade. Revise e aceite os documentos atualizados para continuar usando a Nova Wallet.</string>
+    <string name="legal_consent_title">Termos atualizados</string>
+    <string name="staking_custom_locked_validator_message">Este validador é operado pela Nova e sempre faz parte da sua nomeação.</string>
+    <string name="swap_network_fees_label">Taxas de rede</string>
+    <string name="swap_nova_fee_disclaimer">Inclui uma taxa da Nova de %s%%.</string>
+    <string name="swap_rate_includes_fee_description">A melhor taxa encontrada, incluindo uma taxa da Nova Wallet de %s%%.</string>
 </resources>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -2067,4 +2067,20 @@
     <string name="yield_boost_stake_increase_time">Частота увеличения стейка</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost будет автоматически стейкать %s все мои переводные токены выше %s</string>
     <string name="yiled_boost_yield_boosted">С Yield Boost</string>
+    <string name="common_go_to_staking">Перейти к Staking</string>
+    <string name="common_privacy_notice">Уведомление о конфиденциальности</string>
+    <string name="common_terms_of_service">Условия использования</string>
+    <string name="dapp_staking_banner_message">Хотите заняться stake? В Nova Wallet есть встроенный Staking.</string>
+    <string name="dapp_staking_notice_continue">Перейти на сайт</string>
+    <string name="dapp_staking_notice_message">Сторонние сайты для Staking часто прекращают работу. Мы рекомендуем использовать встроенные функции Staking в Nova Wallet.</string>
+    <string name="dapp_staking_notice_title">Уведомление</string>
+    <string name="legal_consent_accept">Принять и продолжить</string>
+    <string name="legal_consent_agreement">Я принимаю %1$s и подтверждаю ознакомление с %2$s.</string>
+    <string name="legal_consent_implicit">Продолжая, вы принимаете %1$s и подтверждаете ознакомление с %2$s.</string>
+    <string name="legal_consent_subtitle">Мы обновили Условия использования и Уведомление о конфиденциальности. Ознакомьтесь с обновлёнными документами и примите их, чтобы продолжить пользоваться Nova Wallet.</string>
+    <string name="legal_consent_title">Обновлённые условия</string>
+    <string name="staking_custom_locked_validator_message">Этот валидатор управляется Nova и всегда входит в вашу номинацию.</string>
+    <string name="swap_network_fees_label">Сетевые комиссии</string>
+    <string name="swap_nova_fee_disclaimer">Включает комиссию Nova в размере %s%%.</string>
+    <string name="swap_rate_includes_fee_description">Лучший найденный курс, включая комиссию Nova Wallet в размере %s%%.</string>
 </resources>

--- a/common/src/main/res/values-tr/strings.xml
+++ b/common/src/main/res/values-tr/strings.xml
@@ -2039,4 +2039,20 @@
     <string name="yield_boost_stake_increase_time">Bahis artış süresi</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost, %s tüm transfer edilebilir tokenlerimi otomatik olarak %s üzerinde stake edecek</string>
     <string name="yiled_boost_yield_boosted">Yield Boost\'lu</string>
+    <string name="common_go_to_staking">Stake etmeye git</string>
+    <string name="common_privacy_notice">Gizlilik Bildirimi</string>
+    <string name="common_terms_of_service">Hizmet Koşulları</string>
+    <string name="dapp_staking_banner_message">Stake etmek mi istiyorsunuz? Nova Wallet yerleşik staking özelliğine sahiptir.</string>
+    <string name="dapp_staking_notice_continue">Siteye devam et</string>
+    <string name="dapp_staking_notice_message">Üçüncü taraf staking siteleri genellikle kullanımdan kaldırılır. Nova Wallet\'ın yerleşik staking özelliklerini kullanmanızı öneririz.</string>
+    <string name="dapp_staking_notice_title">Bildirim</string>
+    <string name="legal_consent_accept">Kabul et ve devam et</string>
+    <string name="legal_consent_agreement">%1$s sözleşmesini kabul ediyor ve %2$s belgesini okuduğumu onaylıyorum.</string>
+    <string name="legal_consent_implicit">Devam ederek %1$s sözleşmesini kabul ediyor ve %2$s belgesini okuduğunuzu onaylıyorsunuz.</string>
+    <string name="legal_consent_subtitle">Hizmet Koşullarımızı ve Gizlilik Bildirimimizi güncelledik. Nova Wallet\'ı kullanmaya devam etmek için lütfen güncellenen belgeleri inceleyip kabul edin.</string>
+    <string name="legal_consent_title">Güncellenen Koşullar</string>
+    <string name="staking_custom_locked_validator_message">Bu doğrulayıcı Nova tarafından işletilir ve aday gösteriminizin her zaman bir parçasıdır.</string>
+    <string name="swap_network_fees_label">Ağ ücretleri</string>
+    <string name="swap_nova_fee_disclaimer">%s%% Nova ücretini içerir.</string>
+    <string name="swap_rate_includes_fee_description">%s%% Nova Wallet ücreti dâhil olmak üzere bulunan en iyi kur.</string>
 </resources>

--- a/common/src/main/res/values-vi/strings.xml
+++ b/common/src/main/res/values-vi/strings.xml
@@ -2025,4 +2025,20 @@
     <string name="yield_boost_stake_increase_time">Thời gian tăng Stake</string>
     <string name="yield_boost_terms" formatted="false">Yield Boost sẽ tự động stake %s tất cả token có thể chuyển được của tôi trên %s</string>
     <string name="yiled_boost_yield_boosted">Yield Boosted</string>
+    <string name="common_go_to_staking">Đi đến Staking</string>
+    <string name="common_privacy_notice">Thông báo về quyền riêng tư</string>
+    <string name="common_terms_of_service">Điều khoản dịch vụ</string>
+    <string name="dapp_staking_banner_message">Bạn muốn Stake? Nova Wallet tích hợp sẵn Staking.</string>
+    <string name="dapp_staking_notice_continue">Tiếp tục đến trang web</string>
+    <string name="dapp_staking_notice_message">Các trang web Staking của bên thứ ba thường ngừng hoạt động. Chúng tôi khuyên bạn nên sử dụng các tính năng Staking tích hợp sẵn của Nova Wallet.</string>
+    <string name="dapp_staking_notice_title">Thông báo</string>
+    <string name="legal_consent_accept">Chấp nhận và tiếp tục</string>
+    <string name="legal_consent_agreement">Tôi đồng ý với %1$s và xác nhận đã đọc %2$s.</string>
+    <string name="legal_consent_implicit">Bằng việc tiếp tục, bạn đồng ý với %1$s và xác nhận đã đọc %2$s.</string>
+    <string name="legal_consent_subtitle">Chúng tôi đã cập nhật Điều khoản dịch vụ và Thông báo về quyền riêng tư. Vui lòng xem xét và chấp nhận các tài liệu đã cập nhật để tiếp tục sử dụng Nova Wallet.</string>
+    <string name="legal_consent_title">Điều khoản đã cập nhật</string>
+    <string name="staking_custom_locked_validator_message">Validator này do Nova vận hành và luôn nằm trong danh sách đề cử của bạn.</string>
+    <string name="swap_network_fees_label">Phí mạng</string>
+    <string name="swap_nova_fee_disclaimer">Đã bao gồm phí Nova %s%%.</string>
+    <string name="swap_rate_includes_fee_description">Tỷ giá tốt nhất được tìm thấy, đã bao gồm phí Nova Wallet %s%%.</string>
 </resources>

--- a/common/src/main/res/values-zh-rCN/strings.xml
+++ b/common/src/main/res/values-zh-rCN/strings.xml
@@ -2025,4 +2025,20 @@
     <string name="yield_boost_stake_increase_time">加注时间</string>
     <string name="yield_boost_terms" formatted="false">收益增强将自动加注我所有可转让代币中超过%s的%s</string>
     <string name="yiled_boost_yield_boosted">已增强收益</string>
+    <string name="common_go_to_staking">前往质押</string>
+    <string name="common_privacy_notice">隐私声明</string>
+    <string name="common_terms_of_service">服务条款</string>
+    <string name="dapp_staking_banner_message">想要进行质押？Nova Wallet 内置质押功能。</string>
+    <string name="dapp_staking_notice_continue">继续前往网站</string>
+    <string name="dapp_staking_notice_message">第三方质押网站经常会停止维护。我们建议使用 Nova Wallet 内置的质押功能。</string>
+    <string name="dapp_staking_notice_title">提示</string>
+    <string name="legal_consent_accept">接受并继续</string>
+    <string name="legal_consent_agreement">我同意%1$s，并确认已知悉%2$s。</string>
+    <string name="legal_consent_implicit">继续操作即表示您同意%1$s，并确认已知悉%2$s。</string>
+    <string name="legal_consent_subtitle">我们已更新《服务条款》和《隐私声明》。请查看并接受更新后的文件，以继续使用 Nova Wallet。</string>
+    <string name="legal_consent_title">更新后的条款</string>
+    <string name="staking_custom_locked_validator_message">该验证人由 Nova 运营，并始终属于您的提名范围。</string>
+    <string name="swap_network_fees_label">网络费用</string>
+    <string name="swap_nova_fee_disclaimer">包含 %s%% 的 Nova 手续费。</string>
+    <string name="swap_rate_includes_fee_description">找到的最佳汇率，已包含 %s%% 的 Nova Wallet 手续费。</string>
 </resources>


### PR DESCRIPTION
Machine translation of the strings that `rc/10.9.0` added to `values/strings.xml` but never got into the other locales. Produced by the [nova-localization](https://github.com/novasamatech/nova-localization) pipeline (`localize.py --platform android`) against the Lokalise branch `rc/10.9.0`, forked from `master` for this release.

**16 keys × 13 locales = 208 strings.** No other files touched, insertions only.

<details>
<summary>Keys</summary>

```
common_go_to_staking
common_privacy_notice
common_terms_of_service
dapp_staking_banner_message
dapp_staking_notice_continue
dapp_staking_notice_message
dapp_staking_notice_title
legal_consent_accept
legal_consent_agreement
legal_consent_implicit
legal_consent_subtitle
legal_consent_title
staking_custom_locked_validator_message
swap_network_fees_label
swap_nova_fee_disclaimer
swap_rate_includes_fee_description
```

</details>

Checked before opening: every locale file still parses as XML; `%1$s` / `%2$s` / `%s%%` placeholders match the English source in all 208 strings; no unescaped apostrophes, quotes or bare ampersands; no string left equal to its English source. `check_parity.py --platform android` now reports 0 missing keys and no plurals needing a manual port.

Translations are GPT output and have not been reviewed by a native speaker — the legal-consent wording in particular is worth a human read before release.
