### PR TITLE
Count locked validators in the custom validators proceed button

### DIFF
--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/select/SelectCustomValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/select/SelectCustomValidatorsViewModel.kt
@@ -112,7 +112,8 @@ class SelectCustomValidatorsViewModel(
         ValidatorSelectionState(
             communitySelected = selected.size - lockedSelected,
             communityLimit = (maxSelected - lockedIds.size).coerceAtLeast(0),
-            lockedSelected = lockedSelected
+            lockedSelected = lockedSelected,
+            totalLimit = maxSelected
         )
     }.shareInBackground()
 
@@ -136,15 +137,15 @@ class SelectCustomValidatorsViewModel(
         if (selection.isEmpty()) {
             ContinueButtonState(
                 enabled = false,
-                text = resourceManager.getString(R.string.staking_custom_proceed_button_disabled_title, selection.communityLimit)
+                text = resourceManager.getString(R.string.staking_custom_proceed_button_disabled_title, selection.totalLimit)
             )
         } else {
             ContinueButtonState(
                 enabled = true,
                 text = resourceManager.getString(
                     R.string.staking_custom_proceed_button_enabled_title,
-                    selection.communitySelected,
-                    selection.communityLimit
+                    selection.totalSelected,
+                    selection.totalLimit
                 )
             )
         }

--- a/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/select/model/ValidatorSelectionState.kt
+++ b/feature-staking-impl/src/main/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/select/model/ValidatorSelectionState.kt
@@ -1,10 +1,23 @@
 package io.novafoundation.nova.feature_staking_impl.presentation.validators.change.custom.select.model
 
+/**
+ * Counters of the custom validators selection.
+ *
+ * Community counters describe the slots the user can actually operate on: [communityLimit] is what is left
+ * after the locked (Nova) validators reserved their slots, [communitySelected] is how many of them are taken.
+ * They drive "fill rest with recommended" and "deselect all".
+ *
+ * Total counters describe the whole nomination that will be submitted, locked validators included, and are
+ * the ones shown to the user on the proceed button - what is displayed must match what is signed.
+ */
 class ValidatorSelectionState(
     val communitySelected: Int,
     val communityLimit: Int,
     val lockedSelected: Int,
+    val totalLimit: Int,
 ) {
 
-    fun isEmpty(): Boolean = communitySelected == 0 && lockedSelected == 0
+    val totalSelected: Int = communitySelected + lockedSelected
+
+    fun isEmpty(): Boolean = totalSelected == 0
 }

--- a/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/select/model/ValidatorSelectionStateTest.kt
+++ b/feature-staking-impl/src/test/java/io/novafoundation/nova/feature_staking_impl/presentation/validators/change/custom/select/model/ValidatorSelectionStateTest.kt
@@ -1,0 +1,59 @@
+package io.novafoundation.nova.feature_staking_impl.presentation.validators.change.custom.select.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ValidatorSelectionStateTest {
+
+    @Test
+    fun `total counters should include locked validators`() {
+        val state = ValidatorSelectionState(
+            communitySelected = 0,
+            communityLimit = 15,
+            lockedSelected = 1,
+            totalLimit = 16
+        )
+
+        assertEquals(1, state.totalSelected)
+        assertEquals(16, state.totalLimit)
+    }
+
+    @Test
+    fun `total counters should sum community and locked selection`() {
+        val state = ValidatorSelectionState(
+            communitySelected = 2,
+            communityLimit = 2,
+            lockedSelected = 1,
+            totalLimit = 3
+        )
+
+        assertEquals(3, state.totalSelected)
+        assertEquals(3, state.totalLimit)
+    }
+
+    @Test
+    fun `selection with only locked validators should not be empty`() {
+        val state = ValidatorSelectionState(
+            communitySelected = 0,
+            communityLimit = 15,
+            lockedSelected = 1,
+            totalLimit = 16
+        )
+
+        assertFalse(state.isEmpty())
+    }
+
+    @Test
+    fun `selection without any validator should be empty`() {
+        val state = ValidatorSelectionState(
+            communitySelected = 0,
+            communityLimit = 16,
+            lockedSelected = 0,
+            totalLimit = 16
+        )
+
+        assertTrue(state.isEmpty())
+    }
+}


### PR DESCRIPTION
### Problem

After #2304 the proceed button on the custom validators screen counts only *community* slots. With locked (Nova) validators reserving part of the nomination, the user sees

> Show selected: 14 of 14

while 16 validators are actually put into the extrinsic. What is displayed does not match what is signed.

### Fix

`ValidatorSelectionState` now also carries `totalLimit` (max nominations) and a derived `totalSelected` (`communitySelected + lockedSelected`). The proceed button title uses the total counters, in both the enabled and the disabled branch.

`fillWithRecommendedEnabled` and `deselectAllEnabled` deliberately keep using the community counters — those are about free slots and about items the user is allowed to remove, and locked validators are neither.

This ports the same fix that landed on iOS: novasamatech/nova-wallet-ios#1846 (`count locked validators in the custom list proceed button`).