### PR TITLE
Fix/hydra commission estimation

### DIFF
--- a/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
+++ b/app/src/main/java/io/novafoundation/nova/app/root/navigation/navigators/staking/StakingDashboardNavigator.kt
@@ -47,6 +47,7 @@ class StakingDashboardNavigator(
         returnToStakingTabRoot()
         scrollToDashboardTopEvent.value = Unit.event()
     }
+
     override fun openStakingDashboard() {
         stakingTabNavController.performNavigationOrDelay(R.id.action_open_staking)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         // App version
         versionName = '10.9.0'
-        versionCode = 265
+        versionCode = 264
 
         applicationId = "io.novafoundation.nova"
         releaseApplicationSuffix = "market"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         // App version
         versionName = '10.9.0'
-        versionCode = 264
+        versionCode = 265
 
         applicationId = "io.novafoundation.nova"
         releaseApplicationSuffix = "market"

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -450,6 +450,9 @@
     <string name="price_chart_year">1Y</string>
     <string name="price_chart_max">All</string>
 
+    <string name="price_chart_no_data">No data for this period</string>
+    <string name="price_chart_load_failed">Unable to load chart data</string>
+
     <string name="app_link_host" translatable="false">app.novawallet.io</string>
 
     <string name="high_price_impact_detacted_title">High price impact detected (%s)</string>

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/chains/HydrationFeePaymentProvider.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/chains/HydrationFeePaymentProvider.kt
@@ -13,6 +13,7 @@ import io.novafoundation.nova.feature_account_impl.data.fee.types.hydra.HydraDxQ
 import io.novafoundation.nova.feature_account_impl.data.fee.types.hydra.HydrationConversionFeePayment
 import io.novafoundation.nova.feature_account_impl.data.fee.types.hydra.HydrationFastLookupFeeCapability
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationPriceConversionFallback
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -24,6 +25,7 @@ class HydrationFeePaymentProvider @AssistedInject constructor(
     private val chainRegistry: ChainRegistry,
     private val hydraDxQuoteSharedComputation: HydraDxQuoteSharedComputation,
     private val hydrationFeeInjector: HydrationFeeInjector,
+    private val hydrationOraclePriceConverter: HydrationOraclePriceConverter,
     private val hydrationPriceConversionFallback: HydrationPriceConversionFallback,
     private val accountRepository: AccountRepository,
     private val hydrationAcceptedFeeCurrenciesFetcher: HydrationAcceptedFeeCurrenciesFetcher
@@ -43,6 +45,7 @@ class HydrationFeePaymentProvider @AssistedInject constructor(
             hydraDxQuoteSharedComputation = hydraDxQuoteSharedComputation,
             accountRepository = accountRepository,
             coroutineScope = coroutineScope!!,
+            hydrationOraclePriceConverter = hydrationOraclePriceConverter,
             hydrationPriceConversionFallback = hydrationPriceConversionFallback,
             hydrationAcceptedFeeCurrenciesFetcher = hydrationAcceptedFeeCurrenciesFetcher
         )

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/types/hydra/HydrationConversionFeePayment.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/data/fee/types/hydra/HydrationConversionFeePayment.kt
@@ -12,7 +12,9 @@ import io.novafoundation.nova.feature_account_api.domain.model.requireAccountIdI
 import io.novafoundation.nova.feature_swap_core_api.data.paths.model.quote
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDirection
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationPriceConversionFallback
+import java.math.BigInteger
 import io.novafoundation.nova.runtime.ext.commissionAsset
 import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
@@ -24,6 +26,7 @@ internal class HydrationConversionFeePayment(
     private val chainRegistry: ChainRegistry,
     private val hydrationFeeInjector: HydrationFeeInjector,
     private val hydraDxQuoteSharedComputation: HydraDxQuoteSharedComputation,
+    private val hydrationOraclePriceConverter: HydrationOraclePriceConverter,
     private val hydrationPriceConversionFallback: HydrationPriceConversionFallback,
     private val hydrationAcceptedFeeCurrenciesFetcher: HydrationAcceptedFeeCurrenciesFetcher,
     private val accountRepository: AccountRepository,
@@ -39,6 +42,21 @@ internal class HydrationConversionFeePayment(
     }
 
     override suspend fun convertNativeFee(nativeFee: Fee): Fee {
+        // The chain converts the fee with an oracle price and falls back to `AcceptedCurrencies`, never swapping.
+        // A best-path quote lands on whichever pool is furthest from the market, so it is only a last resort here
+        val convertedAmount = hydrationOraclePriceConverter.convertNativeAmount(nativeFee.amount, paymentAsset)
+            ?: runCatching { hydrationPriceConversionFallback.convertNativeAmount(nativeFee.amount, paymentAsset) }
+                .recoverCatching { quoteNativeFee(nativeFee) }
+                .getOrThrow()
+
+        return SubstrateFee(
+            amount = convertedAmount,
+            submissionOrigin = nativeFee.submissionOrigin,
+            asset = paymentAsset
+        )
+    }
+
+    private suspend fun quoteNativeFee(nativeFee: Fee): BigInteger {
         val metaAccount = accountRepository.getSelectedMetaAccount()
         val chain = chainRegistry.getChain(paymentAsset.chainId)
         val accountId = metaAccount.requireAccountIdIn(chain)
@@ -46,21 +64,11 @@ internal class HydrationConversionFeePayment(
 
         val quoter = hydraDxQuoteSharedComputation.getQuoter(chain, accountId, coroutineScope)
 
-        val convertedAmount = runCatching {
-            quoter.findBestPath(
-                chainAssetIn = fromAsset,
-                chainAssetOut = paymentAsset,
-                amount = nativeFee.amount,
-                swapDirection = SwapDirection.SPECIFIED_IN
-            ).bestPath.quote
-        }
-            .recoverCatching { hydrationPriceConversionFallback.convertNativeAmount(nativeFee.amount, paymentAsset) }
-            .getOrThrow()
-
-        return SubstrateFee(
-            amount = convertedAmount,
-            submissionOrigin = nativeFee.submissionOrigin,
-            asset = paymentAsset
-        )
+        return quoter.findBestPath(
+            chainAssetIn = fromAsset,
+            chainAssetOut = paymentAsset,
+            amount = nativeFee.amount,
+            swapDirection = SwapDirection.SPECIFIED_IN
+        ).bestPath.quote
     }
 }

--- a/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureDependencies.kt
+++ b/feature-account-impl/src/main/java/io/novafoundation/nova/feature_account_impl/di/AccountFeatureDependencies.kt
@@ -53,6 +53,7 @@ import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdC
 import io.novafoundation.nova.feature_swap_core_api.data.paths.PathQuoter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationPriceConversionFallback
 import io.novafoundation.nova.feature_versions_api.domain.UpdateNotificationsInteractor
 import io.novafoundation.nova.feature_xcm_api.converter.MultiLocationConverterFactory
@@ -129,6 +130,8 @@ interface AccountFeatureDependencies {
     val chainStateRepository: ChainStateRepository
 
     val metadataShortenerService: MetadataShortenerService
+
+    val hydrationOraclePriceConverter: HydrationOraclePriceConverter
 
     val hydrationPriceConversionFallback: HydrationPriceConversionFallback
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/detail/BalanceDetailViewModel.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/balance/detail/BalanceDetailViewModel.kt
@@ -407,13 +407,20 @@ class BalanceDetailViewModel(
     private fun mapChartsToUi(assetPriceChart: AssetPriceChart): PriceChartModel {
         val buttonText = mapButtonText(assetPriceChart.range)
 
-        return if (assetPriceChart.chart is ExtendedLoadingState.Loaded) {
-            val periodName = mapPeriodName(assetPriceChart.range)
-            val supportTimeShowing = supportTimeShowing(assetPriceChart.range)
-            val mappedChart = assetPriceChart.chart.data.map { PriceChartModel.Chart.Price(it.timestamp, it.rate) }
-            PriceChartModel.Chart(buttonText, periodName, supportTimeShowing, mappedChart)
-        } else {
-            PriceChartModel.Loading(buttonText)
+        return when (val chart = assetPriceChart.chart) {
+            is ExtendedLoadingState.Loading -> PriceChartModel.Loading(buttonText)
+
+            is ExtendedLoadingState.Error -> PriceChartModel.Empty(buttonText, resourceManager.getString(R.string.price_chart_load_failed))
+
+            // Price feed may successfully return no points at all - for example, when the feed is stale or the asset has just been listed
+            is ExtendedLoadingState.Loaded -> if (chart.data.isEmpty()) {
+                PriceChartModel.Empty(buttonText, resourceManager.getString(R.string.price_chart_no_data))
+            } else {
+                val periodName = mapPeriodName(assetPriceChart.range)
+                val supportTimeShowing = supportTimeShowing(assetPriceChart.range)
+                val mappedChart = chart.data.map { PriceChartModel.Chart.Price(it.timestamp, it.rate) }
+                PriceChartModel.Chart(buttonText, periodName, supportTimeShowing, mappedChart)
+            }
         }
     }
 

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/views/priceCharts/ChartController.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/views/priceCharts/ChartController.kt
@@ -181,7 +181,9 @@ class ChartController(private val chart: LineChart, private val callback: Callba
     }
 
     private fun List<Entry>.isBullish(): Boolean {
-        return last().y >= first().y
+        val firstEntry = firstOrNull() ?: return true
+
+        return last().y >= firstEntry.y
     }
 
     private fun LineChart.getEntryByTouchPoint(event: MotionEvent): Entry? {

--- a/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/views/priceCharts/PriceChartsView.kt
+++ b/feature-assets/src/main/java/io/novafoundation/nova/feature_assets/presentation/views/priceCharts/PriceChartsView.kt
@@ -26,6 +26,14 @@ sealed class PriceChartModel(val buttonText: String) {
 
     class Loading(buttonText: String) : PriceChartModel(buttonText)
 
+    /**
+     * There is nothing to draw for this period - either the price feed returned no points or the request has failed
+     */
+    class Empty(buttonText: String, val message: String) : PriceChartModel(buttonText)
+
+    /**
+     * [priceChart] is expected to be non-empty - a period without points should be mapped to [Empty] instead
+     */
     class Chart(
         buttonText: String,
         val periodName: String,
@@ -58,7 +66,7 @@ class PriceChartsView @JvmOverloads constructor(
 
     init {
         controller = ChartController(binder.priceChart, this)
-        setEmptyState()
+        showLoadingState()
     }
 
     fun setTitle(title: String) {
@@ -78,7 +86,7 @@ class PriceChartsView @JvmOverloads constructor(
         }
 
         if (charts.isEmpty()) {
-            setEmptyState()
+            showLoadingState()
         } else {
             if (selectedChartIndex >= charts.size) {
                 selectedChartIndex = 0
@@ -104,18 +112,36 @@ class PriceChartsView @JvmOverloads constructor(
         dateTextInjector?.format(selectedEntry.x.roundToLong(), isEntrySelected, binder.priceChartDate, charts[selectedChartIndex])
     }
 
-    private fun setEmptyState() {
-        showCharts(false)
+    private fun showLoadingState() {
+        setChartContentVisible(false)
+        binder.priceChartEmptyLabel.isGone = true
+        setShimmeringVisible(true)
     }
 
-    private fun showCharts(show: Boolean) {
-        binder.priceChart.setVisible(show, falseState = View.INVISIBLE)
-        binder.priceChartDate.setVisible(show, falseState = View.INVISIBLE)
-        binder.priceChartPriceChange.setVisible(show, falseState = View.INVISIBLE)
-        binder.priceChartCurrentPrice.setVisible(show, falseState = View.INVISIBLE)
-        binder.priceChartPriceChangeShimmering.isGone = show
-        binder.priceChartCurrentPriceShimmering.isGone = show
-        binder.priceChartShimmering.isGone = show
+    private fun showEmptyState(message: String) {
+        setChartContentVisible(false)
+        binder.priceChartEmptyLabel.text = message
+        binder.priceChartEmptyLabel.isGone = false
+        setShimmeringVisible(false)
+    }
+
+    private fun showChartState() {
+        setChartContentVisible(true)
+        binder.priceChartEmptyLabel.isGone = true
+        setShimmeringVisible(false)
+    }
+
+    private fun setChartContentVisible(visible: Boolean) {
+        binder.priceChart.setVisible(visible, falseState = View.INVISIBLE)
+        binder.priceChartDate.setVisible(visible, falseState = View.INVISIBLE)
+        binder.priceChartPriceChange.setVisible(visible, falseState = View.INVISIBLE)
+        binder.priceChartCurrentPrice.setVisible(visible, falseState = View.INVISIBLE)
+    }
+
+    private fun setShimmeringVisible(visible: Boolean) {
+        binder.priceChartPriceChangeShimmering.isGone = !visible
+        binder.priceChartCurrentPriceShimmering.isGone = !visible
+        binder.priceChartShimmering.isGone = !visible
     }
 
     private fun selectChart(index: Int) {
@@ -125,14 +151,16 @@ class PriceChartsView @JvmOverloads constructor(
             view.isSelected = i == index
         }
 
-        val currentChart = charts[index]
-        if (currentChart is PriceChartModel.Loading) {
-            setEmptyState()
-            return
-        } else if (currentChart is PriceChartModel.Chart) {
-            controller.setEntries(currentChart.asEntries())
+        when (val currentChart = charts[index]) {
+            is PriceChartModel.Loading -> showLoadingState()
 
-            showCharts(true)
+            is PriceChartModel.Empty -> showEmptyState(currentChart.message)
+
+            is PriceChartModel.Chart -> {
+                controller.setEntries(currentChart.asEntries())
+
+                showChartState()
+            }
         }
     }
 

--- a/feature-assets/src/main/res/layout/view_price_charts.xml
+++ b/feature-assets/src/main/res/layout/view_price_charts.xml
@@ -91,6 +91,21 @@
         android:background="@android:color/transparent"
         app:layout_constraintTop_toBottomOf="@+id/priceChartDate" />
 
+    <TextView
+        android:id="@+id/priceChartEmptyLabel"
+        style="@style/TextAppearance.NovaFoundation.Regular.Footnote"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:textColor="@color/text_secondary"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/priceChart"
+        app:layout_constraintEnd_toEndOf="@+id/priceChart"
+        app:layout_constraintStart_toStartOf="@+id/priceChart"
+        app:layout_constraintTop_toTopOf="@+id/priceChart"
+        tools:text="No data for this period"
+        tools:visibility="visible" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/priceChartShimmering"
         android:layout_width="0dp"

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/types/hydra/HydrationOraclePriceConverter.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/data/types/hydra/HydrationOraclePriceConverter.kt
@@ -1,0 +1,19 @@
+package io.novafoundation.nova.feature_swap_core_api.data.types.hydra
+
+import io.novafoundation.nova.common.data.network.runtime.binding.BalanceOf
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+
+/**
+ * Converts a native-asset amount the same way the chain does when charging a fee in a non-native currency:
+ * the EMA price over the route registered in `Router.Routes`.
+ *
+ * Deliberately not a swap quote - the chain never swaps the fee, and a best-path quote lands on whichever
+ * pool is furthest from the market, which is exactly the pool a cheapest-route search selects.
+ */
+interface HydrationOraclePriceConverter {
+
+    /**
+     * @return null when the route or oracle entries are unavailable
+     */
+    suspend fun convertNativeAmount(nativeAmount: BalanceOf, conversionTarget: Chain.Asset): BalanceOf?
+}

--- a/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/di/SwapCoreApi.kt
+++ b/feature-swap-core/api/src/main/java/io/novafoundation/nova/feature_swap_core_api/di/SwapCoreApi.kt
@@ -4,6 +4,7 @@ import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdC
 import io.novafoundation.nova.feature_swap_core_api.data.paths.PathQuoter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationPriceConversionFallback
 
 interface SwapCoreApi {
@@ -15,6 +16,8 @@ interface SwapCoreApi {
     val hydraDxAssetIdConverter: HydraDxAssetIdConverter
 
     val hydrationPriceConversionFallback: HydrationPriceConversionFallback
+
+    val hydrationOraclePriceConverter: HydrationOraclePriceConverter
 
     val pathQuoterFactory: PathQuoter.Factory
 }

--- a/feature-swap-core/build.gradle
+++ b/feature-swap-core/build.gradle
@@ -1,3 +1,4 @@
+apply from: '../tests.gradle'
 
 android {
     namespace 'io.novafoundation.nova.feature_swap_core'
@@ -19,6 +20,8 @@ dependencies {
     implementation androidDep
 
     api project(':core-api')
+
+    testImplementation jUnitDep
 
     androidTestImplementation androidTestRunnerDep
     androidTestImplementation androidTestRulesDep

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOnChain.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOnChain.kt
@@ -65,14 +65,18 @@ object HydrationOnChain {
     /**
      * `OraclePeriod::TenMinutes::as_period()` - the fee oracle period expressed in blocks.
      *
-     * The runtime derives it from its block time (`10 * MINUTES`, `MINUTES = 60_000 / MILLISECS_PER_BLOCK`),
-     * so it changes with every block time upgrade - Hydration moving from 6s to 2s blocks turns 100 into 300.
-     * Deriving it here instead of hardcoding keeps the smoothing factor correct across that upgrade.
+     * The runtime rounds at the minute (`10 * MINUTES`, `MINUTES = 60_000 / MILLISECS_PER_BLOCK`), so the
+     * division is reproduced in the same order. Returns null when the block time is unknown - a guessed
+     * period silently yields a plausible but wrong smoothing factor
+     *
+     * https://github.com/galacticcouncil/hydration-node/blob/master/traits/src/oracle.rs#L87-L96
      */
-    fun feeOraclePeriodInBlocks(blockTimeMillis: Long): Int {
-        val blocksPerMinute = MILLIS_PER_MINUTE / blockTimeMillis.coerceAtLeast(1)
+    fun feeOraclePeriodInBlocks(blockTimeMillis: Long): Int? {
+        if (blockTimeMillis <= 0) return null
 
-        return (FEE_ORACLE_PERIOD_MINUTES * blocksPerMinute).toInt().coerceAtLeast(1)
+        val blocksPerMinute = MILLIS_PER_MINUTE / blockTimeMillis
+
+        return (FEE_ORACLE_PERIOD_MINUTES * blocksPerMinute).toInt().takeIf { it > 0 }
     }
 
     /**
@@ -80,8 +84,10 @@ object HydrationOnChain {
      * `fraction::frac(2, period + 1)`, rounding to nearest with ties down. Plain truncation is off by a bit
      * for some periods, so the rounding is reproduced here
      */
-    fun feeOracleSmoothing(blockTimeMillis: Long): BigInteger {
-        val denominator = (feeOraclePeriodInBlocks(blockTimeMillis) + 1).toBigInteger()
+    fun feeOracleSmoothing(blockTimeMillis: Long): BigInteger? {
+        val periodInBlocks = feeOraclePeriodInBlocks(blockTimeMillis) ?: return null
+
+        val denominator = (periodInBlocks + 1).toBigInteger()
         val (quotient, remainder) = (TWO * FRACTION_ONE).divideAndRemainder(denominator)
 
         return if (remainder.shiftLeft(1) > denominator) quotient + BigInteger.ONE else quotient

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOnChain.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOnChain.kt
@@ -1,0 +1,73 @@
+package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra
+
+import java.math.BigInteger
+
+/**
+ * Identifiers defined by the Hydration runtime itself, not by Nova.
+ *
+ * They are kept together to make it obvious that these strings must match the chain exactly - they are not
+ * ours to rename, and they intentionally differ from the swap sources' own ids
+ * (e.g. the runtime spells the pool `Stableswap`, while [RealStableSwapQuotingSource] uses `StableSwap`).
+ *
+ * Every value below is linked to its definition in `galacticcouncil/hydration-node`, pinned at the commit
+ * these were read from. Follow the link before changing anything here.
+ */
+object HydrationOnChain {
+
+    /**
+     * Pool variants of the entries stored in `Router.Routes`, spelled as the `PoolType` enum declares them.
+     *
+     * `LBP` and `HSM` are deliberately absent: `OraclePriceProvider::price` bails out on those, and so do we.
+     *
+     * https://github.com/galacticcouncil/hydration-node/blob/846b2232e54045ad1a6bc02f701455b8d7835e99/traits/src/router.rs#L82-L90
+     */
+    object PoolType {
+
+        const val OMNIPOOL = "Omnipool"
+
+        const val XYK = "XYK"
+
+        const val STABLESWAP = "Stableswap"
+
+        const val AAVE = "Aave"
+    }
+
+    /**
+     * `EmaOracle` source ids. The runtime type is `[u8; 8]`, which is why the names are truncated to 8 bytes.
+     *
+     * https://github.com/galacticcouncil/hydration-node/blob/846b2232e54045ad1a6bc02f701455b8d7835e99/primitives/src/constants.rs#L82-L85
+     */
+    object OracleSource {
+
+        val OMNIPOOL = "omnipool".toByteArray()
+
+        val XYK = "hydraxyk".toByteArray()
+
+        val STABLESWAP = "stablesw".toByteArray()
+    }
+
+    /**
+     * The `OraclePeriod` `MultiTransactionPayment` uses when it prices a fee in a non-native currency.
+     *
+     * Period enum: https://github.com/galacticcouncil/hydration-node/blob/846b2232e54045ad1a6bc02f701455b8d7835e99/traits/src/oracle.rs#L61-L74
+     * Chosen at: https://github.com/galacticcouncil/hydration-node/blob/846b2232e54045ad1a6bc02f701455b8d7835e99/pallets/transaction-multi-payment/src/lib.rs#L687-L695
+     */
+    const val FEE_ORACLE_PERIOD = "TenMinutes"
+
+    /**
+     * The unaggregated last-trade oracle entry. When a period entry is stale, the runtime advances it
+     * toward this one before use instead of returning the stored value.
+     *
+     * https://github.com/galacticcouncil/hydration-node/blob/846b2232e54045ad1a6bc02f701455b8d7835e99/pallets/ema-oracle/src/lib.rs#L779-L799
+     */
+    const val LAST_BLOCK_ORACLE_PERIOD = "LastBlock"
+
+    /**
+     * `into_smoothing(TenMinutes)` - the per-block EMA smoothing factor for [FEE_ORACLE_PERIOD], copied
+     * verbatim from the runtime: `Fraction` bits in U1F127 fixed point (127 fractional bits), ~2/101 for
+     * the 100-block period.
+     *
+     * https://github.com/galacticcouncil/hydration-node/blob/846b2232e54045ad1a6bc02f701455b8d7835e99/pallets/ema-oracle/src/types.rs#L233-L244
+     */
+    val TEN_MINUTES_SMOOTHING = BigInteger("3369132345751865974884897103284833777")
+}

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOnChain.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOnChain.kt
@@ -63,11 +63,40 @@ object HydrationOnChain {
     const val LAST_BLOCK_ORACLE_PERIOD = "LastBlock"
 
     /**
-     * `into_smoothing(TenMinutes)` - the per-block EMA smoothing factor for [FEE_ORACLE_PERIOD], copied
-     * verbatim from the runtime: `Fraction` bits in U1F127 fixed point (127 fractional bits), ~2/101 for
-     * the 100-block period.
+     * `OraclePeriod::TenMinutes::as_period()` - the fee oracle period expressed in blocks.
      *
-     * https://github.com/galacticcouncil/hydration-node/blob/846b2232e54045ad1a6bc02f701455b8d7835e99/pallets/ema-oracle/src/types.rs#L233-L244
+     * The runtime derives it from its block time (`10 * MINUTES`, `MINUTES = 60_000 / MILLISECS_PER_BLOCK`),
+     * so it changes with every block time upgrade - Hydration moving from 6s to 2s blocks turns 100 into 300.
+     * Deriving it here instead of hardcoding keeps the smoothing factor correct across that upgrade.
      */
-    val TEN_MINUTES_SMOOTHING = BigInteger("3369132345751865974884897103284833777")
+    fun feeOraclePeriodInBlocks(blockTimeMillis: Long): Int {
+        val blocksPerMinute = MILLIS_PER_MINUTE / blockTimeMillis.coerceAtLeast(1)
+
+        return (FEE_ORACLE_PERIOD_MINUTES * blocksPerMinute).toInt().coerceAtLeast(1)
+    }
+
+    /**
+     * `into_smoothing(TenMinutes)` - the runtime keeps this as a hardcoded table, but generates it with
+     * `fraction::frac(2, period + 1)`, rounding to nearest with ties down. Plain truncation is off by a bit
+     * for some periods, so the rounding is reproduced here
+     */
+    fun feeOracleSmoothing(blockTimeMillis: Long): BigInteger {
+        val denominator = (feeOraclePeriodInBlocks(blockTimeMillis) + 1).toBigInteger()
+        val (quotient, remainder) = (TWO * FRACTION_ONE).divideAndRemainder(denominator)
+
+        return if (remainder.shiftLeft(1) > denominator) quotient + BigInteger.ONE else quotient
+    }
+
+    /**
+     * One in the runtime oracle's U1F127 fixed point (127 fractional bits)
+     */
+    val FRACTION_ONE: BigInteger = BigInteger.ONE.shiftLeft(FRACTION_BITS)
+
+    const val FRACTION_BITS = 127
+
+    private val TWO = 2.toBigInteger()
+
+    private const val MILLIS_PER_MINUTE = 60_000L
+
+    private const val FEE_ORACLE_PERIOD_MINUTES = 10L
 }

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOracleApi.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOracleApi.kt
@@ -1,0 +1,122 @@
+@file:Suppress("RedundantUnitExpression")
+
+package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra
+
+import io.novafoundation.nova.common.data.network.runtime.binding.bindNumber
+import io.novafoundation.nova.common.data.network.runtime.binding.castToDictEnum
+import io.novafoundation.nova.common.data.network.runtime.binding.castToList
+import io.novafoundation.nova.common.data.network.runtime.binding.castToStruct
+import io.novafoundation.nova.common.utils.structOf
+import io.novafoundation.nova.common.utils.system
+import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetId
+import io.novafoundation.nova.runtime.storage.source.query.StorageQueryContext
+import io.novafoundation.nova.runtime.storage.source.query.api.QueryableModule
+import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry0
+import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry1
+import io.novafoundation.nova.runtime.storage.source.query.api.QueryableStorageEntry3
+import io.novafoundation.nova.runtime.storage.source.query.api.storage0
+import io.novafoundation.nova.runtime.storage.source.query.api.storage1
+import io.novafoundation.nova.runtime.storage.source.query.api.storage3
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.DictEnum
+import io.novasama.substrate_sdk_android.runtime.definitions.types.composite.Struct
+import io.novasama.substrate_sdk_android.runtime.metadata.module
+import io.novasama.substrate_sdk_android.runtime.metadata.RuntimeMetadata
+import io.novasama.substrate_sdk_android.runtime.metadata.module.Module
+import java.math.BigInteger
+
+/**
+ * One leg of the route registered on chain. [pool] is the pool type name as the runtime spells it:
+ * `Omnipool`, `XYK`, `Stableswap`, `Aave`. [poolId] is only carried by `Stableswap`, where it is the
+ * pool's share token - the asset its oracle entries are stored against
+ */
+class HydrationRouteHop(
+    val pool: String,
+    val poolId: HydraDxAssetId?,
+    val assetIn: HydraDxAssetId,
+    val assetOut: HydraDxAssetId
+)
+
+/**
+ * A stored `EmaOracle.Oracles` entry: EMA price for an ordered asset pair - planks of the lower asset id
+ * per plank of the higher one - and the block the entry was last updated at
+ */
+class HydrationOracleEntry(
+    val numerator: BigInteger,
+    val denominator: BigInteger,
+    val updatedAt: BigInteger
+)
+
+@JvmInline
+value class HydrationRouterApi(override val module: Module) : QueryableModule
+
+@JvmInline
+value class HydrationEmaOracleApi(override val module: Module) : QueryableModule
+
+@JvmInline
+value class HydrationSystemApi(override val module: Module) : QueryableModule
+
+context(StorageQueryContext)
+val RuntimeMetadata.hydrationRouter: HydrationRouterApi
+    get() = HydrationRouterApi(module("Router"))
+
+context(StorageQueryContext)
+val RuntimeMetadata.hydrationEmaOracle: HydrationEmaOracleApi
+    get() = HydrationEmaOracleApi(module("EmaOracle"))
+
+context(StorageQueryContext)
+val RuntimeMetadata.hydrationSystem: HydrationSystemApi
+    get() = HydrationSystemApi(system())
+
+context(StorageQueryContext)
+val HydrationSystemApi.number: QueryableStorageEntry0<BigInteger>
+    get() = storage0(name = "Number", binding = { decoded -> bindNumber(decoded) })
+
+context(StorageQueryContext)
+val HydrationRouterApi.routes: QueryableStorageEntry1<Struct.Instance, List<HydrationRouteHop>>
+    get() = storage1(
+        name = "Routes",
+        binding = { decoded, _ -> bindRoute(decoded) },
+    )
+
+context(StorageQueryContext)
+val HydrationEmaOracleApi.oracles: QueryableStorageEntry3<ByteArray, Pair<HydraDxAssetId, HydraDxAssetId>, String, HydrationOracleEntry>
+    get() = storage3(
+        name = "Oracles",
+        binding = { decoded, _, _, _ -> bindOracleEntry(decoded) },
+        key2ToInternalConverter = { (first, second) -> listOf(first, second) },
+        key3ToInternalConverter = { period -> DictEnum.Entry(period, null) },
+        key2FromInternalConverter = { instance ->
+            val (first, second) = instance.castToList()
+            bindNumber(first) to bindNumber(second)
+        },
+        key3FromInternalConverter = { instance -> instance.castToDictEnum().name }
+    )
+
+fun hydrationAssetPairKey(first: HydraDxAssetId, second: HydraDxAssetId): Struct.Instance {
+    return structOf("assetIn" to first, "assetOut" to second)
+}
+
+private fun bindRoute(decoded: Any?): List<HydrationRouteHop> {
+    return decoded.castToList().map { hop ->
+        val asStruct = hop.castToStruct()
+        val pool = asStruct.get<Any?>("pool").castToDictEnum()
+
+        HydrationRouteHop(
+            pool = pool.name,
+            poolId = pool.value?.let { runCatching { bindNumber(it) }.getOrNull() },
+            assetIn = bindNumber(asStruct["assetIn"]),
+            assetOut = bindNumber(asStruct["assetOut"])
+        )
+    }
+}
+
+private fun bindOracleEntry(decoded: Any?): HydrationOracleEntry {
+    val entry = decoded.castToList().first().castToStruct()
+    val price = entry.get<Any?>("price").castToStruct()
+
+    return HydrationOracleEntry(
+        numerator = bindNumber(price["n"]),
+        denominator = bindNumber(price["d"]),
+        updatedAt = bindNumber(entry["updatedAt"])
+    )
+}

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/RealHydrationOraclePriceConverter.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/RealHydrationOraclePriceConverter.kt
@@ -13,8 +13,11 @@ import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOr
 import io.novafoundation.nova.runtime.di.REMOTE_STORAGE_SOURCE
 import io.novafoundation.nova.runtime.ext.isUtilityAsset
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import java.math.BigInteger
+import kotlin.math.ceil
+import kotlin.math.ln
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -23,21 +26,18 @@ import javax.inject.Named
  */
 private val FIXED_U128_DIV = BigInteger.TEN.pow(18)
 
-/**
- * One in the runtime oracle's U1F127 fixed point (127 fractional bits)
- */
-private val FRACTION_ONE = BigInteger.ONE.shiftLeft(127)
+private val MAX_STALE_BLOCKS = Int.MAX_VALUE.toBigInteger()
 
 /**
- * `1 - s` for the fee oracle period - the per-block decay of a stale entry's weight
+ * Staleness at which `(1-s)^k` underflows the runtime's fixed point to zero and the fast-forwarded price
+ * becomes the last-trade one. Derived from the smoothing factor since it moves with the block time
  */
-private val SMOOTHING_COMPLEMENT = FRACTION_ONE - HydrationOnChain.TEN_MINUTES_SMOOTHING
+internal fun saturationBlocks(smoothing: BigInteger): Int {
+    val decayPerBlock = (HydrationOnChain.FRACTION_ONE - smoothing).toDouble() / HydrationOnChain.FRACTION_ONE.toDouble()
+    if (decayPerBlock <= 0.0) return 1
 
-/**
- * `(1-s)^k` underflows the runtime's fixed point to exactly zero around k=4400 (~7.3h of staleness),
- * from where the fast-forwarded price equals the last-trade price
- */
-private const val SMOOTHING_SATURATION_BLOCKS = 4400
+    return ceil(HydrationOnChain.FRACTION_BITS * ln(2.0) / -ln(decayPerBlock)).toInt()
+}
 
 /**
  * An exact price ratio, mirroring the runtime's `EmaPrice`. Kept as a pair of integers for the whole
@@ -58,12 +58,15 @@ private operator fun PriceRatio.times(other: PriceRatio): PriceRatio {
 private class HydrationFeeContext(
     val nativeAssetId: HydraDxAssetId,
     val hubAssetId: HydraDxAssetId,
-    val parentBlock: BigInteger
+    val parentBlock: BigInteger,
+    val smoothing: BigInteger,
+    val saturationBlocks: Int
 )
 
 @FeatureScope
 class RealHydrationOraclePriceConverter @Inject constructor(
     private val hydraDxAssetIdConverter: HydraDxAssetIdConverter,
+    private val chainStateRepository: ChainStateRepository,
     @Named(REMOTE_STORAGE_SOURCE)
     private val remoteStorageSource: StorageDataSource,
 ) : HydrationOraclePriceConverter {
@@ -86,13 +89,18 @@ class RealHydrationOraclePriceConverter @Inject constructor(
     }
 
     private suspend fun loadContext(chainId: String): HydrationFeeContext {
+        val blockTimeMillis = chainStateRepository.expectedBlockTimeInMillis(chainId).toLong()
+        val smoothing = HydrationOnChain.feeOracleSmoothing(blockTimeMillis)
+
         return remoteStorageSource.query(chainId) {
             HydrationFeeContext(
                 nativeAssetId = metadata.multiTransactionPayment().numberConstant("NativeAssetId", runtime),
                 hubAssetId = metadata.omnipool().numberConstant("HubAssetId", runtime),
                 // The chain prices fees during `on_initialize` against the parent block's oracle state;
                 // the current head is the closest available stand-in for the parent of the inclusion block
-                parentBlock = metadata.hydrationSystem.number.query() ?: error("No block number")
+                parentBlock = metadata.hydrationSystem.number.query() ?: error("No block number"),
+                smoothing = smoothing,
+                saturationBlocks = saturationBlocks(smoothing)
             )
         }
     }
@@ -208,7 +216,7 @@ class RealHydrationOraclePriceConverter @Inject constructor(
         val stored = entriesByPeriod.entryFor(HydrationOnChain.FEE_ORACLE_PERIOD, lower, higher)
         val lastBlock = entriesByPeriod.entryFor(HydrationOnChain.LAST_BLOCK_ORACLE_PERIOD, lower, higher)
 
-        val current = fastForward(stored, lastBlock, context.parentBlock)
+        val current = fastForward(stored, lastBlock, context)
 
         return if (assetA == lower) current else PriceRatio(current.denominator, current.numerator)
     }
@@ -239,18 +247,18 @@ class RealHydrationOraclePriceConverter @Inject constructor(
     private fun fastForward(
         stored: HydrationOracleEntry,
         lastBlock: HydrationOracleEntry,
-        parentBlock: BigInteger
+        context: HydrationFeeContext
     ): PriceRatio {
-        val staleBlocks = (parentBlock - stored.updatedAt).toInt()
+        val staleBlocks = (context.parentBlock - stored.updatedAt).coerceAtMost(MAX_STALE_BLOCKS).toInt()
 
         return when {
             staleBlocks <= 0 -> PriceRatio(stored.numerator, stored.denominator)
 
-            staleBlocks >= SMOOTHING_SATURATION_BLOCKS -> PriceRatio(lastBlock.numerator, lastBlock.denominator)
+            staleBlocks >= context.saturationBlocks -> PriceRatio(lastBlock.numerator, lastBlock.denominator)
 
             else -> {
-                val decay = SMOOTHING_COMPLEMENT.pow(staleBlocks)
-                val one = BigInteger.ONE.shiftLeft(127 * staleBlocks)
+                val decay = (HydrationOnChain.FRACTION_ONE - context.smoothing).pow(staleBlocks)
+                val one = BigInteger.ONE.shiftLeft(HydrationOnChain.FRACTION_BITS * staleBlocks)
 
                 PriceRatio(
                     numerator = stored.numerator * decay * lastBlock.denominator +

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/RealHydrationOraclePriceConverter.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/RealHydrationOraclePriceConverter.kt
@@ -1,5 +1,6 @@
 package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra
 
+import android.util.Log
 import io.novafoundation.nova.common.data.network.runtime.binding.BalanceOf
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.common.utils.metadata
@@ -12,8 +13,8 @@ import io.novafoundation.nova.feature_swap_core_api.data.network.toOnChainIdOrTh
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.runtime.di.REMOTE_STORAGE_SOURCE
 import io.novafoundation.nova.runtime.ext.isUtilityAsset
+import io.novafoundation.nova.runtime.multiNetwork.ChainRegistry
 import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
-import io.novafoundation.nova.runtime.repository.ChainStateRepository
 import io.novafoundation.nova.runtime.storage.source.StorageDataSource
 import java.math.BigInteger
 import kotlin.math.ceil
@@ -24,6 +25,8 @@ import javax.inject.Named
 /**
  * `FixedU128::DIV` - the scale substrate's fixed point numbers are stored at
  */
+private const val LOG_TAG = "HydrationOraclePrice"
+
 private val FIXED_U128_DIV = BigInteger.TEN.pow(18)
 
 private val MAX_STALE_BLOCKS = Int.MAX_VALUE.toBigInteger()
@@ -66,7 +69,7 @@ private class HydrationFeeContext(
 @FeatureScope
 class RealHydrationOraclePriceConverter @Inject constructor(
     private val hydraDxAssetIdConverter: HydraDxAssetIdConverter,
-    private val chainStateRepository: ChainStateRepository,
+    private val chainRegistry: ChainRegistry,
     @Named(REMOTE_STORAGE_SOURCE)
     private val remoteStorageSource: StorageDataSource,
 ) : HydrationOraclePriceConverter {
@@ -85,12 +88,15 @@ class RealHydrationOraclePriceConverter @Inject constructor(
             val price = routePrice(chainId, route, context)
 
             convertFeeWithPrice(nativeAmount, price)
-        }.getOrNull()
+        }
+            .onFailure { Log.e(LOG_TAG, "Failed to price the fee with the oracle, falling back", it) }
+            .getOrNull()
     }
 
     private suspend fun loadContext(chainId: String): HydrationFeeContext {
-        val blockTimeMillis = chainStateRepository.expectedBlockTimeInMillis(chainId).toLong()
-        val smoothing = HydrationOnChain.feeOracleSmoothing(blockTimeMillis)
+        val blockTimeMillis = chainRegistry.getChain(chainId).additional?.defaultBlockTimeMillis
+        val smoothing = blockTimeMillis?.let(HydrationOnChain::feeOracleSmoothing)
+            ?: error("Unknown block time for $chainId - cannot derive the oracle smoothing factor")
 
         return remoteStorageSource.query(chainId) {
             HydrationFeeContext(

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/RealHydrationOraclePriceConverter.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/RealHydrationOraclePriceConverter.kt
@@ -1,0 +1,276 @@
+package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra
+
+import io.novafoundation.nova.common.data.network.runtime.binding.BalanceOf
+import io.novafoundation.nova.common.di.scope.FeatureScope
+import io.novafoundation.nova.common.utils.metadata
+import io.novafoundation.nova.common.utils.multiTransactionPayment
+import io.novafoundation.nova.common.utils.numberConstant
+import io.novafoundation.nova.common.utils.omnipool
+import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetId
+import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdConverter
+import io.novafoundation.nova.feature_swap_core_api.data.network.toOnChainIdOrThrow
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
+import io.novafoundation.nova.runtime.di.REMOTE_STORAGE_SOURCE
+import io.novafoundation.nova.runtime.ext.isUtilityAsset
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.Chain
+import io.novafoundation.nova.runtime.storage.source.StorageDataSource
+import java.math.BigInteger
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * `FixedU128::DIV` - the scale substrate's fixed point numbers are stored at
+ */
+private val FIXED_U128_DIV = BigInteger.TEN.pow(18)
+
+/**
+ * One in the runtime oracle's U1F127 fixed point (127 fractional bits)
+ */
+private val FRACTION_ONE = BigInteger.ONE.shiftLeft(127)
+
+/**
+ * `1 - s` for the fee oracle period - the per-block decay of a stale entry's weight
+ */
+private val SMOOTHING_COMPLEMENT = FRACTION_ONE - HydrationOnChain.TEN_MINUTES_SMOOTHING
+
+/**
+ * `(1-s)^k` underflows the runtime's fixed point to exactly zero around k=4400 (~7.3h of staleness),
+ * from where the fast-forwarded price equals the last-trade price
+ */
+private const val SMOOTHING_SATURATION_BLOCKS = 4400
+
+/**
+ * An exact price ratio, mirroring the runtime's `EmaPrice`. Kept as a pair of integers for the whole
+ * computation since the runtime only collapses it into a fixed point number at the very last step
+ */
+private class PriceRatio(val numerator: BigInteger, val denominator: BigInteger) {
+
+    companion object {
+
+        val ONE = PriceRatio(BigInteger.ONE, BigInteger.ONE)
+    }
+}
+
+private operator fun PriceRatio.times(other: PriceRatio): PriceRatio {
+    return PriceRatio(numerator * other.numerator, denominator * other.denominator)
+}
+
+private class HydrationFeeContext(
+    val nativeAssetId: HydraDxAssetId,
+    val hubAssetId: HydraDxAssetId,
+    val parentBlock: BigInteger
+)
+
+@FeatureScope
+class RealHydrationOraclePriceConverter @Inject constructor(
+    private val hydraDxAssetIdConverter: HydraDxAssetIdConverter,
+    @Named(REMOTE_STORAGE_SOURCE)
+    private val remoteStorageSource: StorageDataSource,
+) : HydrationOraclePriceConverter {
+
+    override suspend fun convertNativeAmount(nativeAmount: BalanceOf, conversionTarget: Chain.Asset): BalanceOf? {
+        if (conversionTarget.isUtilityAsset) return nativeAmount
+
+        val chainId = conversionTarget.chainId
+        val targetOnChainId = hydraDxAssetIdConverter.toOnChainIdOrThrow(conversionTarget)
+
+        return runCatching {
+            val context = loadContext(chainId)
+
+            // `AssetFeeOraclePriceProvider` prices the target asset against the native one, then scales the native fee by it
+            val route = loadRoute(chainId, from = targetOnChainId, to = context.nativeAssetId)
+            val price = routePrice(chainId, route, context)
+
+            convertFeeWithPrice(nativeAmount, price)
+        }.getOrNull()
+    }
+
+    private suspend fun loadContext(chainId: String): HydrationFeeContext {
+        return remoteStorageSource.query(chainId) {
+            HydrationFeeContext(
+                nativeAssetId = metadata.multiTransactionPayment().numberConstant("NativeAssetId", runtime),
+                hubAssetId = metadata.omnipool().numberConstant("HubAssetId", runtime),
+                // The chain prices fees during `on_initialize` against the parent block's oracle state;
+                // the current head is the closest available stand-in for the parent of the inclusion block
+                parentBlock = metadata.hydrationSystem.number.query() ?: error("No block number")
+            )
+        }
+    }
+
+    /**
+     * Mirrors `RouteProvider::get_route`: routes are stored under the ordered asset pair and inverted when
+     * requested the other way around. A pair with no registered route falls back to a single omnipool hop
+     * (`DefaultRoutePoolType`)
+     */
+    private suspend fun loadRoute(
+        chainId: String,
+        from: HydraDxAssetId,
+        to: HydraDxAssetId
+    ): List<HydrationRouteHop> {
+        val ordered = from <= to
+        val key = if (ordered) hydrationAssetPairKey(from, to) else hydrationAssetPairKey(to, from)
+
+        val stored = remoteStorageSource.query(chainId) {
+            metadata.hydrationRouter.routes.query(key)
+        }
+
+        return when {
+            stored == null -> listOf(HydrationRouteHop(HydrationOnChain.PoolType.OMNIPOOL, poolId = null, assetIn = from, assetOut = to))
+            ordered -> stored
+            else -> stored.inverted()
+        }
+    }
+
+    private fun List<HydrationRouteHop>.inverted(): List<HydrationRouteHop> {
+        return asReversed().map { hop ->
+            HydrationRouteHop(pool = hop.pool, poolId = hop.poolId, assetIn = hop.assetOut, assetOut = hop.assetIn)
+        }
+    }
+
+    /**
+     * Mirrors `OraclePriceProvider::price` - the product of the per-hop prices
+     */
+    private suspend fun routePrice(
+        chainId: String,
+        route: List<HydrationRouteHop>,
+        context: HydrationFeeContext
+    ): PriceRatio {
+        require(route.isNotEmpty()) { "Empty route" }
+
+        return route.fold(PriceRatio.ONE) { acc, hop ->
+            acc * hopPrice(chainId, hop, context)
+        }
+    }
+
+    private suspend fun hopPrice(chainId: String, hop: HydrationRouteHop, context: HydrationFeeContext): PriceRatio {
+        return when (hop.pool) {
+            // aToken <-> underlying is always 1:1 and the runtime keeps no oracle entry for it
+            HydrationOnChain.PoolType.AAVE -> PriceRatio.ONE
+
+            HydrationOnChain.PoolType.OMNIPOOL -> composeVia(chainId, HydrationOnChain.OracleSource.OMNIPOOL, hop, context.hubAssetId, context)
+
+            HydrationOnChain.PoolType.STABLESWAP -> {
+                val shareToken = hop.poolId ?: error("Stableswap hop without a pool id")
+
+                composeVia(chainId, HydrationOnChain.OracleSource.STABLESWAP, hop, shareToken, context)
+            }
+
+            HydrationOnChain.PoolType.XYK -> oraclePrice(chainId, HydrationOnChain.OracleSource.XYK, hop.assetIn, hop.assetOut, context)
+
+            else -> error("Unsupported pool type in route: ${hop.pool}")
+        }
+    }
+
+    /**
+     * Omnipool prices everything against the hub asset and stableswap against the pool's share token,
+     * so those hops are the product of the two legs through [intermediate]
+     */
+    private suspend fun composeVia(
+        chainId: String,
+        source: ByteArray,
+        hop: HydrationRouteHop,
+        intermediate: HydraDxAssetId,
+        context: HydrationFeeContext
+    ): PriceRatio {
+        val toIntermediate = oraclePrice(chainId, source, hop.assetIn, intermediate, context)
+        val fromIntermediate = oraclePrice(chainId, source, intermediate, hop.assetOut, context)
+
+        return toIntermediate * fromIntermediate
+    }
+
+    /**
+     * Mirrors `EmaOracle::get_price`: entries are stored against the ordered asset pair and inverted when
+     * asked for in the opposite order, while an asset against itself is priced as one. The chain never uses
+     * the stored value directly - a stale entry is first advanced to the current block ([fastForward]),
+     * which is why the `LastBlock` entry is read alongside the fee period one
+     */
+    private suspend fun oraclePrice(
+        chainId: String,
+        source: ByteArray,
+        assetA: HydraDxAssetId,
+        assetB: HydraDxAssetId,
+        context: HydrationFeeContext
+    ): PriceRatio {
+        if (assetA == assetB) return PriceRatio.ONE
+
+        val lower = minOf(assetA, assetB)
+        val higher = maxOf(assetA, assetB)
+
+        val entriesByPeriod = remoteStorageSource.query(chainId) {
+            metadata.hydrationEmaOracle.oracles.entries(
+                listOf(
+                    Triple(source, lower to higher, HydrationOnChain.FEE_ORACLE_PERIOD),
+                    Triple(source, lower to higher, HydrationOnChain.LAST_BLOCK_ORACLE_PERIOD)
+                )
+            )
+        }
+
+        val stored = entriesByPeriod.entryFor(HydrationOnChain.FEE_ORACLE_PERIOD, lower, higher)
+        val lastBlock = entriesByPeriod.entryFor(HydrationOnChain.LAST_BLOCK_ORACLE_PERIOD, lower, higher)
+
+        val current = fastForward(stored, lastBlock, context.parentBlock)
+
+        return if (assetA == lower) current else PriceRatio(current.denominator, current.numerator)
+    }
+
+    private fun Map<Triple<ByteArray, Pair<HydraDxAssetId, HydraDxAssetId>, String>, HydrationOracleEntry>.entryFor(
+        period: String,
+        lower: HydraDxAssetId,
+        higher: HydraDxAssetId
+    ): HydrationOracleEntry {
+        val entry = entries.firstOrNull { it.key.third == period }?.value
+            ?: error("No $period oracle entry for ($lower, $higher)")
+
+        require(entry.numerator.signum() > 0 && entry.denominator.signum() > 0) {
+            "Degenerate oracle price for ($lower, $higher): ${entry.numerator}/${entry.denominator}"
+        }
+
+        return entry
+    }
+
+    /**
+     * Mirrors `EmaOracle::get_updated_entry`: an entry that was not updated in the parent block is advanced
+     * to it by iterating the EMA toward the last-trade (`LastBlock`) price:
+     * `new = stored * (1-s)^k + lastBlock * (1 - (1-s)^k)`, with k blocks of staleness.
+     *
+     * Computed with exact rationals; the runtime's per-step fixed point rounding inside the pow differs
+     * from this by less than 2^-100 relatively - far below a plank at any realistic amount
+     */
+    private fun fastForward(
+        stored: HydrationOracleEntry,
+        lastBlock: HydrationOracleEntry,
+        parentBlock: BigInteger
+    ): PriceRatio {
+        val staleBlocks = (parentBlock - stored.updatedAt).toInt()
+
+        return when {
+            staleBlocks <= 0 -> PriceRatio(stored.numerator, stored.denominator)
+
+            staleBlocks >= SMOOTHING_SATURATION_BLOCKS -> PriceRatio(lastBlock.numerator, lastBlock.denominator)
+
+            else -> {
+                val decay = SMOOTHING_COMPLEMENT.pow(staleBlocks)
+                val one = BigInteger.ONE.shiftLeft(127 * staleBlocks)
+
+                PriceRatio(
+                    numerator = stored.numerator * decay * lastBlock.denominator +
+                        lastBlock.numerator * (one - decay) * stored.denominator,
+                    denominator = stored.denominator * one * lastBlock.denominator
+                )
+            }
+        }
+    }
+
+    /**
+     * Mirrors `convert_fee_with_price`: `FixedU128::from_rational` (round to nearest, ties down), then
+     * `checked_mul_int` (truncating), with a floor of one plank
+     */
+    private fun convertFeeWithPrice(nativeAmount: BalanceOf, price: PriceRatio): BalanceOf {
+        val (quotient, remainder) = (price.numerator * FIXED_U128_DIV).divideAndRemainder(price.denominator)
+        val fixedPointPrice = if (remainder.shiftLeft(1) > price.denominator) quotient + BigInteger.ONE else quotient
+
+        val converted = fixedPointPrice * nativeAmount / FIXED_U128_DIV
+
+        return converted.max(BigInteger.ONE)
+    }
+}

--- a/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/di/conversions/HydraDxBindsModule.kt
+++ b/feature-swap-core/src/main/java/io/novafoundation/nova/feature_swap_core/di/conversions/HydraDxBindsModule.kt
@@ -4,8 +4,10 @@ import dagger.Binds
 import dagger.Module
 import io.novafoundation.nova.common.di.scope.FeatureScope
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.RealHydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.RealHydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.RealHydrationPriceConversionFallback
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationPriceConversionFallback
 
 @Module
@@ -13,6 +15,10 @@ internal interface HydraDxBindsModule {
 
     @Binds
     fun bindHydrationPriceConversionFallback(real: RealHydrationPriceConversionFallback): HydrationPriceConversionFallback
+
+    @Binds
+    @FeatureScope
+    fun bindHydrationOraclePriceConverter(real: RealHydrationOraclePriceConverter): HydrationOraclePriceConverter
 
     @Binds
     @FeatureScope

--- a/feature-swap-core/src/test/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOracleSmoothingTest.kt
+++ b/feature-swap-core/src/test/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOracleSmoothingTest.kt
@@ -1,0 +1,74 @@
+package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigInteger
+
+private const val SIX_SECOND_BLOCKS = 6_000L
+private const val TWO_SECOND_BLOCKS = 2_000L
+
+private val SMOOTHING_AT_SIX_SECONDS = BigInteger("3369132345751865974884897103284833777")
+private val SMOOTHING_AT_TWO_SECONDS = BigInteger("1130506202395144396888287732331455852")
+
+class HydrationOracleSmoothingTest {
+
+    @Test
+    fun `period follows the chain block time`() {
+        assertEquals(100, HydrationOnChain.feeOraclePeriodInBlocks(SIX_SECOND_BLOCKS))
+        assertEquals(300, HydrationOnChain.feeOraclePeriodInBlocks(TWO_SECOND_BLOCKS))
+    }
+
+    @Test
+    fun `smoothing matches the runtime table for six second blocks`() {
+        assertEquals(SMOOTHING_AT_SIX_SECONDS, HydrationOnChain.feeOracleSmoothing(SIX_SECOND_BLOCKS))
+    }
+
+    @Test
+    fun `smoothing matches the runtime table for two second blocks`() {
+        assertEquals(SMOOTHING_AT_TWO_SECONDS, HydrationOnChain.feeOracleSmoothing(TWO_SECOND_BLOCKS))
+    }
+
+    @Test
+    fun `smoothing rounds to nearest rather than truncating`() {
+        val truncated = 2.toBigInteger() * HydrationOnChain.FRACTION_ONE / 101.toBigInteger()
+
+        assertEquals(truncated + BigInteger.ONE, HydrationOnChain.feeOracleSmoothing(SIX_SECOND_BLOCKS))
+    }
+
+    @Test
+    fun `smoothing stays below one`() {
+        listOf(SIX_SECOND_BLOCKS, TWO_SECOND_BLOCKS, 500L, 12_000L).forEach { blockTime ->
+            assertTrue(HydrationOnChain.feeOracleSmoothing(blockTime) < HydrationOnChain.FRACTION_ONE)
+        }
+    }
+
+    @Test
+    fun `degenerate block time still yields a usable period`() {
+        listOf(0L, -1L, Long.MAX_VALUE).forEach { blockTime ->
+            val period = HydrationOnChain.feeOraclePeriodInBlocks(blockTime)
+
+            assertTrue("period must stay positive for $blockTime", period >= 1)
+            assertTrue("smoothing must stay <= 1 for $blockTime", HydrationOnChain.feeOracleSmoothing(blockTime) <= HydrationOnChain.FRACTION_ONE)
+        }
+    }
+
+    @Test
+    fun `saturation follows the smoothing`() {
+        assertEquals(4402, saturationBlocks(SMOOTHING_AT_SIX_SECONDS))
+        assertEquals(13205, saturationBlocks(SMOOTHING_AT_TWO_SECONDS))
+    }
+
+    @Test
+    fun `saturation keeps the same wall clock horizon across block times`() {
+        val atSixSeconds = saturationBlocks(SMOOTHING_AT_SIX_SECONDS) * SIX_SECOND_BLOCKS
+        val atTwoSeconds = saturationBlocks(SMOOTHING_AT_TWO_SECONDS) * TWO_SECOND_BLOCKS
+
+        assertTrue(atSixSeconds - atTwoSeconds < 60_000)
+    }
+
+    @Test
+    fun `full smoothing saturates immediately`() {
+        assertEquals(1, saturationBlocks(HydrationOnChain.FRACTION_ONE))
+    }
+}

--- a/feature-swap-core/src/test/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOracleSmoothingTest.kt
+++ b/feature-swap-core/src/test/java/io/novafoundation/nova/feature_swap_core/data/assetExchange/conversion/types/hydra/HydrationOracleSmoothingTest.kt
@@ -1,6 +1,7 @@
 package io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.math.BigInteger
@@ -39,17 +40,15 @@ class HydrationOracleSmoothingTest {
     @Test
     fun `smoothing stays below one`() {
         listOf(SIX_SECOND_BLOCKS, TWO_SECOND_BLOCKS, 500L, 12_000L).forEach { blockTime ->
-            assertTrue(HydrationOnChain.feeOracleSmoothing(blockTime) < HydrationOnChain.FRACTION_ONE)
+            assertTrue(HydrationOnChain.feeOracleSmoothing(blockTime)!! < HydrationOnChain.FRACTION_ONE)
         }
     }
 
     @Test
-    fun `degenerate block time still yields a usable period`() {
+    fun `unusable block time yields no smoothing rather than a guess`() {
         listOf(0L, -1L, Long.MAX_VALUE).forEach { blockTime ->
-            val period = HydrationOnChain.feeOraclePeriodInBlocks(blockTime)
-
-            assertTrue("period must stay positive for $blockTime", period >= 1)
-            assertTrue("smoothing must stay <= 1 for $blockTime", HydrationOnChain.feeOracleSmoothing(blockTime) <= HydrationOnChain.FRACTION_ONE)
+            assertNull("period must be absent for $blockTime", HydrationOnChain.feeOraclePeriodInBlocks(blockTime))
+            assertNull("smoothing must be absent for $blockTime", HydrationOnChain.feeOracleSmoothing(blockTime))
         }
     }
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxAssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxAssetExchange.kt
@@ -60,6 +60,7 @@ import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.SwapDir
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationPriceConversionFallback
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.AssetExchange
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.FeePaymentProviderOverride
@@ -115,6 +116,7 @@ class HydraDxExchangeFactory(
     private val chainStateRepository: ChainStateRepository,
     private val swapDeductionUseCase: AssetInAdditionalSwapDeductionUseCase,
     private val hydrationPriceConversionFallback: HydrationPriceConversionFallback,
+    private val hydrationOraclePriceConverter: HydrationOraclePriceConverter,
     private val hydrationAcceptedFeeCurrenciesFetcher: HydrationAcceptedFeeCurrenciesFetcher,
     private val assetSourceRegistry: AssetSourceRegistry,
     private val novaSwapCommission: NovaSwapCommission,
@@ -134,6 +136,7 @@ class HydraDxExchangeFactory(
             chainStateRepository = chainStateRepository,
             swapDeductionUseCase = swapDeductionUseCase,
             hydrationPriceConversionFallback = hydrationPriceConversionFallback,
+            hydrationOraclePriceConverter = hydrationOraclePriceConverter,
             hydrationAcceptedFeeCurrenciesFetcher = hydrationAcceptedFeeCurrenciesFetcher,
             assetSourceRegistry = assetSourceRegistry,
             novaSwapCommission = novaSwapCommission,
@@ -157,6 +160,7 @@ internal class HydraDxAssetExchange(
     private val chainStateRepository: ChainStateRepository,
     private val swapDeductionUseCase: AssetInAdditionalSwapDeductionUseCase,
     private val hydrationPriceConversionFallback: HydrationPriceConversionFallback,
+    private val hydrationOraclePriceConverter: HydrationOraclePriceConverter,
     private val hydrationAcceptedFeeCurrenciesFetcher: HydrationAcceptedFeeCurrenciesFetcher,
     private val assetSourceRegistry: AssetSourceRegistry,
     private val novaSwapCommission: NovaSwapCommission,
@@ -652,9 +656,12 @@ internal class HydraDxAssetExchange(
                 swapDirection = SwapDirection.SPECIFIED_OUT
             )
 
-            val quotedFee = runCatching { swapHost.quote(args) }
-                .recoverCatching { hydrationPriceConversionFallback.convertNativeAmount(nativeFee.amount, customFeeAsset) }
-                .getOrThrow()
+            // The chain converts the fee with an oracle price and falls back to `AcceptedCurrencies`, never swapping.
+            // A best-path quote lands on whichever pool is furthest from the market, so it is only a last resort here
+            val quotedFee = hydrationOraclePriceConverter.convertNativeAmount(nativeFee.amount, customFeeAsset)
+                ?: runCatching { hydrationPriceConversionFallback.convertNativeAmount(nativeFee.amount, customFeeAsset) }
+                    .recoverCatching { swapHost.quote(args) }
+                    .getOrThrow()
 
             // Fees in non-native assets are especially volatile since conversion happens through swaps so we add some buffer to mitigate volatility
             val quotedFeeWithBuffer = quotedFee * FEE_QUOTE_BUFFER

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureDependencies.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/SwapFeatureDependencies.kt
@@ -33,6 +33,7 @@ import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdC
 import io.novafoundation.nova.feature_swap_core_api.data.paths.PathQuoter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationPriceConversionFallback
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.assets.AssetSourceRegistry
 import io.novafoundation.nova.feature_wallet_api.data.network.crosschain.CrossChainTransfersRepository
@@ -116,6 +117,8 @@ interface SwapFeatureDependencies {
     val hydraDxQuotingFactory: HydraDxQuoting.Factory
 
     val hydrationPriceConversionFallback: HydrationPriceConversionFallback
+
+    val hydrationOraclePriceConverter: HydrationOraclePriceConverter
 
     val runtimeCallsApi: MultiChainRuntimeCallsApi
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/exchanges/HydraDxExchangeModule.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/di/exchanges/HydraDxExchangeModule.kt
@@ -8,6 +8,7 @@ import io.novafoundation.nova.feature_account_api.data.fee.types.hydra.Hydration
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuoting
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationAcceptedFeeCurrenciesFetcher
+import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationOraclePriceConverter
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydrationPriceConversionFallback
 import io.novafoundation.nova.feature_swap_api.domain.model.NovaSwapCommission
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxExchangeFactory
@@ -74,6 +75,7 @@ class HydraDxExchangeModule {
         chainStateRepository: ChainStateRepository,
         swapDeductionUseCase: AssetInAdditionalSwapDeductionUseCase,
         hydrationPriceConversionFallback: HydrationPriceConversionFallback,
+        hydrationOraclePriceConverter: HydrationOraclePriceConverter,
         hydrationAcceptedFeeCurrenciesFetcher: HydrationAcceptedFeeCurrenciesFetcher,
         assetSourceRegistry: AssetSourceRegistry,
         novaSwapCommission: NovaSwapCommission,
@@ -89,6 +91,7 @@ class HydraDxExchangeModule {
             chainStateRepository = chainStateRepository,
             swapDeductionUseCase = swapDeductionUseCase,
             hydrationPriceConversionFallback = hydrationPriceConversionFallback,
+            hydrationOraclePriceConverter = hydrationOraclePriceConverter,
             hydrationAcceptedFeeCurrenciesFetcher = hydrationAcceptedFeeCurrenciesFetcher,
             assetSourceRegistry = assetSourceRegistry,
             novaSwapCommission = novaSwapCommission,


### PR DESCRIPTION
## Problem

Swaps on Hydration that pay the fee in a non-native asset were failing with
`Token: FundsUnavailable`. Max-amount swaps hit it every time, and each failed
attempt still burned the fee (~2.7 MYTH).

The cause was fee under-estimation. To convert the native fee into the fee asset
we asked the router for the cheapest swap path. But the chain never swaps the
fee — it converts it with a 10-minute EMA oracle price along the route registered
in `Router.Routes`. Taking the cheapest of several candidate paths systematically
lands on whichever pool is furthest from the market, so our estimate came out too
low. For the failing swap we showed 1.85 MYTH while the chain charged 2.69.

## Fix

New `HydrationOraclePriceConverter` that mirrors what `pallet-transaction-multi-payment`
actually does:

- takes the route from `Router.Routes`, with the same ordered-pair lookup,
  inversion, and single-Omnipool-hop default when no route is registered
- prices each hop the way the runtime does — Omnipool through the LRNA hub,
  Stableswap through the pool's share token, XYK directly, Aave 1:1
- advances stale oracle entries to the current block like
  `EmaOracle::get_updated_entry`, instead of using the stored value as-is
- finishes with the same fixed-point steps as `convert_fee_with_price`

Asset ids (native, hub) come from runtime constants. Pool names, oracle source ids
and the EMA smoothing factor are collected in `HydrationOnChain`, each with a link
to its definition in the Hydration runtime.

The fallback order now matches the chain as well: oracle price → `AcceptedCurrencies`.
A best-path quote is kept only as a last resort if both are unavailable.

The same bug existed in `HydrationConversionFeePayment`, which handles fees for
non-swap transactions (transfers, XCM out of Hydration) when paying in a custom
asset. Fixed there too.

## Verification

Checked against two real failed transactions (Hydration blocks 13596237 and
13596264) by comparing with the fee the chain actually withdrew. The new
conversion reproduces it exactly, down to the last plank. Reading oracle entries
without the fast-forward was off by a small margin; the old quote-based path was
off by ~30%.

Swap also tested on device.