### PR TITLE
Filter swap commisisons

### DIFF
--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/orml/OrmlAssetHistory.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/assets/history/orml/OrmlAssetHistory.kt
@@ -66,6 +66,8 @@ class OrmlAssetHistory(
             if (!call.isTransfer(runtime)) return null
 
             val inferredAsset = chain.findAssetByOrmlCurrencyId(runtime, call.arguments["currency_id"]) ?: return null
+            if (inferredAsset.id != chainAsset.id) return null
+
             val amount = bindNumber(call.arguments["amount"])
 
             return RealtimeHistoryUpdate.Type.Transfer(

--- a/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/updaters/balance/FullSyncPaymentUpdater.kt
+++ b/feature-wallet-impl/src/main/java/io/novafoundation/nova/feature_wallet_impl/data/network/blockchain/updaters/balance/FullSyncPaymentUpdater.kt
@@ -83,6 +83,7 @@ internal class FullSyncPaymentUpdater(
                 .onSuccess { blockOperations ->
                     val localOperations = blockOperations
                         .filter { it.type.relates(accountId) }
+                        .withoutTransfersFromSwapExtrinsics()
                         .map { operation -> createOperationLocal(chainAsset, operation, accountId) }
 
                     operationDao.insertAll(localOperations)
@@ -97,6 +98,13 @@ internal class FullSyncPaymentUpdater(
 
             BalanceSyncUpdate.NoCause -> {}
         }
+    }
+
+    private fun List<RealtimeHistoryUpdate>.withoutTransfersFromSwapExtrinsics(): List<RealtimeHistoryUpdate> {
+        val swapHashes = filter { it.type is RealtimeHistoryUpdate.Type.Swap }
+            .mapTo(mutableSetOf()) { it.txHash }
+
+        return filterNot { it.type is RealtimeHistoryUpdate.Type.Transfer && it.txHash in swapHashes }
     }
 
     private suspend fun createOperationLocal(


### PR DESCRIPTION
## Problem

Right after a Hydration swap, the operation appears in history as a Transfer —
the 0.85% Nova commission — instead of a Swap. Pull to refresh replaces it with
the correct Swap entry.

Reproduced on a gDOT swap, but it affects every Hydration swap that charges the
commission.

## Cause

A swap is submitted as a single extrinsic holding two calls: `router.sell` and
the commission transfer. The realtime path walks the batch and runs every
extractor on every inner call, so for an ORML asset one extrinsic yields two
history updates — a Swap and a Transfer.

Both are stored under the same id (the extrinsic hash), producing one row in
`operations` linked to both `operation_transfers` and `operation_swaps`. The
mapper checks transfer before swap, so the row renders as the commission
transfer.

Refresh hides the problem because the remote path deletes the local row by hash
and re-inserts the indexer's swap, with the commission transfer filtered out —
that filter was only ever wired into the remote path, never into the DB-observe
path.

Introduced together with the Nova swap commission (#2300). The mapper's ordering
is older and was harmless until a swap and a transfer could share one extrinsic.

## Fix

**1. Drop transfers that belong to a swap extrinsic** (`FullSyncPaymentUpdater`)

Before inserting, collect the hashes of swaps found in the block and remove
transfers carrying those hashes. The commission is part of the swap, not a
standalone operation, so it never reaches the database and the type collision
cannot happen in the first place.

**2. ORML transfer extractor now ignores foreign assets** (`OrmlAssetHistory`)

It resolved the asset from `currency_id`, but the code that saves the operation
ignores that and stores it under the currently subscribed asset. As a result the
gDOT commission transfer also showed up in DOT history, with the wrong amount and
the wrong decimals. The extractor now bails out when the resolved asset is not
the subscribed one — the same guard `StatemineAssetHistory` already has.

## Note on scope

The first fix keys on the extrinsic hash, not on the recipient account, so any
transfer sharing an extrinsic with a swap is dropped from the realtime path. Nova
never batches a swap with a user transfer; an externally built batch that did
would have its transfer hidden until refresh. Filtering by recipient would not
help there anyway — the local table keeps one row per hash, so a genuine transfer
would still collide with the swap. Closing that case properly means making the
type tables mutually exclusive, which is out of scope here.