### PR TITLE
Do not block staking screens on the announcements request

### DIFF
--- a/common/src/main/java/io/novafoundation/nova/common/data/announcements/AnnouncementsRepository.kt
+++ b/common/src/main/java/io/novafoundation/nova/common/data/announcements/AnnouncementsRepository.kt
@@ -31,21 +31,18 @@ class RealAnnouncementsRepository(
     @Volatile
     private var cache: AnnouncementsRemote? = null
 
+    // Announcements are supplementary content, so consumers must never wait for the network to render.
+    // The first value is always available synchronously and is replaced once the fresh one arrives
     private val remoteAnnouncements = flow {
-        val cached = cache
-        if (cached != null) emit(cached)
+        emit(cache ?: emptyMap())
 
         val fresh = runCatching { announcementsApi.getAnnouncements() }
             .onFailure { Log.e(LOG_TAG, "Failed to load announcements", it) }
             .getOrNull()
 
-        when {
-            fresh != null -> {
-                cache = fresh
-                emit(fresh)
-            }
-
-            cached == null -> emit(emptyMap())
+        if (fresh != null) {
+            cache = fresh
+            emit(fresh)
         }
     }.shareIn(rootScope, SharingStarted.WhileSubscribed(), replay = 1)
 

--- a/common/src/test/java/io/novafoundation/nova/common/data/announcements/AnnouncementsRepositoryTest.kt
+++ b/common/src/test/java/io/novafoundation/nova/common/data/announcements/AnnouncementsRepositoryTest.kt
@@ -1,0 +1,94 @@
+package io.novafoundation.nova.common.data.announcements
+
+import io.novafoundation.nova.common.domain.announcements.AnnouncementSection
+import io.novafoundation.nova.common.resources.ContextManager
+import io.novafoundation.nova.common.utils.coroutines.DangerousScope
+import io.novafoundation.nova.common.utils.coroutines.RootScope
+import io.novafoundation.nova.test_shared.whenever
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.util.Locale
+
+private const val AWAIT_TIMEOUT = 1_000L
+
+@OptIn(DangerousScope::class, ExperimentalCoroutinesApi::class)
+class AnnouncementsRepositoryTest {
+
+    private val contextManager = mock(ContextManager::class.java)
+
+    private lateinit var rootScope: RootScope
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+
+        rootScope = RootScope()
+
+        whenever(contextManager.getLocale()).thenReturn(Locale.ENGLISH)
+    }
+
+    @After
+    fun tearDown() {
+        rootScope.cancel()
+
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `announcements are available before the request completes`() = runBlocking {
+        val repository = repository(NeverRespondingApi())
+
+        val first = withTimeout(AWAIT_TIMEOUT) {
+            repository.announcementsFlow(AnnouncementSection.STAKING).first()
+        }
+
+        assertEquals(emptyList<Any>(), first)
+    }
+
+    @Test
+    fun `loaded announcements replace the initial empty value`() = runBlocking {
+        val repository = repository(StaticApi(mapOf("staking" to listOf(REMOTE_ANNOUNCEMENT))))
+
+        val loaded = withTimeout(AWAIT_TIMEOUT) {
+            repository.announcementsFlow(AnnouncementSection.STAKING).first { it.isNotEmpty() }
+        }
+
+        assertEquals(listOf("Rewards will resume"), loaded.map { it.description })
+    }
+
+    private fun repository(api: AnnouncementsApi): AnnouncementsRepository {
+        return RealAnnouncementsRepository(api, contextManager, rootScope)
+    }
+}
+
+private val REMOTE_ANNOUNCEMENT = AnnouncementRemote(
+    chainId = null,
+    style = "warning",
+    description = mapOf("default" to "Rewards will resume")
+)
+
+/**
+ * Stands in for any request that never produces a response - an offline device, a blocked host, a stalled connection
+ */
+private class NeverRespondingApi : AnnouncementsApi {
+
+    override suspend fun getAnnouncements(): AnnouncementsRemote = CompletableDeferred<AnnouncementsRemote>().await()
+}
+
+private class StaticApi(private val response: AnnouncementsRemote) : AnnouncementsApi {
+
+    override suspend fun getAnnouncements(): AnnouncementsRemote = response
+}


### PR DESCRIPTION
## Problem

`RealAnnouncementsRepository` emitted its first value only **after** the announcements request had finished:

```kotlin
val cached = cache
if (cached != null) emit(cached)          // cache is empty on a cold start

val fresh = runCatching { announcementsApi.getAnnouncements() }...

when {
    fresh != null -> { cache = fresh; emit(fresh) }
    cached == null -> emit(emptyMap())     // only reached after the request
}
```

`StakingDashboardViewModel` combines that flow with the dashboard content:

```kotlin
val stakingDashboardUiFlow = combine(
    stakingDashboardFlow.throttleLast(dashboardUpdatePeriod),
    dashboardFormattersFlow,
    announcementsByChain
) { ... }
```

`combine` does not emit until **every** source has emitted, so the staking dashboard could not render at all until the announcements request completed — up to the 20s OkHttp timeout (`NetworkModule.TIMEOUT_SECONDS`) when `raw.githubusercontent.com` is slow, blocked or the device is offline. `StakingDashboardFragment` only calls `setLoaded` from inside that observer, so `DashboardLoadingAdapter` stayed on its shimmer placeholders the whole time — while the stakes were already in the database and used to render instantly.

The same gating affected `StakingViewModel.announcementFlow` and `StartStakingLandingViewModel.announcementFlow`, just less visibly.

## Fix

Announcements are supplementary content, so the flow now emits the cached value (or an empty one) *before* going to the network, and replaces it once fresh data arrives. Fixing it in the repository covers every consumer at once, instead of patching each `combine`.