### PR TITLE
docs: fix sovereign spelling in account matcher

### DIFF
--- a/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/SystemAccountMatcher.kt
+++ b/feature-account-api/src/main/java/io/novafoundation/nova/feature_account_api/domain/account/system/SystemAccountMatcher.kt
@@ -17,7 +17,7 @@ fun SystemAccountMatcher.Companion.default(): SystemAccountMatcher {
         PrefixSystemAccountMatcher("para"),
         // Relaychain sovereign account on parachains
         PrefixSystemAccountMatcher("Parent"),
-        // Sibling parachain soveregin accounts
+        // Sibling parachain sovereign accounts
         PrefixSystemAccountMatcher("sibl")
     )
 }


### PR DESCRIPTION
Correct “soveregin” to “sovereign” in the comment describing sibling parachain sovereign accounts.

The matcher prefixes and Kotlin behavior are unchanged; this only makes the system-account classification comment accurate and searchable.