### PR TITLE
Reject swap routes that enter the same Hydration pool twice

### DIFF
--- a/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/model/SwapGraph.kt
+++ b/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/model/SwapGraph.kt
@@ -37,6 +37,12 @@ interface SwapGraphEdge : QuotableEdge {
     suspend fun debugLabel(): String
 
     /**
+     * The pool this edge trades through, when the route must not enter it twice
+     */
+    val poolId: SwapPoolId?
+        get() = null
+
+    /**
      * Whether this Edge fee check should be skipped when adding to after a specified [predecessor]
      * The main purpose is to mirror the behavior of [appendToOperation] - multiple segments appended together
      * most likely will only use fee configuration from the first segment in the batch

--- a/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/model/SwapPoolId.kt
+++ b/feature-swap-api/src/main/java/io/novafoundation/nova/feature_swap_api/domain/model/SwapPoolId.kt
@@ -1,0 +1,12 @@
+package io.novafoundation.nova.feature_swap_api.domain.model
+
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+
+/**
+ * Identifies the on-chain liquidity pool a swap edge trades through.
+ *
+ * A route must not enter the same pool twice. Hydration router pre-computes every hop of a buy
+ * from the state before execution and passes the result as an exact per-hop limit, so a pool
+ * modified by an earlier hop of the same route reverts the later hop with a slippage error.
+ */
+data class SwapPoolId(val chainId: ChainId, val identifier: String)

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxAssetExchange.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxAssetExchange.kt
@@ -41,6 +41,7 @@ import io.novafoundation.nova.feature_swap_api.domain.model.ReQuoteTrigger
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapExecutionCorrection
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapFee.SwapSegment.SegmentNetFlow
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapGraphEdge
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapPoolId
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapLimit
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapMaxAdditionalAmountDeduction
 import io.novafoundation.nova.feature_swap_api.domain.model.SwapSubmissionResult
@@ -262,6 +263,9 @@ internal class HydraDxAssetExchange(
     private inner class HydraDxSwapEdge(
         private val sourceQuotableEdge: HydraDxSourceEdge,
     ) : SwapGraphEdge, HydraDxQuotableEdge by sourceQuotableEdge {
+
+        override val poolId: SwapPoolId
+            get() = sourceQuotableEdge.poolId
 
         override suspend fun beginOperation(args: AtomicSwapOperationArgs): AtomicSwapOperation {
             return HydraDxOperation(sourceQuotableEdge, args)

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxPoolId.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxPoolId.kt
@@ -1,0 +1,29 @@
+package io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx
+
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapPoolId
+import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetId
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.ChainId
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
+
+object HydraDxPoolId {
+
+    const val XYK = "xyk"
+    const val AAVE = "aave"
+
+    fun omnipool(chainId: ChainId): SwapPoolId {
+        return SwapPoolId(chainId, "omnipool")
+    }
+
+    fun stableswap(chainId: ChainId, poolId: HydraDxAssetId): SwapPoolId {
+        return SwapPoolId(chainId, "stableswap:$poolId")
+    }
+
+    /**
+     * Identifies a pool that holds exactly one asset pair, so both trade directions map to the same pool
+     */
+    fun pair(poolType: String, from: FullChainAssetId, to: FullChainAssetId): SwapPoolId {
+        val pairIdentifier = listOf(from.assetId, to.assetId).sorted().joinToString(separator = "-")
+
+        return SwapPoolId(from.chainId, "$poolType:$pairIdentifier")
+    }
+}

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxSwapSource.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxSwapSource.kt
@@ -3,6 +3,7 @@ package io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx
 import io.novafoundation.nova.common.utils.Identifiable
 import io.novafoundation.nova.core.updater.SharedRequestsBuilder
 import io.novafoundation.nova.feature_swap_api.domain.model.AtomicSwapOperationArgs
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapPoolId
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.HydraDxQuotableEdge
 import io.novafoundation.nova.feature_swap_core_api.data.types.hydra.HydraDxQuotingSource
 import io.novafoundation.nova.feature_wallet_api.data.network.blockhain.types.Balance
@@ -23,6 +24,11 @@ interface StandaloneHydraSwap {
 interface HydraDxSourceEdge : HydraDxQuotableEdge {
 
     fun routerPoolArgument(): DictEnum.Entry<*>
+
+    /**
+     * The pool this edge trades through
+     */
+    val poolId: SwapPoolId
 
     /**
      * Whether hydra swap source is able to perform optimized standalone swap without using Router

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/aave/AaveSwapSource.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/aave/AaveSwapSource.kt
@@ -6,6 +6,8 @@ import io.novafoundation.nova.core.updater.SharedRequestsBuilder
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.aave.AavePoolQuotingSource
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.aave.AaveSwapQuotingSourceFactory
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapPoolId
+import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxPoolId
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxSourceEdge
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxSwapSource
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -49,6 +51,8 @@ private class AaveSwapSource(
         override fun routerPoolArgument(): DictEnum.Entry<*> {
             return DictEnum.Entry("Aave", null)
         }
+
+        override val poolId: SwapPoolId = HydraDxPoolId.pair(HydraDxPoolId.AAVE, from, to)
 
         override val standaloneSwap = null
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/omnipool/OmniPoolSwapSource.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/omnipool/OmniPoolSwapSource.kt
@@ -10,6 +10,8 @@ import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.ty
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.omnipool.OmniPoolQuotingSourceFactory
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetId
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapPoolId
+import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxPoolId
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxSourceEdge
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxSwapSource
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.StandaloneHydraSwap
@@ -60,6 +62,8 @@ private class OmniPoolSwapSource(
         override fun routerPoolArgument(): DictEnum.Entry<*> {
             return DictEnum.Entry("Omnipool", null)
         }
+
+        override val poolId: SwapPoolId = HydraDxPoolId.omnipool(from.chainId)
 
         override val standaloneSwap = this
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/stableswap/StableSwapSource.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/stableswap/StableSwapSource.kt
@@ -6,6 +6,8 @@ import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.ty
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.stableswap.StableSwapQuotingSourceFactory
 import io.novafoundation.nova.feature_swap_core_api.data.network.HydraDxAssetIdConverter
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapPoolId
+import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxPoolId
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxSourceEdge
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxSwapSource
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -63,5 +65,7 @@ private class StableSwapSource(
         override fun routerPoolArgument(): DictEnum.Entry<*> {
             return DictEnum.Entry("Stableswap", delegate.poolId)
         }
+
+        override val poolId: SwapPoolId = HydraDxPoolId.stableswap(chain.id, delegate.poolId)
     }
 }

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/xyk/XYKSwapSource.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/xyk/XYKSwapSource.kt
@@ -5,6 +5,8 @@ import io.novafoundation.nova.core.updater.SharedRequestsBuilder
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.xyk.XYKSwapQuotingSource
 import io.novafoundation.nova.feature_swap_core.data.assetExchange.conversion.types.hydra.sources.xyk.XYKSwapQuotingSourceFactory
 import io.novafoundation.nova.feature_swap_core_api.data.primitive.model.QuotableEdge
+import io.novafoundation.nova.feature_swap_api.domain.model.SwapPoolId
+import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxPoolId
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxSourceEdge
 import io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx.HydraDxSwapSource
 import io.novasama.substrate_sdk_android.runtime.AccountId
@@ -46,6 +48,8 @@ private class XYKSwapSource(
         override fun routerPoolArgument(): DictEnum.Entry<*> {
             return DictEnum.Entry("XYK", null)
         }
+
+        override val poolId: SwapPoolId = HydraDxPoolId.pair(HydraDxPoolId.XYK, from, to)
 
         override val standaloneSwap = null
 

--- a/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
+++ b/feature-swap-impl/src/main/java/io/novafoundation/nova/feature_swap_impl/domain/swap/RealSwapService.kt
@@ -949,6 +949,9 @@ internal class RealSwapService(
             // First path segments don't have any extra restrictions
             if (pathPredecessor == null) return true
 
+            // A pool modified by the previous hop can't be entered again in the same route
+            if (edge.poolId != null && edge.poolId == pathPredecessor.poolId) return false
+
             // Second and subsequent edges are subject to checking whether we can execute them one by one immediately
             if (!canExecuteIntermediateEdgeSequentially(edge, pathPredecessor)) return false
 

--- a/feature-swap-impl/src/test/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxPoolIdTest.kt
+++ b/feature-swap-impl/src/test/java/io/novafoundation/nova/feature_swap_impl/data/assetExchange/hydraDx/HydraDxPoolIdTest.kt
@@ -1,0 +1,53 @@
+package io.novafoundation.nova.feature_swap_impl.data.assetExchange.hydraDx
+
+import io.novafoundation.nova.runtime.multiNetwork.chain.model.FullChainAssetId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import java.math.BigInteger
+
+class HydraDxPoolIdTest {
+
+    private val chainId = "hydration"
+
+    private val usdc = FullChainAssetId(chainId, 1)
+    private val hollar = FullChainAssetId(chainId, 2)
+    private val dot = FullChainAssetId(chainId, 3)
+
+    @Test
+    fun `stableswap pool id is the same for every hop through the pool`() {
+        assertEquals(
+            HydraDxPoolId.stableswap(chainId, BigInteger.valueOf(110)),
+            HydraDxPoolId.stableswap(chainId, BigInteger.valueOf(110))
+        )
+    }
+
+    @Test
+    fun `stableswap pool ids differ between pools`() {
+        assertNotEquals(
+            HydraDxPoolId.stableswap(chainId, BigInteger.valueOf(110)),
+            HydraDxPoolId.stableswap(chainId, BigInteger.valueOf(111))
+        )
+    }
+
+    @Test
+    fun `omnipool is a single pool`() {
+        assertEquals(HydraDxPoolId.omnipool(chainId), HydraDxPoolId.omnipool(chainId))
+    }
+
+    @Test
+    fun `pair pool id does not depend on trade direction`() {
+        assertEquals(
+            HydraDxPoolId.pair(HydraDxPoolId.XYK, usdc, hollar),
+            HydraDxPoolId.pair(HydraDxPoolId.XYK, hollar, usdc)
+        )
+    }
+
+    @Test
+    fun `pair pool ids differ between pairs and pool types`() {
+        val xykUsdcHollar = HydraDxPoolId.pair(HydraDxPoolId.XYK, usdc, hollar)
+
+        assertNotEquals(xykUsdcHollar, HydraDxPoolId.pair(HydraDxPoolId.XYK, usdc, dot))
+        assertNotEquals(xykUsdcHollar, HydraDxPoolId.pair(HydraDxPoolId.AAVE, usdc, hollar))
+    }
+}


### PR DESCRIPTION
## Problem

Swaps with the amount specified via **receive** (`router.buy`) for USDC → DOT on Hydration revert with `Stableswap.SlippageLimit`, while the same pair works via **send**.

The route search produces paths that use the same stableswap pool twice in a row, e.g.

`USDC → aUSDC (Aave) → 2-Pool-HUSDC (Stableswap#110) → HOLLAR (Stableswap#110) → aDOT (Omnipool) → DOT (Aave)`

i.e. add liquidity to pool 110 and then withdraw from pool 110.

- `router.sell` executes each hop on the router's actual balance with a zero limit and only checks the final amount, so this route succeeds.
- `router.buy` pre-computes every hop from the state *before* execution and passes the result as the exact per-hop `max_limit`. The first hop changes the pool's reserves, the second hop needs more shares than pre-computed, and the stableswap pallet reverts with `SlippageLimit`.

Fee-account data confirms it: every `Router.buy` whose route re-enters a stableswap pool reverted, all `Router.buy` without pool re-entry succeeded, and `Router.sell` with the same share detours succeeded 135 times. The detour is never needed: a direct edge between any two assets of the same pool always exists.

## Fix

- `SwapGraphEdge.poolId` (`SwapPoolId`, default `null`) declares the pool an edge trades through. Hydration edges fill it via `HydraDxPoolId`: Omnipool is one pool per chain, stableswap by pool id, XYK and Aave by unordered asset pair.
- `RealSwapService.NodeVisitFilter` refuses an edge that re-enters the pool of its predecessor.

## Tests

- `HydraDxPoolIdTest` (pool identity: same stableswap pool, different pools, omnipool, pair order independence, pair vs pool type).
- Module compiles, `./gradlew ktlint` clean. Not verified on a device.

iOS counterpart: novasamatech/nova-wallet-ios#1858.